### PR TITLE
Fix/performances add tests

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -1,0 +1,50 @@
+# Maestro E2E Scaffold
+
+This directory contains the initial Maestro mobile-flow scaffold for the two highest-value journeys identified in the testing assessment:
+
+- `auth-boot-login.yml`
+- `hide-to-guess-to-result.yml`
+
+The flows are intentionally conservative. They only automate steps that currently have stable visible text in the React Native UI and stop where the app depends on missing selectors, OS-owned pickers, gesture coordinates, or nondeterministic remote data.
+
+## Files
+
+- `auth-boot-login.yml`: boot to login screen, assert the auth UI, and document the missing input selectors needed to finish the login journey.
+- `hide-to-guess-to-result.yml`: start from an authenticated home state, cover entry into the hide and guess paths, and document the exact blockers that prevent a reliable hide-to-result run today.
+- `e2e.env.example.yaml`: sample values for a non-production test account and reusable copy.
+
+## Current Blockers
+
+1. Login inputs are not automatable reliably.
+   `components/Auth/Input.js` renders `TextInput` controls without `testID`, `accessibilityLabel`, or placeholder text, so Maestro has no stable way to focus the email and password fields.
+
+2. The hide journey enters OS-owned media flows.
+   `components/Picture/LogicalImagePicker.js` launches the camera or image library directly. That makes the flow depend on device permissions, picker UI outside the app, and a known test image being present on the emulator or device.
+
+3. Hide and guess confirmation depends on coordinate-only image taps.
+   `components/Picture/ShowPicture.js` uses an image `Pressable` plus a modal opened by tapping a dynamically positioned icon. There is no stable selector for the image surface, the target marker, or the confirmation anchor.
+
+4. Guessing depends on remote or cached cards with no stable identifiers.
+   `components/UI/SwipeImage.js` loads data from local storage and API requests, then renders gesture cards without fixed text or `testID` hooks that Maestro can target deterministically.
+
+5. Result state is delayed behind a timed ad screen.
+   `screens/GuessScreens/AdScreen.js` waits five seconds before routing to the result screen in the current non-ad path. That is testable, but it is slow and still depends on reaching the guess confirmation step first.
+
+## What Is Needed To Execute Reliably Later
+
+1. Add stable selectors to auth inputs, image pickers, swipe cards, image surfaces, confirmation buttons, and result actions.
+2. Provide a non-production test account with predictable login credentials.
+3. Seed at least one deterministic guessable image for the test account or add an internal dev shortcut that bypasses remote image loading.
+4. Make the media source deterministic for the hide path, either by exposing an in-app fixture picker or preloading emulator media and stabilizing the OS permission flow.
+5. Add a test-only path that skips or shortens the ad wait.
+
+## Suggested Later Commands
+
+Once the blockers above are addressed and Maestro is installed locally, the likely commands are:
+
+```bash
+maestro test .maestro/auth-boot-login.yml -e LOGIN_EMAIL=your.test.user@example.com -e LOGIN_PASSWORD=replace-me
+maestro test .maestro/hide-to-guess-to-result.yml
+```
+
+The Android app id in this repo is `com.alegarn.WoIstWaldoProject`. The iOS bundle id in `app.json` is the same string.

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -9,34 +9,34 @@ The flows are intentionally conservative. They only automate steps that currentl
 
 ## Files
 
-- `auth-boot-login.yml`: boot to login screen, assert the auth UI, and document the missing input selectors needed to finish the login journey.
-- `hide-to-guess-to-result.yml`: start from an authenticated home state, cover entry into the hide and guess paths, and document the exact blockers that prevent a reliable hide-to-result run today.
+- `auth-boot-login.yml`: boot to login screen on a clean state, assert the auth UI through stable selectors, switch auth modes, and perform a real login when test credentials are supplied.
+- `hide-to-guess-to-result.yml`: start from an authenticated home state and cover the selector-stable parts of the hide and guess paths, while documenting the remaining deterministic-fixture and coordinate blockers.
 - `e2e.env.example.yaml`: sample values for a non-production test account and reusable copy.
 
 ## Current Blockers
 
 1. Login inputs are not automatable reliably.
-   `components/Auth/Input.js` renders `TextInput` controls without `testID`, `accessibilityLabel`, or placeholder text, so Maestro has no stable way to focus the email and password fields.
+   Resolved. Auth inputs and submit/switch buttons now expose stable selectors such as `auth.input.email`, `auth.input.password`, and `auth.button.login-submit`.
 
 2. The hide journey enters OS-owned media flows.
    `components/Picture/LogicalImagePicker.js` launches the camera or image library directly. That makes the flow depend on device permissions, picker UI outside the app, and a known test image being present on the emulator or device.
 
 3. Hide and guess confirmation depends on coordinate-only image taps.
-   `components/Picture/ShowPicture.js` uses an image `Pressable` plus a modal opened by tapping a dynamically positioned icon. There is no stable selector for the image surface, the target marker, or the confirmation anchor.
+   Partially resolved. `components/Picture/ShowPicture.js` now exposes selectors like `game.picture.hide-surface`, `game.picture.guess-surface`, and modal anchors such as `game.picture.hide-modal.confirm`, but the actual target choice still depends on deterministic coordinates.
 
 4. Guessing depends on remote or cached cards with no stable identifiers.
-   `components/UI/SwipeImage.js` loads data from local storage and API requests, then renders gesture cards without fixed text or `testID` hooks that Maestro can target deterministically.
+   Partially resolved. `components/UI/SwipeImage.js` and `components/UI/SwipeableCard.js` now expose `guess-path.swipe-stack` and `guess-path.card.*`, but the loaded data still needs to be deterministic.
 
 5. Result state is delayed behind a timed ad screen.
    `screens/GuessScreens/AdScreen.js` waits five seconds before routing to the result screen in the current non-ad path. That is testable, but it is slow and still depends on reaching the guess confirmation step first.
 
 ## What Is Needed To Execute Reliably Later
 
-1. Add stable selectors to auth inputs, image pickers, swipe cards, image surfaces, confirmation buttons, and result actions.
-2. Provide a non-production test account with predictable login credentials.
-3. Seed at least one deterministic guessable image for the test account or add an internal dev shortcut that bypasses remote image loading.
-4. Make the media source deterministic for the hide path, either by exposing an in-app fixture picker or preloading emulator media and stabilizing the OS permission flow.
-5. Add a test-only path that skips or shortens the ad wait.
+1. Provide a non-production test account with predictable login credentials.
+2. Seed at least one deterministic guessable image for the test account or add an internal dev shortcut that bypasses remote image loading.
+3. Make the media source deterministic for the hide path, either by exposing an in-app fixture picker or preloading emulator media and stabilizing the OS permission flow.
+4. Add a test-only path that skips or shortens the ad wait.
+5. Optionally add explicit result/action selectors if you want Maestro to assert deeper past the current ad handoff.
 
 ## Suggested Later Commands
 

--- a/.maestro/auth-boot-login.yml
+++ b/.maestro/auth-boot-login.yml
@@ -1,0 +1,37 @@
+appId: com.alegarn.WoIstWaldoProject
+env:
+  LOGIN_EMAIL: your.test.user@example.com
+  LOGIN_PASSWORD: replace-me
+---
+# Scope: verify boot lands on auth when no session is restored, then outline the login steps.
+# Non-destructive by default: this flow does not clear app state or submit credentials.
+#
+# Blocker:
+# `components/Auth/Input.js` renders unlabeled `TextInput` controls from a Maestro perspective.
+# The visible labels are separate `Text` nodes, but the underlying inputs have no `testID`,
+# `accessibilityLabel`, or placeholder. Until that changes, focusing the email/password fields
+# would require brittle screen-coordinate taps.
+#
+# Intended continuation once selectors exist:
+# - tapOn:
+#     id: auth-email-input
+# - inputText: ${LOGIN_EMAIL}
+# - tapOn:
+#     id: auth-password-input
+# - inputText: ${LOGIN_PASSWORD}
+# - tapOn: Log In
+# - assertVisible: Hide Waldo
+
+- launchApp
+- waitForAnimationToEnd
+- assertVisible: "Email Address"
+- assertVisible: "Password"
+- assertVisible: "Log In"
+- assertVisible: "Create a new user"
+- tapOn: "Create a new user"
+- assertVisible: "Confirm Email Address"
+- assertVisible: "Confirm Password"
+- assertVisible: "Username"
+- assertVisible: "Sign Up"
+- tapOn: "Log in instead"
+- assertVisible: "Log In"

--- a/.maestro/auth-boot-login.yml
+++ b/.maestro/auth-boot-login.yml
@@ -3,35 +3,43 @@ env:
   LOGIN_EMAIL: your.test.user@example.com
   LOGIN_PASSWORD: replace-me
 ---
-# Scope: verify boot lands on auth when no session is restored, then outline the login steps.
-# Non-destructive by default: this flow does not clear app state or submit credentials.
+# Scope: boot on a clean app state, switch between auth modes, then perform a real login
+# using stable in-app selectors.
 #
-# Blocker:
-# `components/Auth/Input.js` renders unlabeled `TextInput` controls from a Maestro perspective.
-# The visible labels are separate `Text` nodes, but the underlying inputs have no `testID`,
-# `accessibilityLabel`, or placeholder. Until that changes, focusing the email/password fields
-# would require brittle screen-coordinate taps.
-#
-# Intended continuation once selectors exist:
-# - tapOn:
-#     id: auth-email-input
-# - inputText: ${LOGIN_EMAIL}
-# - tapOn:
-#     id: auth-password-input
-# - inputText: ${LOGIN_PASSWORD}
-# - tapOn: Log In
-# - assertVisible: Hide Waldo
+# Preconditions for reliable execution:
+# - provide a non-production account via LOGIN_EMAIL and LOGIN_PASSWORD
+# - backend/API is reachable and returns a successful login response
 
-- launchApp
+- launchApp:
+  clearState: true
 - waitForAnimationToEnd
-- assertVisible: "Email Address"
-- assertVisible: "Password"
-- assertVisible: "Log In"
-- assertVisible: "Create a new user"
-- tapOn: "Create a new user"
-- assertVisible: "Confirm Email Address"
-- assertVisible: "Confirm Password"
-- assertVisible: "Username"
-- assertVisible: "Sign Up"
-- tapOn: "Log in instead"
-- assertVisible: "Log In"
+- assertVisible:
+  id: auth.input.email
+- assertVisible:
+  id: auth.input.password
+- assertVisible:
+  id: auth.button.login-submit
+- tapOn:
+  id: auth.button.switch-to-signup
+- assertVisible:
+  id: auth.input.confirm-email
+- assertVisible:
+  id: auth.input.confirm-password
+- assertVisible:
+  id: auth.input.username
+- assertVisible:
+  id: auth.button.signup-submit
+- tapOn:
+  id: auth.button.switch-to-login
+- tapOn:
+  id: auth.input.email
+- inputText: ${LOGIN_EMAIL}
+- tapOn:
+  id: auth.input.password
+- inputText: ${LOGIN_PASSWORD}
+- tapOn:
+  id: auth.button.login-submit
+- assertVisible:
+  id: home.button.hide
+- assertVisible:
+  id: home.button.guess

--- a/.maestro/e2e.env.example.yaml
+++ b/.maestro/e2e.env.example.yaml
@@ -1,0 +1,3 @@
+LOGIN_EMAIL: your.test.user@example.com
+LOGIN_PASSWORD: replace-me
+HIDE_DESCRIPTION: Hidden near the left side of the tree.

--- a/.maestro/hide-to-guess-to-result.yml
+++ b/.maestro/hide-to-guess-to-result.yml
@@ -3,45 +3,64 @@ env:
   HIDE_DESCRIPTION: Hidden near the left side of the tree.
 ---
 # Scope: scaffold the highest-value gameplay journey from the authenticated home screen.
-# This flow intentionally stops at each unstable boundary and documents the missing seam.
+# This flow now uses the stable selectors added in the app and stops only at the still-unstable seams.
 #
 # Preconditions for later execution:
 # - The app is already on `HomeScreen` with a valid authenticated session.
 # - A deterministic image fixture or dev-only shortcut exists for both hide and guess flows.
 #
 # Blockers in the current app:
-# 1. `LogicalImagePicker` opens camera or gallery UI owned by the OS.
-# 2. `ShowPicture` requires coordinate-based taps on the image and dynamically positioned icon.
-# 3. `SwipeImage` depends on storage/API-loaded cards without stable text or ids.
-# 4. Reaching `ResultScreen` requires a deterministic guess outcome and then the `AdScreen` delay.
+# 1. `LogicalImagePicker` still opens camera or gallery UI owned by the OS.
+# 2. `ShowPicture` now has a stable surface selector, but choosing the hidden point still depends on image coordinates.
+# 3. `SwipeImage` and `SwipeableCard` now have stable ids, but the card content still depends on cached/API-provided data.
+# 4. Reaching `ResultScreen` still requires a deterministic guess outcome and then the `AdScreen` delay.
 #
-# Intended continuation once selectors and test seams exist:
-# - tapOn: Select an Image
+# Intended continuation once deterministic fixtures/test seams exist:
+# - tapOn:
+#     id: image-picker.button.select-image
 # - handle permission dialogs and pick a known fixture image
-# - tapOn image surface at a stable coordinate or selector
-# - tapOn target confirmation icon
-# - tapOn: Confirm
-# - inputText: ${HIDE_DESCRIPTION}
-# - tapOn: Confirm ?
-# - tapOn: Confirm
-# - tapOn: Find Waldo
-# - tapOn: Let's go!
-# - select a seeded guess card
+# - tapOn image surface at a known coordinate on:
+#     id: game.picture.hide-surface
+# - tapOn:
+#     id: game.picture.hide-modal.confirm
+# - inputText: ${HIDE_DESCRIPTION} into:
+#     id: set-instructions.input.description
+# - tapOn:
+#     id: set-instructions.button.confirm-description
+# - tapOn:
+#     id: set-instructions.confirm-modal.confirm
+# - tapOn:
+#     id: home.button.guess
+# - tapOn:
+#     id: guess-path.button.start
+# - select a seeded guess card using `guess-path.card.*`
 # - tap on the known target area
-# - tapOn: Confirm
+# - tapOn:
+#     id: game.picture.guess-modal.confirm
 # - wait for the ad handoff
 # - assertVisible: You Found It! or You didn't find it :(
 
 - launchApp
 - waitForAnimationToEnd
-- assertVisible: "Hide Waldo"
-- assertVisible: "Find Waldo"
-- tapOn: "Hide Waldo"
-- assertVisible: "Take a Picture"
-- assertVisible: "Select an Image"
+- assertVisible:
+  id: home.button.hide
+- assertVisible:
+  id: home.button.guess
+- tapOn:
+  id: home.button.hide
+- assertVisible:
+  id: image-picker.button.take-picture
+- assertVisible:
+  id: image-picker.button.select-image
 - back
-- assertVisible: "Hide Waldo"
-- tapOn: "Find Waldo"
+- assertVisible:
+  id: home.button.hide
+- tapOn:
+  id: home.button.guess
 - assertVisible: "Swipe !"
-- assertVisible: "Let's go!"
-- tapOn: "Let's go!"
+- assertVisible:
+  id: guess-path.button.start
+- tapOn:
+  id: guess-path.button.start
+- assertVisible:
+  id: guess-path.swipe-stack

--- a/.maestro/hide-to-guess-to-result.yml
+++ b/.maestro/hide-to-guess-to-result.yml
@@ -1,0 +1,47 @@
+appId: com.alegarn.WoIstWaldoProject
+env:
+  HIDE_DESCRIPTION: Hidden near the left side of the tree.
+---
+# Scope: scaffold the highest-value gameplay journey from the authenticated home screen.
+# This flow intentionally stops at each unstable boundary and documents the missing seam.
+#
+# Preconditions for later execution:
+# - The app is already on `HomeScreen` with a valid authenticated session.
+# - A deterministic image fixture or dev-only shortcut exists for both hide and guess flows.
+#
+# Blockers in the current app:
+# 1. `LogicalImagePicker` opens camera or gallery UI owned by the OS.
+# 2. `ShowPicture` requires coordinate-based taps on the image and dynamically positioned icon.
+# 3. `SwipeImage` depends on storage/API-loaded cards without stable text or ids.
+# 4. Reaching `ResultScreen` requires a deterministic guess outcome and then the `AdScreen` delay.
+#
+# Intended continuation once selectors and test seams exist:
+# - tapOn: Select an Image
+# - handle permission dialogs and pick a known fixture image
+# - tapOn image surface at a stable coordinate or selector
+# - tapOn target confirmation icon
+# - tapOn: Confirm
+# - inputText: ${HIDE_DESCRIPTION}
+# - tapOn: Confirm ?
+# - tapOn: Confirm
+# - tapOn: Find Waldo
+# - tapOn: Let's go!
+# - select a seeded guess card
+# - tap on the known target area
+# - tapOn: Confirm
+# - wait for the ad handoff
+# - assertVisible: You Found It! or You didn't find it :(
+
+- launchApp
+- waitForAnimationToEnd
+- assertVisible: "Hide Waldo"
+- assertVisible: "Find Waldo"
+- tapOn: "Hide Waldo"
+- assertVisible: "Take a Picture"
+- assertVisible: "Select an Image"
+- back
+- assertVisible: "Hide Waldo"
+- tapOn: "Find Waldo"
+- assertVisible: "Swipe !"
+- assertVisible: "Let's go!"
+- tapOn: "Let's go!"

--- a/App.js
+++ b/App.js
@@ -123,17 +123,21 @@ function AuthenticatedStack({ authContext }) {
             headerRight: ({ tintColor }) => (
               <>
                 <IconButton
+                  accessibilityLabel="Open settings"
                   icon="settings"
                   color={tintColor}
                   size={24}
                   onPress={() => navigation.navigate("SettingsScreen")}
+                  testID="home.header.settings"
                   style={{ marginRight: 20 }}
                 />
                 <IconButton
+                  accessibilityLabel="Log out"
                   icon="exit"
                   color={tintColor}
                   size={24}
                   onPress={() => disconnecting()}
+                  testID="home.header.logout"
                 />
               </>
             )

--- a/__tests__/AdScreen.test.js
+++ b/__tests__/AdScreen.test.js
@@ -1,0 +1,73 @@
+const mockLoadingOverlay = jest.fn(() => null);
+
+jest.mock('../components/UI/LoadingOverlay', () => {
+  return function MockLoadingOverlay(props) {
+    mockLoadingOverlay(props);
+    return null;
+  };
+});
+
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import AdScreen from '../screens/GuessScreens/AdScreen';
+
+describe('AdScreen', () => {
+  const originalDev = global.__DEV__;
+  const route = {
+    params: {
+      onTarget: true,
+      imageFile: 'file:///waldo.jpg',
+      pictureId: 'img-42',
+      description: 'Look near the fountain',
+      imageHeight: 1200,
+      imageWidth: 800,
+      isPortrait: true,
+      hiddenLocation: { x: 0.2, y: 0.4 },
+      screenHeight: 640,
+      screenWidth: 320,
+      listId: 9,
+      isTutorial: false,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    global.__DEV__ = originalDev;
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('navigates to the result screen after the production timeout elapses', async () => {
+    global.__DEV__ = false;
+    const navigation = {
+      replace: jest.fn(),
+    };
+
+    await act(async () => {
+      create(<AdScreen navigation={navigation} route={route} />);
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(navigation.replace).toHaveBeenCalledWith('ResultScreen', route.params);
+  });
+
+  it('shows the loading overlay immediately in development mode while no ad is loaded', async () => {
+    global.__DEV__ = true;
+
+    await act(async () => {
+      create(<AdScreen navigation={{ replace: jest.fn() }} route={route} />);
+    });
+
+    expect(mockLoadingOverlay).toHaveBeenCalledWith({
+      message: 'Loading Ads... Are you a test user? Sorry, just wait 5 seconds :3 ',
+    });
+  });
+});

--- a/__tests__/AdScreen.test.js
+++ b/__tests__/AdScreen.test.js
@@ -38,7 +38,7 @@ describe('AdScreen', () => {
 
   afterEach(() => {
     global.__DEV__ = originalDev;
-    jest.runOnlyPendingTimers();
+    jest.clearAllTimers();
     jest.useRealTimers();
   });
 
@@ -61,13 +61,19 @@ describe('AdScreen', () => {
 
   it('shows the loading overlay immediately in development mode while no ad is loaded', async () => {
     global.__DEV__ = true;
+    let renderer;
 
     await act(async () => {
-      create(<AdScreen navigation={{ replace: jest.fn() }} route={route} />);
+      renderer = create(<AdScreen navigation={{ replace: jest.fn() }} route={route} />);
     });
 
     expect(mockLoadingOverlay).toHaveBeenCalledWith({
       message: 'Loading Ads... Are you a test user? Sorry, just wait 5 seconds :3 ',
+    });
+
+    await act(async () => {
+      renderer.unmount();
+      jest.clearAllTimers();
     });
   });
 });

--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -1,0 +1,192 @@
+const mockLoadingOverlay = jest.fn(() => null);
+const mockIconButton = jest.fn(() => null);
+const recordedScreens = [];
+
+jest.mock('expo-dev-client', () => ({}));
+
+jest.mock('expo-navigation-bar', () => ({
+  setPositionAsync: jest.fn(),
+  setVisibilityAsync: jest.fn(),
+  setBehaviorAsync: jest.fn(),
+}));
+
+jest.mock('expo-status-bar', () => ({
+  setStatusBarHidden: jest.fn(),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  NavigationContainer: ({ children }) => children,
+}));
+
+jest.mock('@react-navigation/native-stack', () => {
+  const React = require('react');
+
+  return {
+    createNativeStackNavigator: jest.fn(() => ({
+      Navigator: ({ children }) => <>{children}</>,
+      Screen: (props) => {
+        recordedScreens.push(props);
+        return null;
+      },
+    })),
+  };
+});
+
+jest.mock('../components/UI/IconButton', () => {
+  return function MockIconButton(props) {
+    mockIconButton(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/LoadingOverlay', () => {
+  return function MockLoadingOverlay(props) {
+    mockLoadingOverlay(props);
+    return null;
+  };
+});
+
+jest.mock('../screens/AuthScreens/LoginScreen', () => 'LoginScreen');
+jest.mock('../screens/AuthScreens/SignupScreen', () => 'SignupScreen');
+jest.mock('../screens/HomeScreen', () => 'HomeScreen');
+jest.mock('../screens/HideScreens/HidingPathScreen', () => 'HidingPathScreen');
+jest.mock('../screens/HideScreens/HideScreen', () => 'HideScreen');
+jest.mock('../screens/GuessScreens/GuessPathScreen', () => 'GuessPathScreen');
+jest.mock('../screens/GuessScreens/GuessScreen', () => 'GuessScreen');
+jest.mock('../screens/GuessScreens/AdScreen', () => 'AdScreen');
+jest.mock('../screens/GuessScreens/ResultScreen', () => 'ResultScreen');
+jest.mock('../screens/SetInstructionScreen', () => 'SetInstructionScreen');
+jest.mock('../screens/RankingScreen', () => 'RankingScreen');
+jest.mock('../screens/SettingsScreen', () => 'SettingsScreen');
+
+jest.mock('../store/auth-context', () => {
+  const React = require('react');
+  const AuthContext = React.createContext({});
+
+  return {
+    __esModule: true,
+    AuthContext,
+    default: ({ children }) => children,
+  };
+});
+
+jest.mock('../utils/auth', () => ({
+  bootstrapStoredAuthSession: jest.fn(),
+}));
+
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import { Root } from '../App';
+import { AuthContext } from '../store/auth-context';
+import { bootstrapStoredAuthSession } from '../utils/auth';
+
+describe('App Root', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    recordedScreens.length = 0;
+  });
+
+  async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function renderRoot(contextValue) {
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <AuthContext.Provider value={contextValue}>
+          <Root />
+        </AuthContext.Provider>
+      );
+
+      await flushEffects();
+    });
+
+    return renderer;
+  }
+
+  it('shows the login loading gate and then renders the auth stack when no session is restored', async () => {
+    let resolveBootstrap;
+
+    bootstrapStoredAuthSession.mockReturnValue(
+      new Promise((resolve) => {
+        resolveBootstrap = resolve;
+      })
+    );
+
+    const contextValue = {
+      IsAuthenticated: false,
+      isAuthenticated: false,
+      restoreSession: jest.fn(),
+      logout: jest.fn(),
+    };
+
+    await renderRoot(contextValue);
+
+    expect(mockLoadingOverlay).toHaveBeenCalledWith({ message: 'Logging in...' });
+
+    await act(async () => {
+      resolveBootstrap(false);
+      await flushEffects();
+    });
+
+    expect(bootstrapStoredAuthSession).toHaveBeenCalledWith(contextValue.restoreSession);
+    expect(recordedScreens.map(({ name }) => name)).toEqual(expect.arrayContaining(['Login', 'Signup']));
+  });
+
+  it('renders the authenticated stack and wires the header actions for settings and logout', async () => {
+    bootstrapStoredAuthSession.mockResolvedValue(true);
+
+    const contextValue = {
+      IsAuthenticated: true,
+      isAuthenticated: true,
+      restoreSession: jest.fn(),
+      logout: jest.fn(),
+    };
+    const navigation = {
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+    };
+
+    await renderRoot(contextValue);
+
+    expect(recordedScreens.map(({ name }) => name)).toEqual(
+      expect.arrayContaining([
+        'HomeScreen',
+        'SettingsScreen',
+        'HidingPathScreen',
+        'GuessPathScreen',
+        'GuessScreen',
+        'AdScreen',
+        'ResultScreen',
+        'RankingScreen',
+      ])
+    );
+
+    const homeScreen = recordedScreens.find(({ name }) => name === 'HomeScreen');
+
+    await act(async () => {
+      const headerRight = homeScreen.options({ navigation }).headerRight;
+      create(headerRight({ tintColor: 'white' }));
+    });
+
+    const settingsButton = mockIconButton.mock.calls.find(([props]) => props.testID === 'home.header.settings')[0];
+    const logoutButton = mockIconButton.mock.calls.find(([props]) => props.testID === 'home.header.logout')[0];
+
+    await act(async () => {
+      settingsButton.onPress();
+    });
+
+    expect(navigation.navigate).toHaveBeenCalledWith('SettingsScreen');
+
+    await act(async () => {
+      logoutButton.onPress();
+    });
+
+    expect(contextValue.logout).toHaveBeenCalledTimes(1);
+    expect(mockLoadingOverlay).toHaveBeenCalledWith({ message: 'Disconnecting...' });
+  });
+});

--- a/__tests__/GuessScreen.test.js
+++ b/__tests__/GuessScreen.test.js
@@ -1,0 +1,88 @@
+const mockGuessPicture = jest.fn(() => null);
+const mockTutorialOverlay = jest.fn(() => null);
+
+jest.mock('../components/Picture/GuessPicture', () => {
+  return function MockGuessPicture(props) {
+    mockGuessPicture(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/TutorialOverlay', () => {
+  return function MockTutorialOverlay(props) {
+    mockTutorialOverlay(props);
+    return null;
+  };
+});
+
+jest.mock('../utils/targetLocation', () => ({
+  isOnTarget: jest.fn(),
+}));
+
+import React from 'react';
+import { Dimensions } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import GuessScreen from '../screens/GuessScreens/GuessScreen';
+import { isOnTarget } from '../utils/targetLocation';
+
+describe('GuessScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Dimensions, 'get').mockReturnValue({
+      width: 320,
+      height: 640,
+      scale: 1,
+      fontScale: 1,
+    });
+  });
+
+  afterEach(() => {
+    Dimensions.get.mockRestore();
+  });
+
+  it('passes the image payload to GuessPicture and routes guesses to AdScreen', async () => {
+    const navigation = { replace: jest.fn() };
+    const route = {
+      params: {
+        imageFile: 'file:///waldo.jpg',
+        pictureId: 'image-1',
+        description: 'Find Waldo',
+        imageHeight: 1200,
+        imageWidth: 800,
+        isPortrait: true,
+        hiddenLocation: { x: 0.5, y: 0.5 },
+        listId: 3,
+        isTutorial: true,
+      },
+    };
+    isOnTarget.mockReturnValue(true);
+
+    await act(async () => {
+      create(<GuessScreen navigation={navigation} route={route} />);
+    });
+
+    const pictureProps = mockGuessPicture.mock.calls[mockGuessPicture.mock.calls.length - 1][0];
+    pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 } });
+
+    expect(pictureProps.screenDimensions).toEqual({ width: 320, height: 640 });
+    expect(isOnTarget).toHaveBeenCalledWith({ location: { x: 0.5, y: 0.5 } });
+    expect(navigation.replace).toHaveBeenCalledWith('AdScreen', {
+      onTarget: true,
+      imageFile: 'file:///waldo.jpg',
+      pictureId: 'image-1',
+      description: 'Find Waldo',
+      imageHeight: 1200,
+      imageWidth: 800,
+      isPortrait: true,
+      hiddenLocation: { x: 0.5, y: 0.5 },
+      screenHeight: 640,
+      screenWidth: 320,
+      listId: 3,
+      isTutorial: true,
+    });
+    expect(mockTutorialOverlay).toHaveBeenCalledWith(
+      expect.objectContaining({ screen: 'GuessScreen', isPortrait: true })
+    );
+  });
+});

--- a/__tests__/HomeScreen.test.js
+++ b/__tests__/HomeScreen.test.js
@@ -1,3 +1,8 @@
+const mockBigButton = jest.fn(() => null);
+const mockCenteredModal = jest.fn(() => null);
+const mockTutorialOverlay = jest.fn(() => null);
+const mockIconButton = jest.fn(() => null);
+
 jest.mock('@react-navigation/native', () => {
   const React = require('react');
 
@@ -28,10 +33,33 @@ jest.mock('../store/auth-context', () => {
   };
 });
 
-jest.mock('../components/UI/BigButton', () => 'BigButton');
-jest.mock('../components/UI/CenteredModal', () => 'CenteredModal');
-jest.mock('../components/UI/TutorialOverlay', () => 'TutorialOverlay');
-jest.mock('../components/UI/IconButton', () => 'IconButton');
+jest.mock('../components/UI/BigButton', () => {
+  return function MockBigButton(props) {
+    mockBigButton(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/CenteredModal', () => {
+  return function MockCenteredModal(props) {
+    mockCenteredModal(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/TutorialOverlay', () => {
+  return function MockTutorialOverlay(props) {
+    mockTutorialOverlay(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/IconButton', () => {
+  return function MockIconButton(props) {
+    mockIconButton(props);
+    return null;
+  };
+});
 
 import React from 'react';
 import { Alert } from 'react-native';
@@ -40,6 +68,7 @@ import { act, create } from 'react-test-renderer';
 import HomeScreen from '../screens/HomeScreen';
 import { AuthContext } from '../store/auth-context';
 import { getScoreId } from '../utils/auth';
+import { isTutorialFinished } from '../utils/tutorialHandler';
 
 describe('HomeScreen post-launch session validation', () => {
   beforeEach(() => {
@@ -50,6 +79,33 @@ describe('HomeScreen post-launch session validation', () => {
   afterEach(() => {
     Alert.alert.mockRestore();
   });
+
+  async function renderScreen(contextValue, route = { params: {} }, navigationOverrides = {}) {
+    const navigation = {
+      navigate: jest.fn(),
+      replace: jest.fn(),
+      reset: jest.fn(),
+      ...navigationOverrides,
+    };
+
+    await act(async () => {
+      create(
+        <AuthContext.Provider value={contextValue}>
+          <HomeScreen navigation={navigation} route={route} />
+        </AuthContext.Provider>
+      );
+
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    return navigation;
+  }
+
+  function getBigButtonProps(text) {
+    const buttonCall = mockBigButton.mock.calls.find(([props]) => props.text === text);
+    return buttonCall?.[0];
+  }
 
   it('validates the persisted session on focus when verifyIsLoggedIn resolves false', async () => {
     getScoreId.mockResolvedValue({ status: 401 });
@@ -79,5 +135,100 @@ describe('HomeScreen post-launch session validation', () => {
       'Error, your session has expired',
       'Any upload will not be possible. \nPlease re-log in first'
     );
+  });
+
+  it('routes the main home actions to their navigation targets', async () => {
+    const contextValue = {
+      verifyIsLoggedIn: jest.fn().mockResolvedValue(true),
+      logout: jest.fn(),
+      token: 'Bearer persisted-token',
+      isTutorialFinished: {},
+    };
+    const navigation = await renderScreen(contextValue);
+
+    getBigButtonProps('Hide Waldo').onPress();
+    getBigButtonProps('Find Waldo').onPress();
+    getBigButtonProps('Ranking').onPress();
+
+    expect(navigation.navigate).toHaveBeenNthCalledWith(1, 'HidingPathScreen');
+    expect(navigation.navigate).toHaveBeenNthCalledWith(2, 'GuessPathScreen');
+    expect(navigation.navigate).toHaveBeenNthCalledWith(3, 'RankingScreen');
+  });
+
+  it('opens the tutorial modal when the context says the tutorial still needs to run', async () => {
+    const contextValue = {
+      verifyIsLoggedIn: jest.fn().mockResolvedValue(true),
+      logout: jest.fn(),
+      token: 'Bearer persisted-token',
+      isTutorialFinished: {
+        isTutorial: true,
+        guessPathDone: false,
+        hidePathDone: false,
+      },
+      turnTutorialOn: jest.fn(),
+    };
+
+    await renderScreen(contextValue);
+
+    expect(mockCenteredModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isModalVisible: true,
+      })
+    );
+  });
+
+  it('cancels the tutorial through the modal and persists the finished flag', async () => {
+    const contextValue = {
+      verifyIsLoggedIn: jest.fn().mockResolvedValue(true),
+      logout: jest.fn(),
+      token: 'Bearer persisted-token',
+      isTutorialFinished: {
+        isTutorial: true,
+        guessPathDone: false,
+        hidePathDone: false,
+      },
+      turnTutorialOn: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await renderScreen(contextValue);
+
+    const modalProps = mockCenteredModal.mock.calls[mockCenteredModal.mock.calls.length - 1][0];
+
+    await act(async () => {
+      await modalProps.onCancel();
+    });
+
+    expect(contextValue.turnTutorialOn).toHaveBeenCalledWith(false);
+    expect(isTutorialFinished).toHaveBeenCalledWith({
+      context: contextValue,
+      data: {
+        user: {
+          is_tutorial_finished: true,
+        },
+      },
+    });
+  });
+
+  it('shows the tutorial overlay and routes its Guess/Hide actions when already inside the tutorial', async () => {
+    const contextValue = {
+      verifyIsLoggedIn: jest.fn().mockResolvedValue(true),
+      logout: jest.fn(),
+      token: 'Bearer persisted-token',
+      isTutorialFinished: {
+        isTutorial: true,
+        guessPathDone: false,
+        hidePathDone: false,
+      },
+      turnTutorialOn: jest.fn(),
+    };
+    const navigation = await renderScreen(contextValue, { params: { isTutorial: true } });
+
+    const overlayProps = mockTutorialOverlay.mock.calls[mockTutorialOverlay.mock.calls.length - 1][0];
+
+    overlayProps.onPress.Guess();
+    overlayProps.onPress.Hide();
+
+    expect(navigation.replace).toHaveBeenNthCalledWith(1, 'GuessPathScreen', { isTutorial: true });
+    expect(navigation.replace).toHaveBeenNthCalledWith(2, 'HidingPathScreen', { isTutorial: true });
   });
 });

--- a/__tests__/LoginScreen.test.js
+++ b/__tests__/LoginScreen.test.js
@@ -1,0 +1,153 @@
+const mockAuthContent = jest.fn(() => null);
+const mockLoadingOverlay = jest.fn(() => null);
+
+jest.mock('../components/Auth/AuthContent', () => {
+	return function MockAuthContent(props) {
+		mockAuthContent(props);
+		return null;
+	};
+});
+
+jest.mock('../components/UI/LoadingOverlay', () => {
+	return function MockLoadingOverlay(props) {
+		mockLoadingOverlay(props);
+		return null;
+	};
+});
+
+jest.mock('../utils/auth', () => ({
+	login: jest.fn(),
+}));
+
+jest.mock('../store/auth-context', () => {
+	const React = require('react');
+
+	return {
+		AuthContext: React.createContext({}),
+	};
+});
+
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import LoginScreen from '../screens/AuthScreens/LoginScreen';
+import { AuthContext } from '../store/auth-context';
+import { login } from '../utils/auth';
+
+describe('LoginScreen', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+	});
+
+	afterEach(() => {
+		Alert.alert.mockRestore();
+	});
+
+	async function renderScreen(contextValue) {
+		await act(async () => {
+			create(
+				<AuthContext.Provider value={contextValue}>
+					<LoginScreen />
+				</AuthContext.Provider>
+			);
+		});
+	}
+
+	function getAuthContentProps() {
+		return mockAuthContent.mock.calls[mockAuthContent.mock.calls.length - 1][0];
+	}
+
+	it('authenticates the user when login succeeds', async () => {
+		const authenticate = jest.fn();
+		login.mockResolvedValue({
+			status: 200,
+			headers: {
+				authorization: 'Bearer token',
+				expiry: '123',
+				'access-token': 'access',
+				uid: 'waldo@example.com',
+				client: 'client',
+			},
+			data: {
+				data: {
+					id: '42',
+					username: 'waldo',
+					finished_tutorial: true,
+					score_id: 'score-1',
+				},
+			},
+		});
+
+		await renderScreen({ authenticate });
+
+		await act(async () => {
+			await getAuthContentProps().onAuthenticate({
+				email: 'waldo@example.com',
+				password: 'secret',
+			});
+		});
+
+		expect(login).toHaveBeenCalledWith({
+			email: 'waldo@example.com',
+			password: 'secret',
+		});
+		expect(authenticate).toHaveBeenCalledWith({
+			token: 'Bearer token',
+			expiry: '123',
+			access_token: 'access',
+			uid: 'waldo@example.com',
+			client: 'client',
+			userId: '42',
+			email: 'waldo@example.com',
+			username: 'waldo',
+			isTutorialFinished: true,
+			scoreId: 'score-1',
+		});
+	});
+
+	it('shows an invalid credentials alert when the backend rejects the login', async () => {
+		login.mockResolvedValue({ status: 401 });
+
+		await renderScreen({ authenticate: jest.fn() });
+
+		await act(async () => {
+			await getAuthContentProps().onAuthenticate({
+				email: 'waldo@example.com',
+				password: 'bad-password',
+			});
+		});
+
+		expect(Alert.alert).toHaveBeenCalledWith(
+			'Invalid credentials, please retry',
+			expect.stringContaining('Change your email or password before retrying')
+		);
+	});
+
+	it('renders the loading overlay while authentication is in flight', async () => {
+		let resolveLogin;
+		login.mockReturnValue(
+			new Promise((resolve) => {
+				resolveLogin = resolve;
+			})
+		);
+
+		await renderScreen({ authenticate: jest.fn() });
+
+		await act(async () => {
+			getAuthContentProps().onAuthenticate({
+				email: 'waldo@example.com',
+				password: 'secret',
+			});
+			await Promise.resolve();
+		});
+
+		expect(mockLoadingOverlay).toHaveBeenCalledWith({ message: 'Authenticating...' });
+
+		await act(async () => {
+			resolveLogin({ status: 500 });
+			await Promise.resolve();
+		});
+	});
+});

--- a/__tests__/RankingScreen.test.js
+++ b/__tests__/RankingScreen.test.js
@@ -1,0 +1,173 @@
+const mockTableComponent = jest.fn(() => null);
+const mockLoadingOverlay = jest.fn(() => null);
+
+jest.mock('../components/UI/TableComponent', () => {
+  return function MockTableComponent(props) {
+    mockTableComponent(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/LoadingOverlay', () => {
+  return function MockLoadingOverlay(props) {
+    mockLoadingOverlay(props);
+    return null;
+  };
+});
+
+jest.mock('../utils/scoreRequests', () => ({
+  getRankingData: jest.fn(),
+  getUserScores: jest.fn(),
+}));
+
+jest.mock('../store/auth-context', () => {
+  const React = require('react');
+
+  return {
+    AuthContext: React.createContext({}),
+  };
+});
+
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import RankingScreen from '../screens/RankingScreen';
+import { AuthContext } from '../store/auth-context';
+import { getRankingData, getUserScores } from '../utils/scoreRequests';
+
+describe('RankingScreen', () => {
+  const contextValue = {
+    token: 'token',
+    uid: 'waldo@example.com',
+    expiry: '123',
+    access_token: 'access-token',
+    client: 'client-id',
+    userId: '42',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function renderScreen() {
+    await act(async () => {
+      create(
+        <AuthContext.Provider value={contextValue}>
+          <RankingScreen />
+        </AuthContext.Provider>
+      );
+
+      await flushEffects();
+    });
+  }
+
+  function getTableProps() {
+    return mockTableComponent.mock.calls[mockTableComponent.mock.calls.length - 1][0];
+  }
+
+  it('loads the initial ranking window and converts the rows for the table component', async () => {
+    getRankingData.mockResolvedValue({
+      status: 200,
+      data: {
+        data: {
+          rows: [
+            { rank: '1', username: 'waldo', total_score: 25 },
+            { rank: '2', username: 'odile', total_score: 14 },
+          ],
+        },
+      },
+    });
+
+    await renderScreen();
+
+    expect(getRankingData).toHaveBeenCalledWith(contextValue, { scope: 'initial', top: 10, window: 5 });
+    expect(getTableProps()).toEqual(
+      expect.objectContaining({
+        data: {
+          tableHeaders: ['Rank', 'Name', 'Score', 'Others'],
+          tableScores: [
+            { rank: 1, name: 'waldo', score: 25, others: '' },
+            { rank: 2, name: 'odile', score: 14, others: '' },
+          ],
+        },
+      })
+    );
+    expect(mockLoadingOverlay).not.toHaveBeenCalled();
+  });
+
+  it('shows the detailed score breakdown when a username is selected from the table', async () => {
+    getRankingData.mockResolvedValue({
+      status: 200,
+      data: {
+        data: {
+          rows: [{ rank: '1', username: 'waldo', total_score: 25 }],
+        },
+      },
+    });
+    getUserScores.mockResolvedValue({
+      status: 200,
+      data: {
+        total: {
+          total_score: 25,
+          total_hide_score: 11,
+          total_guess_score: 14,
+        },
+        hide_info: {
+          hide_count: 4,
+        },
+        guess_info: {
+          guess_count: 6,
+        },
+      },
+    });
+
+    await renderScreen();
+
+    await act(async () => {
+      await getTableProps().onPress('waldo');
+    });
+
+    expect(getUserScores).toHaveBeenCalledWith({ username: 'waldo', context: contextValue });
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Complementary Scores of waldo',
+      expect.stringContaining('Total Score: 25')
+    );
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Complementary Scores of waldo',
+      expect.stringContaining('Guessed Images Count: 6')
+    );
+  });
+
+  it('alerts when detailed scores are not found for a selected user', async () => {
+    getRankingData.mockResolvedValue({
+      status: 200,
+      data: {
+        data: {
+          rows: [{ rank: '1', username: 'waldo', total_score: 25 }],
+        },
+      },
+    });
+    getUserScores.mockResolvedValue({
+      status: 404,
+    });
+
+    await renderScreen();
+
+    await act(async () => {
+      await getTableProps().onPress('waldo');
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith('User not found', 'No scores found for waldo.');
+  });
+});

--- a/__tests__/RankingScreen.test.js
+++ b/__tests__/RankingScreen.test.js
@@ -103,7 +103,6 @@ describe('RankingScreen', () => {
         },
       })
     );
-    expect(mockLoadingOverlay).not.toHaveBeenCalled();
   });
 
   it('shows the detailed score breakdown when a username is selected from the table', async () => {

--- a/__tests__/ResultChoices.test.js
+++ b/__tests__/ResultChoices.test.js
@@ -1,0 +1,90 @@
+const mockBigButton = jest.fn(() => null);
+
+jest.mock('../components/UI/BigButton', () => {
+  return function MockBigButton(props) {
+    mockBigButton(props);
+    return null;
+  };
+});
+
+jest.mock('../store/auth-context', () => {
+  const React = require('react');
+
+  return {
+    AuthContext: React.createContext({}),
+  };
+});
+
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import ResultChoices from '../components/Results/ResultChoices';
+import { AuthContext } from '../store/auth-context';
+
+describe('ResultChoices', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function getButtonProps(text) {
+    const buttonCall = mockBigButton.mock.calls.find(([props]) => props.text === text);
+    return buttonCall?.[0];
+  }
+
+  it('returns to HomeScreen and persists tutorial progress when needed', async () => {
+    const navigation = { reset: jest.fn() };
+    const updateTutorialStatus = jest.fn().mockResolvedValue(undefined);
+
+    await act(async () => {
+      create(
+        <AuthContext.Provider value={{
+          updateTutorialStatus,
+          isTutorialFinished: { hidePathDone: false },
+        }}>
+          <ResultChoices navigation={navigation} success={true} isTutorial={true} />
+        </AuthContext.Provider>
+      );
+    });
+
+    await act(async () => {
+      await getButtonProps('Go to Home').onPress();
+    });
+
+    expect(updateTutorialStatus).toHaveBeenCalledWith({
+      isTutorial: true,
+      guessPathDone: true,
+      hidePathDone: false,
+    });
+    expect(navigation.reset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: 'HomeScreen', params: { isTutorial: true } }],
+    });
+  });
+
+  it('offers retry and next-image flows when the guess failed', async () => {
+    const navigation = { reset: jest.fn() };
+    const retryGuess = jest.fn();
+
+    await act(async () => {
+      create(
+        <AuthContext.Provider value={{ updateTutorialStatus: jest.fn(), isTutorialFinished: {} }}>
+          <ResultChoices
+            navigation={navigation}
+            success={false}
+            retryGuess={retryGuess}
+            isTutorial={false}
+          />
+        </AuthContext.Provider>
+      );
+    });
+
+    getButtonProps('Retry this one').onPress();
+    getButtonProps('Another one').onPress();
+
+    expect(retryGuess).toHaveBeenCalledTimes(1);
+    expect(navigation.reset).toHaveBeenCalledWith({
+      index: 1,
+      routes: [{ name: 'GuessPathScreen', params: { isTutorial: false } }],
+    });
+  });
+});

--- a/__tests__/ResultScreen.test.js
+++ b/__tests__/ResultScreen.test.js
@@ -1,0 +1,57 @@
+const mockShowSuccess = jest.fn(() => null);
+const mockShowFailure = jest.fn(() => null);
+
+jest.mock('../utils/orientation', () => ({
+  handleOrientation: jest.fn(),
+}));
+
+jest.mock('../components/Results/ShowSuccess', () => {
+  return function MockShowSuccess(props) {
+    mockShowSuccess(props);
+    return null;
+  };
+});
+
+jest.mock('../components/Results/ShowFailure', () => {
+  return function MockShowFailure(props) {
+    mockShowFailure(props);
+    return null;
+  };
+});
+
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import ResultScreen from '../screens/GuessScreens/ResultScreen';
+import { handleOrientation } from '../utils/orientation';
+
+describe('ResultScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('locks the screen back to portrait and renders the success branch', async () => {
+    const navigation = { reset: jest.fn() };
+    const route = { params: { onTarget: true } };
+
+    await act(async () => {
+      create(<ResultScreen route={route} navigation={navigation} />);
+    });
+
+    expect(handleOrientation).toHaveBeenCalledWith('portrait');
+    expect(mockShowSuccess).toHaveBeenCalledWith({ navigation, route });
+    expect(mockShowFailure).not.toHaveBeenCalled();
+  });
+
+  it('renders the failure branch when the guess misses the target', async () => {
+    const navigation = { reset: jest.fn() };
+    const route = { params: { onTarget: false } };
+
+    await act(async () => {
+      create(<ResultScreen route={route} navigation={navigation} />);
+    });
+
+    expect(mockShowFailure).toHaveBeenCalledWith({ navigation, route });
+    expect(mockShowSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/SetInstructionScreen.test.js
+++ b/__tests__/SetInstructionScreen.test.js
@@ -1,0 +1,289 @@
+const mockHideDescription = jest.fn(() => null);
+const mockCenteredModal = jest.fn(() => null);
+const mockModalContent = jest.fn(() => null);
+const mockTutorialOverlay = jest.fn(() => null);
+const mockLoadingOverlay = jest.fn(() => null);
+
+const mockRequestPermission = jest.fn();
+const mockUsePermissions = jest.fn();
+const mockOpenSettings = jest.fn();
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('expo-media-library', () => ({
+  usePermissions: () => mockUsePermissions(),
+}));
+
+jest.mock('expo-linking', () => ({
+  openSettings: () => mockOpenSettings(),
+}));
+
+jest.mock('../store/auth-context', () => {
+  const React = require('react');
+
+  return {
+    AuthContext: React.createContext({}),
+  };
+});
+
+jest.mock('../components/Picture/Descriptions/HideDescription', () => {
+  return function MockHideDescription(props) {
+    mockHideDescription(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/CenteredModal', () => {
+  return function MockCenteredModal(props) {
+    mockCenteredModal(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/ModalContent', () => {
+  return function MockModalContent(props) {
+    mockModalContent(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/TutorialOverlay', () => {
+  return function MockTutorialOverlay(props) {
+    mockTutorialOverlay(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/LoadingOverlay', () => {
+  return function MockLoadingOverlay(props) {
+    mockLoadingOverlay(props);
+    return null;
+  };
+});
+
+jest.mock('../utils/fileUploader', () => ({
+  imageUploader: jest.fn(),
+}));
+
+jest.mock('../utils/orientation', () => ({
+  handleOrientation: jest.fn(),
+}));
+
+jest.mock('../utils/imageInfos', () => ({
+  handleImageType: jest.fn(),
+  isTypeValid: jest.fn(),
+}));
+
+jest.mock('../utils/auth', () => ({
+  checkSecureStoreItem: jest.fn(),
+}));
+
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import SetInstructionsScreen from '../screens/SetInstructionScreen';
+import { AuthContext } from '../store/auth-context';
+import { checkSecureStoreItem } from '../utils/auth';
+import { imageUploader } from '../utils/fileUploader';
+import { handleImageType, isTypeValid } from '../utils/imageInfos';
+import { handleOrientation } from '../utils/orientation';
+
+describe('SetInstructionScreen', () => {
+  const navigation = {
+    replace: jest.fn(),
+    reset: jest.fn(),
+  };
+  const route = {
+    params: {
+      uri: 'file:///waldo.png',
+      imageWidth: 1024,
+      imageHeight: 768,
+      screenHeight: 640,
+      screenWidth: 320,
+      isPortrait: true,
+      touchLocation: { x: 0.3, y: 0.7 },
+      target: { targetSize: 18, targetStyle: { top: 10, left: 10 } },
+      imageDimensionStyle: { width: 200, height: 300 },
+      isTutorial: false,
+    },
+  };
+  const contextValue = {
+    isTutorialFinished: {
+      guessPathDone: false,
+      hidePathDone: false,
+    },
+    updateTutorialStatus: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    mockUsePermissions.mockReturnValue([
+      {
+        status: 'granted',
+        canAskAgain: true,
+      },
+      mockRequestPermission,
+    ]);
+    checkSecureStoreItem.mockResolvedValue('user-42');
+    handleImageType.mockReturnValue('png');
+    isTypeValid.mockReturnValue(true);
+    imageUploader.mockResolvedValue({ status: 200 });
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function renderScreen(routeOverrides = {}, contextOverrides = {}) {
+    await act(async () => {
+      create(
+        <AuthContext.Provider value={{ ...contextValue, ...contextOverrides }}>
+          <SetInstructionsScreen
+            navigation={navigation}
+            route={{
+              ...route,
+              ...routeOverrides,
+              params: {
+                ...route.params,
+                ...(routeOverrides.params || {}),
+              },
+            }}
+          />
+        </AuthContext.Provider>
+      );
+
+      await flushEffects();
+    });
+  }
+
+  function getModalProps() {
+    return mockCenteredModal.mock.calls[mockCenteredModal.mock.calls.length - 1][0];
+  }
+
+  it('rejects invalid file types before trying the upload pipeline', async () => {
+    handleImageType.mockReturnValue('gif');
+    isTypeValid.mockReturnValue(false);
+
+    await renderScreen();
+
+    await act(async () => {
+      mockHideDescription.mock.calls[0][0].onSubmit('Look near the river');
+    });
+
+    await act(async () => {
+      await getModalProps().onPress();
+      await flushEffects();
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Invalid image type',
+      'Please select a valid image type (png, jpg or jpeg)'
+    );
+    expect(imageUploader).not.toHaveBeenCalled();
+    expect(navigation.reset).not.toHaveBeenCalled();
+  });
+
+  it('opens the app settings when media-library permission can no longer be requested', async () => {
+    mockUsePermissions.mockReturnValue([
+      {
+        status: 'denied',
+        canAskAgain: false,
+      },
+      mockRequestPermission,
+    ]);
+
+    await renderScreen();
+
+    await act(async () => {
+      mockHideDescription.mock.calls[0][0].onSubmit('Look near the river');
+    });
+
+    await act(async () => {
+      await getModalProps().onPress();
+      await flushEffects();
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Insufficient Permissions',
+      'Access to  Photos and Videos / audio is denied'
+    );
+    expect(mockOpenSettings).toHaveBeenCalledTimes(1);
+    expect(imageUploader).not.toHaveBeenCalled();
+  });
+
+  it('uploads the image, updates the tutorial state, and resets back to the home screen', async () => {
+    const tutorialContext = {
+      isTutorialFinished: {
+        guessPathDone: false,
+        hidePathDone: false,
+      },
+      updateTutorialStatus: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await renderScreen(
+      {
+        params: {
+          isTutorial: true,
+        },
+      },
+      tutorialContext
+    );
+
+    await act(async () => {
+      mockHideDescription.mock.calls[0][0].onSubmit('Look near the river');
+    });
+
+    await act(async () => {
+      await getModalProps().onPress();
+      await flushEffects();
+    });
+
+    expect(checkSecureStoreItem).toHaveBeenCalledWith({
+      secureStoreValue: 'userId',
+      context: expect.objectContaining(tutorialContext),
+    });
+    expect(imageUploader).toHaveBeenCalledWith({
+      imageInfos: {
+        uri: 'file:///waldo.png',
+        userId: 'user-42',
+        fileExtension: 'png',
+        imageHeight: 768,
+        imageWidth: 1024,
+        screenHeight: 640,
+        screenWidth: 320,
+        description: 'Look near the river',
+        isPortrait: true,
+        xLocation: 0.3,
+        yLocation: 0.7,
+      },
+      context: expect.objectContaining(tutorialContext),
+    });
+    expect(handleOrientation).toHaveBeenCalledWith('portrait');
+    expect(tutorialContext.updateTutorialStatus).toHaveBeenCalledWith({
+      isTutorial: true,
+      guessPathDone: false,
+      hidePathDone: true,
+    });
+    expect(navigation.reset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [
+        {
+          name: 'HomeScreen',
+          params: {
+            isTutorial: true,
+            hidePathDone: true,
+          },
+        },
+      ],
+    });
+  });
+});

--- a/__tests__/SettingsScreen.test.js
+++ b/__tests__/SettingsScreen.test.js
@@ -94,7 +94,8 @@ describe('SettingsScreen', () => {
   }
 
   function getButtonProps(testID) {
-    return mockButton.mock.calls.find(([props]) => props.testID === testID)[0];
+    const matchingCalls = mockButton.mock.calls.filter(([props]) => props.testID === testID);
+    return matchingCalls[matchingCalls.length - 1][0];
   }
 
   function getModalProps() {

--- a/__tests__/SettingsScreen.test.js
+++ b/__tests__/SettingsScreen.test.js
@@ -1,0 +1,180 @@
+const mockButton = jest.fn(() => null);
+const mockCenteredModal = jest.fn(() => null);
+const mockLoadingOverlay = jest.fn(() => null);
+
+jest.mock('../components/UI/Button', () => {
+  return function MockButton(props) {
+    mockButton(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/CenteredModal', () => {
+  return function MockCenteredModal(props) {
+    mockCenteredModal(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/LoadingOverlay', () => {
+  return function MockLoadingOverlay(props) {
+    mockLoadingOverlay(props);
+    return null;
+  };
+});
+
+jest.mock('../utils/auth', () => ({
+  updateUser: jest.fn(),
+  deleteAccount: jest.fn(),
+  checkSecureStoreItem: jest.fn(),
+}));
+
+jest.mock('../store/auth-context', () => {
+  const React = require('react');
+
+  return {
+    AuthContext: React.createContext({}),
+  };
+});
+
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import SettingsScreen from '../screens/SettingsScreen';
+import { AuthContext } from '../store/auth-context';
+import { checkSecureStoreItem, deleteAccount, updateUser } from '../utils/auth';
+
+describe('SettingsScreen', () => {
+  const contextValue = {
+    changeUserEmail: jest.fn(),
+    changeUsername: jest.fn(),
+    logout: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    checkSecureStoreItem.mockImplementation(({ secureStoreValue }) => {
+      if (secureStoreValue === 'email') {
+        return Promise.resolve('stored@example.com');
+      }
+
+      if (secureStoreValue === 'username') {
+        return Promise.resolve('stored-user');
+      }
+
+      return Promise.resolve(null);
+    });
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function renderScreen() {
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <AuthContext.Provider value={contextValue}>
+          <SettingsScreen />
+        </AuthContext.Provider>
+      );
+
+      await flushEffects();
+    });
+
+    return renderer;
+  }
+
+  function getButtonProps(testID) {
+    return mockButton.mock.calls.find(([props]) => props.testID === testID)[0];
+  }
+
+  function getModalProps() {
+    return mockCenteredModal.mock.calls[mockCenteredModal.mock.calls.length - 1][0];
+  }
+
+  it('preloads the stored email and username into the form fields', async () => {
+    const renderer = await renderScreen();
+
+    expect(renderer.root.findByProps({ testID: 'settings.input.email' }).props.value).toBe('stored@example.com');
+    expect(renderer.root.findByProps({ testID: 'settings.input.username' }).props.value).toBe('stored-user');
+  });
+
+  it('confirms and submits an email change through the modal flow', async () => {
+    updateUser.mockResolvedValue({
+      status: 200,
+      data: {
+        email: 'fresh@example.com',
+      },
+    });
+
+    const renderer = await renderScreen();
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'settings.input.email' }).props.onChangeText('new@example.com');
+    });
+
+    await act(async () => {
+      getButtonProps('settings.button.save-email').onPress();
+    });
+
+    expect(getModalProps()).toEqual(
+      expect.objectContaining({
+        isModalVisible: true,
+        children: 'Are you sure you want to change your email to new@example.com ?',
+      })
+    );
+
+    await act(async () => {
+      getModalProps().onPress();
+      await flushEffects();
+    });
+
+    expect(updateUser).toHaveBeenCalledWith({
+      context: contextValue,
+      data: { email: 'new@example.com' },
+    });
+    expect(contextValue.changeUserEmail).toHaveBeenCalledWith('fresh@example.com');
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Email changed successfully!',
+      'Your new email is: fresh@example.com'
+    );
+  });
+
+  it('confirms account deletion, logs the user out, and shows the success alert', async () => {
+    deleteAccount.mockResolvedValue({
+      status: 200,
+      data: {
+        message: 'Account removed.',
+      },
+    });
+
+    await renderScreen();
+
+    await act(async () => {
+      getButtonProps('settings.button.delete-account').onPress();
+    });
+
+    expect(getModalProps().children).toContain('PERMANENT DELETION');
+
+    await act(async () => {
+      getModalProps().onPress();
+      await flushEffects();
+    });
+
+    expect(deleteAccount).toHaveBeenCalledWith({ context: contextValue });
+    expect(contextValue.logout).toHaveBeenCalledTimes(1);
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Account deleted successfully!',
+      'Account removed.\nWe are sorry to see you go!'
+    );
+  });
+});

--- a/__tests__/ShowSuccess.test.js
+++ b/__tests__/ShowSuccess.test.js
@@ -1,0 +1,107 @@
+const mockResultChoices = jest.fn(() => null);
+const mockImageAnimated = jest.fn(() => null);
+const mockTutorialOverlay = jest.fn(() => null);
+
+jest.mock('../components/Results/ResultChoices', () => {
+  return function MockResultChoices(props) {
+    mockResultChoices(props);
+    return null;
+  };
+});
+
+jest.mock('../components/Results/ImageAnimated', () => {
+  return function MockImageAnimated(props) {
+    mockImageAnimated(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/TutorialOverlay', () => {
+  return function MockTutorialOverlay(props) {
+    mockTutorialOverlay(props);
+    return null;
+  };
+});
+
+jest.mock('../utils/storageDatum', () => ({
+  deleteImageFromStorage: jest.fn(),
+  removeImageFromList: jest.fn(),
+}));
+
+jest.mock('../utils/scoreRequests', () => ({
+  updateUserScore: jest.fn(),
+}));
+
+jest.mock('../store/auth-context', () => {
+  const React = require('react');
+
+  return {
+    AuthContext: React.createContext({}),
+  };
+});
+
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import ShowSuccess from '../components/Results/ShowSuccess';
+import { AuthContext } from '../store/auth-context';
+import { deleteImageFromStorage, removeImageFromList } from '../utils/storageDatum';
+import { updateUserScore } from '../utils/scoreRequests';
+
+describe('ShowSuccess', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    removeImageFromList.mockResolvedValue(undefined);
+    deleteImageFromStorage.mockResolvedValue(undefined);
+    updateUserScore.mockResolvedValue({ status: 200 });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('cleans up storage, updates the score, and reveals result choices after the animation', async () => {
+    const navigation = { reset: jest.fn() };
+    const route = {
+      params: {
+        pictureId: 'image-1',
+        listId: 7,
+        imageFile: 'file:///waldo.jpg',
+        isTutorial: true,
+      },
+    };
+
+    await act(async () => {
+      create(
+        <AuthContext.Provider value={{ userId: '42' }}>
+          <ShowSuccess navigation={navigation} route={route} />
+        </AuthContext.Provider>
+      );
+    });
+
+    expect(mockImageAnimated).toHaveBeenCalledWith({ success: true });
+    expect(removeImageFromList).toHaveBeenCalledWith(7);
+    expect(deleteImageFromStorage).toHaveBeenCalledWith('file:///waldo.jpg');
+    expect(updateUserScore).toHaveBeenCalledWith({
+      score: 1,
+      pictureId: 'image-1',
+      context: { userId: '42' },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(mockResultChoices).toHaveBeenCalledWith(
+      expect.objectContaining({
+        navigation,
+        success: true,
+        isTutorial: true,
+      })
+    );
+    expect(mockTutorialOverlay).toHaveBeenCalledWith(
+      expect.objectContaining({ screen: 'ShowSuccess' })
+    );
+  });
+});

--- a/__tests__/SignupScreen.test.js
+++ b/__tests__/SignupScreen.test.js
@@ -1,0 +1,170 @@
+const mockAuthContent = jest.fn(() => null);
+const mockLoadingOverlay = jest.fn(() => null);
+
+jest.mock('../components/Auth/AuthContent', () => {
+  return function MockAuthContent(props) {
+    mockAuthContent(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/LoadingOverlay', () => {
+  return function MockLoadingOverlay(props) {
+    mockLoadingOverlay(props);
+    return null;
+  };
+});
+
+jest.mock('../utils/auth', () => ({
+  createUser: jest.fn(),
+  getScoreId: jest.fn(),
+  login: jest.fn(),
+}));
+
+jest.mock('../store/auth-context', () => {
+  const React = require('react');
+
+  return {
+    AuthContext: React.createContext({}),
+  };
+});
+
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import SignupScreen from '../screens/AuthScreens/SignupScreen';
+import { AuthContext } from '../store/auth-context';
+import { createUser, getScoreId, login } from '../utils/auth';
+
+describe('SignupScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function renderScreen(contextValue) {
+    await act(async () => {
+      create(
+        <AuthContext.Provider value={contextValue}>
+          <SignupScreen navigation={{ navigate: jest.fn() }} />
+        </AuthContext.Provider>
+      );
+    });
+  }
+
+  function getAuthContentProps() {
+    return mockAuthContent.mock.calls[mockAuthContent.mock.calls.length - 1][0];
+  }
+
+  it('creates the user, logs them in, and stores the returned score id', async () => {
+    const authenticate = jest.fn();
+    const saveScoreId = jest.fn();
+
+    createUser.mockResolvedValue({ status: 200 });
+    login.mockResolvedValue({
+      status: 200,
+      headers: {
+        authorization: 'Bearer token',
+        expiry: '123',
+        'access-token': 'access',
+        uid: 'new@example.com',
+        client: 'client',
+      },
+      data: {
+        data: {
+          id: '42',
+          email: 'new@example.com',
+          username: 'new-user',
+        },
+      },
+    });
+    getScoreId.mockResolvedValue({ status: 200, data: { score_id: 'score-1' } });
+
+    await renderScreen({ authenticate, saveScoreId });
+
+    await act(async () => {
+      await getAuthContentProps().onAuthenticate({
+        email: 'new@example.com',
+        password: 'secret',
+        confirmPassword: 'secret',
+        username: 'new-user',
+      });
+    });
+
+    expect(createUser).toHaveBeenCalledWith({
+      email: 'new@example.com',
+      password: 'secret',
+      confirmPassword: 'secret',
+      username: 'new-user',
+    });
+    expect(login).toHaveBeenCalledWith({
+      email: 'new@example.com',
+      password: 'secret',
+    });
+    expect(authenticate).toHaveBeenCalledWith({
+      token: 'Bearer token',
+      expiry: '123',
+      access_token: 'access',
+      uid: 'new@example.com',
+      client: 'client',
+      userId: '42',
+      email: 'new@example.com',
+      username: 'new-user',
+    });
+    expect(saveScoreId).toHaveBeenCalledWith('score-1');
+  });
+
+  it('shows a duplicate-user alert when signup fails with 422', async () => {
+    createUser.mockResolvedValue({ status: 422 });
+
+    await renderScreen({ authenticate: jest.fn(), saveScoreId: jest.fn() });
+
+    await act(async () => {
+      await getAuthContentProps().onAuthenticate({
+        email: 'new@example.com',
+        password: 'secret',
+        confirmPassword: 'secret',
+        username: 'new-user',
+      });
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'User creation failed',
+      '422: Please choose an other email.'
+    );
+  });
+
+  it('renders the loading overlay while the signup pipeline is still pending', async () => {
+    let resolveCreateUser;
+
+    createUser.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreateUser = resolve;
+      })
+    );
+
+    await renderScreen({ authenticate: jest.fn(), saveScoreId: jest.fn() });
+
+    await act(async () => {
+      getAuthContentProps().onAuthenticate({
+        email: 'new@example.com',
+        password: 'secret',
+        confirmPassword: 'secret',
+        username: 'new-user',
+      });
+      await Promise.resolve();
+    });
+
+    expect(mockLoadingOverlay).toHaveBeenCalledWith({ message: 'Creating user...' });
+
+    await act(async () => {
+      resolveCreateUser({ status: 500 });
+      await Promise.resolve();
+    });
+  });
+});

--- a/__tests__/SwipeImage.test.js
+++ b/__tests__/SwipeImage.test.js
@@ -1,0 +1,217 @@
+const mockSwipeableCard = jest.fn(() => null);
+const mockLoadingOverlay = jest.fn(() => null);
+
+jest.mock('react-native-gesture-handler', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  return {
+    GestureHandlerRootView: ({ children }) => <View>{children}</View>,
+  };
+});
+
+jest.mock('../components/UI/SwipeableCard', () => {
+  return function MockSwipeableCard(props) {
+    mockSwipeableCard(props);
+    return null;
+  };
+});
+
+jest.mock('../components/UI/LoadingOverlay', () => {
+  return function MockLoadingOverlay(props) {
+    mockLoadingOverlay(props);
+    return null;
+  };
+});
+
+jest.mock('../utils/imagesRequests', () => ({
+  getImages: jest.fn(),
+}));
+
+jest.mock('../utils/storageDatum', () => ({
+  getLocalImages: jest.fn(),
+  storeImageList: jest.fn(),
+  getLastImageId: jest.fn(),
+  emptyImageList: jest.fn(),
+  removeImageFromList: jest.fn(),
+  updateImageList: jest.fn(),
+  getLastImageUuid: jest.fn(),
+  saveLastImageUuid: jest.fn(),
+  deleteImageFromStorage: jest.fn(),
+}));
+
+jest.mock('../store/auth-context', () => {
+  const React = require('react');
+
+  return {
+    AuthContext: React.createContext({}),
+  };
+});
+
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import SwipeImage from '../components/UI/SwipeImage';
+import { AuthContext } from '../store/auth-context';
+import { getImages } from '../utils/imagesRequests';
+import {
+  deleteImageFromStorage,
+  getLastImageId,
+  getLastImageUuid,
+  getLocalImages,
+  removeImageFromList,
+  storeImageList,
+  updateImageList,
+} from '../utils/storageDatum';
+
+describe('SwipeImage', () => {
+  const contextValue = {
+    token: 'token',
+    uid: 'waldo@example.com',
+    expiry: '123',
+    access_token: 'access-token',
+    client: 'client-id',
+    userId: '42',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    getLastImageId.mockResolvedValue(0);
+    getLastImageUuid.mockResolvedValue(null);
+    updateImageList.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function renderSwipeImage(startGuessing = jest.fn()) {
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <AuthContext.Provider value={contextValue}>
+          <SwipeImage screenWidth={320} screenHeight={640} startGuessing={startGuessing} />
+        </AuthContext.Provider>
+      );
+
+      await flushEffects();
+    });
+
+    return { renderer, startGuessing };
+  }
+
+  it('uses the local cache when at least four cards are already stored', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, imageFile: 'file:///1.jpg' },
+      { listId: 2, imageFile: 'file:///2.jpg' },
+      { listId: 3, imageFile: 'file:///3.jpg' },
+      { listId: 4, imageFile: 'file:///4.jpg' },
+    ]);
+
+    const { startGuessing } = await renderSwipeImage();
+
+    expect(getImages).not.toHaveBeenCalled();
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.listId)).toEqual([4, 3, 2, 1]);
+    expect(mockSwipeableCard.mock.calls[0][0].onSwipe).toBe(startGuessing);
+  });
+
+  it('loads new images, assigns incremental list ids, and stores them when the cache is empty', async () => {
+    getLocalImages.mockResolvedValue(null);
+    getLastImageId.mockResolvedValue(4);
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [
+        { pictureId: 'img-1', imageFile: 'file:///one.jpg' },
+        { pictureId: 'img-2', imageFile: 'file:///two.jpg' },
+      ],
+    });
+
+    await renderSwipeImage();
+
+    expect(getImages).toHaveBeenCalledWith(null, contextValue);
+    expect(storeImageList).toHaveBeenCalledWith([
+      expect.objectContaining({ pictureId: 'img-1', listId: 5 }),
+      expect.objectContaining({ pictureId: 'img-2', listId: 6 }),
+    ]);
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.listId)).toEqual([6, 5]);
+  });
+
+  it('shows the empty-state guidance when the backend returns no playable images', async () => {
+    getLocalImages.mockResolvedValue(null);
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [],
+    });
+
+    const { renderer } = await renderSwipeImage();
+
+    const renderedText = renderer.root
+      .findAll((node) => node.type === 'Text')
+      .map((node) => node.props.children)
+      .flat()
+      .join(' ');
+
+    expect(renderedText).toContain('To play you can:');
+    expect(renderedText).toContain('Upload new images');
+  });
+
+  it('alerts the user when loading fresh images fails', async () => {
+    getLocalImages.mockResolvedValue(null);
+    getImages.mockResolvedValue({
+      isError: true,
+      title: 'Server error',
+      message: 'Please retry later',
+    });
+
+    await renderSwipeImage();
+
+    expect(Alert.alert).toHaveBeenCalledWith('Server error', 'Please retry later');
+  });
+
+  it('deletes a dismissed card and fetches more images when the stack drops below four', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, imageFile: 'file:///1.jpg' },
+      { listId: 2, imageFile: 'file:///2.jpg' },
+      { listId: 3, imageFile: 'file:///3.jpg' },
+      { listId: 4, imageFile: 'file:///4.jpg' },
+    ]);
+    getLastImageId.mockResolvedValue(4);
+    getLastImageUuid.mockResolvedValue('image-4');
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [{ pictureId: 'img-5', imageFile: 'file:///5.jpg' }],
+    });
+    updateImageList.mockResolvedValue([
+      { listId: 2, imageFile: 'file:///2.jpg' },
+      { listId: 3, imageFile: 'file:///3.jpg' },
+      { listId: 4, imageFile: 'file:///4.jpg' },
+      { listId: 5, imageFile: 'file:///5.jpg' },
+    ]);
+
+    await renderSwipeImage();
+
+    const removableCard = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+    mockSwipeableCard.mockClear();
+
+    await act(async () => {
+      await removableCard.removeCard(1);
+      await flushEffects();
+    });
+
+    expect(removeImageFromList).toHaveBeenCalledWith(1);
+    expect(deleteImageFromStorage).toHaveBeenCalledWith('file:///1.jpg');
+    expect(getImages).toHaveBeenCalledWith('image-4', contextValue);
+    expect(updateImageList).toHaveBeenCalledWith([
+      expect.objectContaining({ pictureId: 'img-5', listId: 5 }),
+    ]);
+  });
+});

--- a/__tests__/SwipeableCard.test.js
+++ b/__tests__/SwipeableCard.test.js
@@ -10,8 +10,6 @@ jest.mock('../components/Picture/Descriptions/GuessDescription', () => {
 });
 
 jest.mock('react-native', () => {
-  const actual = jest.requireActual('react-native');
-
   class MockAnimatedValue {
     constructor(value) {
       this._value = value;
@@ -37,7 +35,12 @@ jest.mock('react-native', () => {
   }
 
   return {
-    ...actual,
+    View: 'View',
+    ImageBackground: 'ImageBackground',
+    StyleSheet: {
+      absoluteFill: {},
+      create: (styles) => styles,
+    },
     PanResponder: {
       create: jest.fn((config) => {
         capturedPanResponder = config;
@@ -45,7 +48,6 @@ jest.mock('react-native', () => {
       }),
     },
     Animated: {
-      ...actual.Animated,
       Value: MockAnimatedValue,
       spring: jest.fn((value, config) => buildAnimation(value, config)),
       timing: jest.fn((value, config) => buildAnimation(value, config)),
@@ -55,8 +57,8 @@ jest.mock('react-native', () => {
           callback?.();
         },
       })),
-      View: actual.View,
-      Image: actual.Image,
+      View: 'AnimatedView',
+      Image: 'AnimatedImage',
     },
   };
 });
@@ -78,25 +80,31 @@ describe('SwipeableCard', () => {
     capturedPanResponder = undefined;
   });
 
-  function renderCard(overrides = {}) {
-    return create(
-      <SwipeableCard
-        item={item}
-        removeCard={jest.fn()}
-        swipedDirection={jest.fn()}
-        screenWidth={320}
-        screenHeight={300}
-        onSwipe={jest.fn()}
-        {...overrides}
-      />
-    );
+  async function renderCard(overrides = {}) {
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <SwipeableCard
+          item={item}
+          removeCard={jest.fn()}
+          swipedDirection={jest.fn()}
+          screenWidth={320}
+          screenHeight={300}
+          onSwipe={jest.fn()}
+          {...overrides}
+        />
+      );
+    });
+
+    return renderer;
   }
 
   it('does not trigger a card action for a swipe below the release thresholds', async () => {
     const removeCard = jest.fn();
     const onSwipe = jest.fn();
 
-    renderCard({ removeCard, onSwipe });
+    await renderCard({ removeCard, onSwipe });
 
     await act(async () => {
       capturedPanResponder.onPanResponderRelease(null, { dx: 40, dy: 20 });
@@ -112,7 +120,7 @@ describe('SwipeableCard', () => {
   it('calls onSwipe when the card is released past the right swipe threshold', async () => {
     const onSwipe = jest.fn();
 
-    renderCard({ onSwipe });
+    await renderCard({ onSwipe });
 
     await act(async () => {
       capturedPanResponder.onPanResponderMove(null, { dx: 180, dy: 0, moveX: 240, x0: 0 });
@@ -125,7 +133,7 @@ describe('SwipeableCard', () => {
   it('calls removeCard when the card is released past the left swipe threshold', async () => {
     const removeCard = jest.fn();
 
-    renderCard({ removeCard });
+    await renderCard({ removeCard });
 
     await act(async () => {
       capturedPanResponder.onPanResponderMove(null, { dx: -181, dy: 0, moveX: 0, x0: 240 });
@@ -136,7 +144,7 @@ describe('SwipeableCard', () => {
   });
 
   it('toggles the full description when the card is swiped vertically far enough', async () => {
-    renderCard();
+    await renderCard();
 
     await act(async () => {
       capturedPanResponder.onPanResponderRelease(null, { dx: 0, dy: -150 });

--- a/__tests__/SwipeableCard.test.js
+++ b/__tests__/SwipeableCard.test.js
@@ -1,0 +1,149 @@
+const mockGuessDescription = jest.fn(() => null);
+
+let capturedPanResponder;
+
+jest.mock('../components/Picture/Descriptions/GuessDescription', () => {
+  return function MockGuessDescription(props) {
+    mockGuessDescription(props);
+    return null;
+  };
+});
+
+jest.mock('react-native', () => {
+  const actual = jest.requireActual('react-native');
+
+  class MockAnimatedValue {
+    constructor(value) {
+      this._value = value;
+    }
+
+    setValue = (nextValue) => {
+      this._value = nextValue;
+    };
+
+    interpolate = () => 'interpolated';
+  }
+
+  function buildAnimation(value, config) {
+    return {
+      start: (callback) => {
+        if (typeof config?.toValue !== 'undefined' && value?.setValue) {
+          value.setValue(config.toValue);
+        }
+
+        callback?.();
+      },
+    };
+  }
+
+  return {
+    ...actual,
+    PanResponder: {
+      create: jest.fn((config) => {
+        capturedPanResponder = config;
+        return { panHandlers: {} };
+      }),
+    },
+    Animated: {
+      ...actual.Animated,
+      Value: MockAnimatedValue,
+      spring: jest.fn((value, config) => buildAnimation(value, config)),
+      timing: jest.fn((value, config) => buildAnimation(value, config)),
+      parallel: jest.fn((animations) => ({
+        start: (callback) => {
+          animations.forEach((animation) => animation.start?.());
+          callback?.();
+        },
+      })),
+      View: actual.View,
+      Image: actual.Image,
+    },
+  };
+});
+
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import SwipeableCard from '../components/UI/SwipeableCard';
+
+describe('SwipeableCard', () => {
+  const item = {
+    listId: 7,
+    imageFile: 'file:///waldo.jpg',
+    description: 'Find Waldo behind the tree.',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedPanResponder = undefined;
+  });
+
+  function renderCard(overrides = {}) {
+    return create(
+      <SwipeableCard
+        item={item}
+        removeCard={jest.fn()}
+        swipedDirection={jest.fn()}
+        screenWidth={320}
+        screenHeight={300}
+        onSwipe={jest.fn()}
+        {...overrides}
+      />
+    );
+  }
+
+  it('does not trigger a card action for a swipe below the release thresholds', async () => {
+    const removeCard = jest.fn();
+    const onSwipe = jest.fn();
+
+    renderCard({ removeCard, onSwipe });
+
+    await act(async () => {
+      capturedPanResponder.onPanResponderRelease(null, { dx: 40, dy: 20 });
+    });
+
+    expect(removeCard).not.toHaveBeenCalled();
+    expect(onSwipe).not.toHaveBeenCalled();
+    expect(mockGuessDescription.mock.calls[mockGuessDescription.mock.calls.length - 1][0]).toEqual(
+      expect.objectContaining({ showFullDescription: false })
+    );
+  });
+
+  it('calls onSwipe when the card is released past the right swipe threshold', async () => {
+    const onSwipe = jest.fn();
+
+    renderCard({ onSwipe });
+
+    await act(async () => {
+      capturedPanResponder.onPanResponderMove(null, { dx: 180, dy: 0, moveX: 240, x0: 0 });
+      capturedPanResponder.onPanResponderRelease(null, { dx: 180, dy: 0 });
+    });
+
+    expect(onSwipe).toHaveBeenCalledWith({ item });
+  });
+
+  it('calls removeCard when the card is released past the left swipe threshold', async () => {
+    const removeCard = jest.fn();
+
+    renderCard({ removeCard });
+
+    await act(async () => {
+      capturedPanResponder.onPanResponderMove(null, { dx: -181, dy: 0, moveX: 0, x0: 240 });
+      capturedPanResponder.onPanResponderRelease(null, { dx: -181, dy: 0 });
+    });
+
+    expect(removeCard).toHaveBeenCalledWith(item.listId);
+  });
+
+  it('toggles the full description when the card is swiped vertically far enough', async () => {
+    renderCard();
+
+    await act(async () => {
+      capturedPanResponder.onPanResponderRelease(null, { dx: 0, dy: -150 });
+    });
+
+    expect(mockGuessDescription.mock.calls[mockGuessDescription.mock.calls.length - 1][0]).toEqual(
+      expect.objectContaining({ showFullDescription: true })
+    );
+  });
+});

--- a/__tests__/adHandling.test.js
+++ b/__tests__/adHandling.test.js
@@ -1,0 +1,57 @@
+const setRequestConfiguration = jest.fn();
+const initialize = jest.fn();
+const requestInfoUpdate = jest.fn();
+const loadAndShowConsentFormIfRequired = jest.fn();
+
+jest.mock('react-native-google-mobile-ads', () => {
+  const mobileAds = jest.fn(() => ({
+    setRequestConfiguration,
+    initialize,
+  }));
+
+  return {
+    __esModule: true,
+    default: mobileAds,
+    MaxAdContentRating: {
+      PG: 'pg',
+    },
+    AdsConsent: {
+      requestInfoUpdate,
+      loadAndShowConsentFormIfRequired,
+    },
+    AdsConsentStatus: {},
+    AdsConsentDebugGeography: {
+      EEA: 'EEA',
+    },
+  };
+});
+
+import { getUserConsent } from '../utils/adHandling';
+
+describe('getUserConsent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setRequestConfiguration.mockResolvedValue(undefined);
+    initialize.mockResolvedValue({ adapterStatuses: 'ready' });
+    requestInfoUpdate.mockResolvedValue({});
+    loadAndShowConsentFormIfRequired.mockResolvedValue({ status: 'OBTAINED' });
+  });
+
+  it('configures ads, requests consent info, and returns the consent status', async () => {
+    const consent = await getUserConsent();
+
+    expect(setRequestConfiguration).toHaveBeenCalledWith({
+      maxAdContentRating: 'pg',
+      tagForChildDirectedTreatment: true,
+      tagForUnderAgeOfConsent: true,
+      testDeviceIdentifiers: ['EMULATOR'],
+    });
+    expect(initialize).toHaveBeenCalledTimes(1);
+    expect(requestInfoUpdate).toHaveBeenCalledWith({
+      debugGeography: 'EEA',
+      testDeviceIdentifiers: ['TEST-DEVICE-HASHED-ID'],
+    });
+    expect(loadAndShowConsentFormIfRequired).toHaveBeenCalledTimes(1);
+    expect(consent).toEqual({ status: 'OBTAINED' });
+  });
+});

--- a/__tests__/adHandling.test.js
+++ b/__tests__/adHandling.test.js
@@ -1,23 +1,9 @@
-const setRequestConfiguration = jest.fn();
-const initialize = jest.fn();
-const requestInfoUpdate = jest.fn();
-const loadAndShowConsentFormIfRequired = jest.fn();
-
 jest.mock('react-native-google-mobile-ads', () => {
-  const mobileAds = jest.fn(() => ({
-    setRequestConfiguration,
-    initialize,
-  }));
-
   return {
     __esModule: true,
-    default: mobileAds,
+    default: jest.fn(),
     MaxAdContentRating: {
       PG: 'pg',
-    },
-    AdsConsent: {
-      requestInfoUpdate,
-      loadAndShowConsentFormIfRequired,
     },
     AdsConsentStatus: {},
     AdsConsentDebugGeography: {
@@ -29,29 +15,40 @@ jest.mock('react-native-google-mobile-ads', () => {
 import { getUserConsent } from '../utils/adHandling';
 
 describe('getUserConsent', () => {
+  const mockSetRequestConfiguration = jest.fn();
+  const mockInitialize = jest.fn();
+  const mockAdsClient = jest.fn(() => ({
+    setRequestConfiguration: mockSetRequestConfiguration,
+    initialize: mockInitialize,
+  }));
+  const mockConsentApi = {
+    requestInfoUpdate: jest.fn(),
+    loadAndShowConsentFormIfRequired: jest.fn(),
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
-    setRequestConfiguration.mockResolvedValue(undefined);
-    initialize.mockResolvedValue({ adapterStatuses: 'ready' });
-    requestInfoUpdate.mockResolvedValue({});
-    loadAndShowConsentFormIfRequired.mockResolvedValue({ status: 'OBTAINED' });
+    mockSetRequestConfiguration.mockResolvedValue(undefined);
+    mockInitialize.mockResolvedValue({ adapterStatuses: 'ready' });
+    mockConsentApi.requestInfoUpdate.mockResolvedValue({});
+    mockConsentApi.loadAndShowConsentFormIfRequired.mockResolvedValue({ status: 'OBTAINED' });
   });
 
   it('configures ads, requests consent info, and returns the consent status', async () => {
-    const consent = await getUserConsent();
+    const consent = await getUserConsent({ adsClient: mockAdsClient, consentApi: mockConsentApi });
 
-    expect(setRequestConfiguration).toHaveBeenCalledWith({
+    expect(mockSetRequestConfiguration).toHaveBeenCalledWith({
       maxAdContentRating: 'pg',
       tagForChildDirectedTreatment: true,
       tagForUnderAgeOfConsent: true,
       testDeviceIdentifiers: ['EMULATOR'],
     });
-    expect(initialize).toHaveBeenCalledTimes(1);
-    expect(requestInfoUpdate).toHaveBeenCalledWith({
+    expect(mockInitialize).toHaveBeenCalledTimes(1);
+    expect(mockConsentApi.requestInfoUpdate).toHaveBeenCalledWith({
       debugGeography: 'EEA',
       testDeviceIdentifiers: ['TEST-DEVICE-HASHED-ID'],
     });
-    expect(loadAndShowConsentFormIfRequired).toHaveBeenCalledTimes(1);
+    expect(mockConsentApi.loadAndShowConsentFormIfRequired).toHaveBeenCalledTimes(1);
     expect(consent).toEqual({ status: 'OBTAINED' });
   });
 });

--- a/__tests__/auth-context.test.js
+++ b/__tests__/auth-context.test.js
@@ -1,0 +1,207 @@
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('../utils/storageDatum', () => ({
+  emptyImageList: jest.fn().mockResolvedValue(undefined),
+}));
+
+import React, { useContext, useEffect } from 'react';
+import { act, create } from 'react-test-renderer';
+import * as SecureStore from 'expo-secure-store';
+
+import AuthContextProvider, { AuthContext } from '../store/auth-context';
+import { emptyImageList } from '../utils/storageDatum';
+
+function AuthContextProbe({ onValue }) {
+  const value = useContext(AuthContext);
+
+  useEffect(() => {
+    onValue(value);
+  }, [onValue, value]);
+
+  return null;
+}
+
+describe('AuthContextProvider', () => {
+  let latestContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    latestContext = undefined;
+    SecureStore.getItemAsync.mockResolvedValue(null);
+    SecureStore.setItemAsync.mockResolvedValue(undefined);
+    SecureStore.deleteItemAsync.mockResolvedValue(undefined);
+  });
+
+  async function renderProvider() {
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <AuthContextProvider>
+          <AuthContextProbe onValue={(value) => {
+            latestContext = value;
+          }} />
+        </AuthContextProvider>
+      );
+    });
+
+    return renderer;
+  }
+
+  it('authenticates, persists the session, and marks tutorial progress from the backend flag', async () => {
+    await renderProvider();
+
+    await act(async () => {
+      await latestContext.authenticate({
+        token: 'Bearer token-123',
+        client: 'mobile-client',
+        expiry: '12345',
+        access_token: 'access-token',
+        uid: 'waldo@example.com',
+        userId: 'user-1',
+        email: 'waldo@example.com',
+        username: 'waldo',
+        scoreId: 'score-9',
+        isTutorialFinished: true,
+      });
+    });
+
+    expect(emptyImageList).toHaveBeenCalledTimes(1);
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('token', 'Bearer token-123');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('client', 'mobile-client');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('expiry', '12345');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('access_token', 'access-token');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('uid', 'waldo@example.com');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('userId', 'user-1');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('email', 'waldo@example.com');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('username', 'waldo');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('scoreId', 'score-9');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+      'isTutorialFinished',
+      JSON.stringify({ isTutorial: false, guessPathDone: true, hidePathDone: true })
+    );
+    expect(latestContext.IsAuthenticated).toBe(true);
+    expect(latestContext.token).toBe('Bearer token-123');
+    expect(latestContext.headers).toEqual({
+      token: 'Bearer token-123',
+      client: 'mobile-client',
+      expiry: '12345',
+      access_token: 'access-token',
+      userId: 'user-1',
+      uid: 'waldo@example.com',
+      email: 'waldo@example.com',
+    });
+    expect(latestContext.isTutorialFinished).toEqual({
+      isTutorial: false,
+      guessPathDone: true,
+      hidePathDone: true,
+    });
+  });
+
+  it('restores a persisted session payload without overwriting missing fields with undefined', async () => {
+    await renderProvider();
+
+    await act(async () => {
+      latestContext.restoreSession({
+        token: 'Bearer restored-token',
+        client: 'restored-client',
+        expiry: '999',
+        access_token: 'restored-access',
+        uid: 'restored@example.com',
+        userId: 'user-2',
+        email: 'restored@example.com',
+        username: 'restored-user',
+        scoreId: 'score-2',
+        isTutorialFinished: { isTutorial: true, guessPathDone: false, hidePathDone: false },
+      });
+    });
+
+    expect(latestContext.IsAuthenticated).toBe(true);
+    expect(latestContext.username).toBe('restored-user');
+    expect(latestContext.scoreId).toBe('score-2');
+    expect(latestContext.isTutorialFinished).toEqual({
+      isTutorial: true,
+      guessPathDone: false,
+      hidePathDone: false,
+    });
+  });
+
+  it('supports verifying and updating the current session state through public helpers', async () => {
+    await renderProvider();
+
+    SecureStore.getItemAsync.mockResolvedValueOnce('Bearer stored-token');
+    let isLoggedIn;
+
+    await act(async () => {
+      isLoggedIn = await latestContext.verifyIsLoggedIn();
+      await latestContext.saveScoreId('score-10');
+      await latestContext.changeUserEmail('new@example.com');
+      await latestContext.changeUsername('new-user');
+      await latestContext.turnTutorialOn(true);
+      await latestContext.updateTutorialStatus({ isTutorial: false, guessPathDone: true, hidePathDone: false });
+    });
+
+    expect(isLoggedIn).toBe(true);
+    expect(latestContext.scoreId).toBe('score-10');
+    expect(latestContext.email).toBe('new@example.com');
+    expect(latestContext.uid).toBe('new@example.com');
+    expect(latestContext.username).toBe('new-user');
+    expect(latestContext.isTutorialFinished).toEqual({
+      isTutorial: false,
+      guessPathDone: true,
+      hidePathDone: false,
+    });
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('scoreId', 'score-10');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('email', 'new@example.com');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('username', 'new-user');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+      'isTutorialFinished',
+      JSON.stringify({ isTutorial: false, guessPathDone: true, hidePathDone: false })
+    );
+  });
+
+  it('logs out by clearing in-memory state, persisted credentials, and cached images', async () => {
+    await renderProvider();
+
+    await act(async () => {
+      await latestContext.authenticate({
+        token: 'Bearer token-123',
+        client: 'mobile-client',
+        expiry: '12345',
+        access_token: 'access-token',
+        uid: 'waldo@example.com',
+        userId: 'user-1',
+        email: 'waldo@example.com',
+        username: 'waldo',
+        scoreId: 'score-9',
+        isTutorialFinished: false,
+      });
+    });
+
+    emptyImageList.mockClear();
+
+    await act(async () => {
+      await latestContext.logout();
+    });
+
+    expect(latestContext.IsAuthenticated).toBe(false);
+    expect(latestContext.token).toBe(null);
+    expect(latestContext.headers).toEqual({});
+    expect(latestContext.isTutorialFinished).toEqual({});
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('token');
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('client');
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('expiry');
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('access_token');
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('uid');
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('userId');
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('email');
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('username');
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('isTutorialFinished');
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('scoreId');
+    expect(emptyImageList).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -2,13 +2,28 @@ jest.mock('expo-secure-store', () => ({
   getItemAsync: jest.fn(),
 }));
 
+jest.mock('axios', () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+}));
+
+import axios from 'axios';
 import * as SecureStore from 'expo-secure-store';
 
 import {
   bootstrapStoredAuthSession,
   checkSecureStoreItem,
+  createUser,
+  deleteAccount,
   getBackendHeaders,
+  getScoreId,
   getStoredAuthState,
+  hasCompleteAuthState,
+  isPersistedBearerToken,
+  login,
+  updateUser,
 } from '../utils/auth';
 
 const storedSession = {
@@ -35,6 +50,37 @@ function mockStoredValues(values = {}) {
 describe('auth utilities', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.EXPO_PUBLIC_APP_BACKEND_URL = 'https://backend.example/';
+  });
+
+  it('detects whether auth state is complete enough to build backend headers', () => {
+    expect(
+      hasCompleteAuthState({
+        token: 'Bearer token',
+        uid: 'user@example.com',
+        expiry: '123',
+        access_token: 'access',
+        client: 'client',
+        userId: '42',
+      })
+    ).toBe(true);
+
+    expect(
+      hasCompleteAuthState({
+        token: 'Bearer token',
+        uid: 'user@example.com',
+        expiry: '',
+        access_token: 'access',
+        client: 'client',
+        userId: '42',
+      })
+    ).toBe(false);
+  });
+
+  it('only treats persisted bearer tokens with the expected prefix and shape as valid', () => {
+    expect(isPersistedBearerToken('Bearer persisted-token._+/=')).toBe(true);
+    expect(isPersistedBearerToken('persisted-token')).toBe(false);
+    expect(isPersistedBearerToken(null)).toBe(false);
   });
 
   it('falls back to context when SecureStore does not have the requested item', async () => {
@@ -68,6 +114,27 @@ describe('auth utilities', () => {
       client: storedSession.client,
       userId: storedSession.userId,
     });
+  });
+
+  it('keeps fully populated context headers instead of re-reading SecureStore', async () => {
+    const headers = await getBackendHeaders({
+      token: 'Bearer in-memory-token',
+      uid: 'memory@example.com',
+      expiry: '321',
+      access_token: 'memory-access',
+      client: 'memory-client',
+      userId: '55',
+    });
+
+    expect(headers).toEqual({
+      token: 'Bearer in-memory-token',
+      uid: 'memory@example.com',
+      expiry: '321',
+      access_token: 'memory-access',
+      client: 'memory-client',
+      userId: '55',
+    });
+    expect(SecureStore.getItemAsync).not.toHaveBeenCalled();
   });
 
   it('parses the persisted tutorial state during session reads', async () => {
@@ -118,5 +185,126 @@ describe('auth utilities', () => {
 
     expect(didRestoreSession).toBe(false);
     expect(restoreSession).not.toHaveBeenCalled();
+  });
+
+  it('logs in against the backend auth endpoint and returns the raw response on success', async () => {
+    const response = {
+      status: 200,
+      headers: { authorization: 'Bearer new-token' },
+      data: { data: { id: '7' } },
+    };
+    axios.post.mockResolvedValue(response);
+
+    const loginResponse = await login({ email: 'waldo@example.com', password: 'secret' });
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://backend.example/auth/sign_in',
+      { email: 'waldo@example.com', password: 'secret' },
+      {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        uid: 'waldo@example.com',
+      }
+    );
+    expect(loginResponse).toBe(response);
+  });
+
+  it('maps createUser success payload into auth token metadata', async () => {
+    axios.post.mockResolvedValue({
+      status: 200,
+      headers: {
+        authorization: 'Bearer signup-token',
+        expiry: '999',
+        'access-token': 'signup-access',
+      },
+      data: { data: { id: '12' } },
+    });
+
+    const response = await createUser({
+      email: 'new@example.com',
+      password: 'hunter2',
+      confirmPassword: 'hunter2',
+      username: 'new-user',
+    });
+
+    expect(response).toMatchObject({
+      status: 200,
+      token: 'Bearer signup-token',
+      expiry: '999',
+      access_token: 'signup-access',
+    });
+  });
+
+  it('loads the current score id with backend headers from context', async () => {
+    axios.get.mockResolvedValue({
+      status: 200,
+      data: { score_id: 'score-42' },
+    });
+
+    const response = await getScoreId({
+      token: 'Bearer token',
+      uid: 'waldo@example.com',
+      expiry: '123',
+      access_token: 'access',
+      client: 'client',
+      userId: '42',
+    });
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://backend.example/api/v1/users/42/get_score_id',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token',
+          uid: 'waldo@example.com',
+        }),
+      })
+    );
+    expect(response).toEqual({ status: 200, data: { score_id: 'score-42' } });
+  });
+
+  it('maps updateUser failures into a status and error payload', async () => {
+    axios.put.mockRejectedValue({
+      request: { status: 500 },
+      message: 'Request failed',
+    });
+
+    const response = await updateUser({
+      context: {
+        token: 'Bearer token',
+        uid: 'waldo@example.com',
+        expiry: '123',
+        access_token: 'access',
+        client: 'client',
+      },
+      data: { email: 'new@example.com' },
+    });
+
+    expect(response).toEqual({
+      status: 500,
+      data: expect.objectContaining({ message: 'Request failed' }),
+    });
+  });
+
+  it('maps deleteAccount failures without throwing when the request metadata exists', async () => {
+    axios.delete.mockRejectedValue({
+      request: { status: 401 },
+      message: 'Unauthorized',
+    });
+
+    const response = await deleteAccount({
+      context: {
+        token: 'Bearer token',
+        uid: 'waldo@example.com',
+        expiry: '123',
+        access_token: 'access',
+        client: 'client',
+        userId: '42',
+      },
+    });
+
+    expect(response).toEqual({
+      status: 401,
+      data: expect.objectContaining({ message: 'Unauthorized' }),
+    });
   });
 });

--- a/__tests__/fileUploader.test.js
+++ b/__tests__/fileUploader.test.js
@@ -1,0 +1,168 @@
+jest.mock('expo-file-system', () => ({
+  deleteAsync: jest.fn(),
+}));
+
+jest.mock('../utils/imageInfos', () => ({
+  handleContentLength: jest.fn(),
+}));
+
+jest.mock('../utils/imagesRequests', () => ({
+  getUploadUrl: jest.fn(),
+  saveImageInfos: jest.fn(),
+  saveImageToAws: jest.fn(),
+}));
+
+jest.mock('../utils/auth', () => ({
+  checkSecureStoreItem: jest.fn(),
+}));
+
+import * as FileSystem from 'expo-file-system';
+
+import { imageUploader } from '../utils/fileUploader';
+import { checkSecureStoreItem } from '../utils/auth';
+import { handleContentLength } from '../utils/imageInfos';
+import { getUploadUrl, saveImageInfos, saveImageToAws } from '../utils/imagesRequests';
+
+describe('imageUploader', () => {
+  const context = {
+    token: 'token',
+    uid: 'waldo@example.com',
+    expiry: '123',
+    access_token: 'access-token',
+    client: 'client-id',
+  };
+  const imageInfos = {
+    uri: 'file:///waldo.png',
+    fileExtension: 'png',
+    imageHeight: 768,
+    imageWidth: 1024,
+    screenHeight: 640,
+    screenWidth: 320,
+    description: 'Near the bridge',
+    isPortrait: true,
+    xLocation: 0.4,
+    yLocation: 0.6,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handleContentLength.mockResolvedValue(4096);
+    checkSecureStoreItem.mockResolvedValue('user-42');
+  });
+
+  it('returns the presign failure without attempting the upload pipeline', async () => {
+    getUploadUrl.mockResolvedValue({
+      status: 500,
+      title: 'Internal server error',
+      message: 'Presign failed',
+    });
+
+    const result = await imageUploader({ imageInfos, context });
+
+    expect(result).toEqual({
+      status: 500,
+      title: 'Internal server error',
+      message: 'Presign failed',
+    });
+    expect(saveImageToAws).not.toHaveBeenCalled();
+    expect(saveImageInfos).not.toHaveBeenCalled();
+    expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
+  });
+
+  it('returns the AWS upload failure and skips metadata persistence', async () => {
+    getUploadUrl.mockResolvedValue({
+      status: 200,
+      data: {
+        url: 'https://example.com/upload',
+        filename: 'waldo-image',
+      },
+    });
+    saveImageToAws.mockResolvedValue({
+      status: 422,
+      title: 'Something went wrong, please try again later',
+      message: 'Upload failed',
+    });
+
+    const result = await imageUploader({ imageInfos, context });
+
+    expect(saveImageToAws).toHaveBeenCalledWith({
+      url: 'https://example.com/upload',
+      filename: 'waldo-image',
+      uri: 'file:///waldo.png',
+      fileExtension: 'png',
+      contentLength: 4096,
+      userId: 'user-42',
+    });
+    expect(result).toEqual({
+      status: 422,
+      title: 'Something went wrong, please try again later',
+      message: 'Upload failed',
+    });
+    expect(saveImageInfos).not.toHaveBeenCalled();
+    expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
+  });
+
+  it('persists the uploaded metadata and deletes the local file after a successful upload', async () => {
+    getUploadUrl.mockResolvedValue({
+      status: 200,
+      data: {
+        url: 'https://example.com/upload',
+        filename: 'waldo-image',
+      },
+    });
+    saveImageToAws.mockResolvedValue({ status: 200 });
+    saveImageInfos.mockResolvedValue({ status: 200 });
+
+    const result = await imageUploader({ imageInfos, context });
+
+    expect(saveImageInfos).toHaveBeenCalledWith({
+      userId: 'user-42',
+      imagesInfos: {
+        user_id: 'user-42',
+        name: 'waldo-image',
+        file_extension: 'png',
+        image_height: 768,
+        image_width: 1024,
+        screen_height: 640,
+        screen_width: 320,
+        description: 'Near the bridge',
+        is_portrait: true,
+        x_location: 0.4,
+        y_location: 0.6,
+        storage_url: '',
+      },
+      token: 'token',
+      uid: 'waldo@example.com',
+      expiry: '123',
+      access_token: 'access-token',
+      client: 'client-id',
+    });
+    expect(FileSystem.deleteAsync).toHaveBeenCalledWith('file:///waldo.png');
+    expect(result).toEqual({ status: 200 });
+  });
+
+  it('returns the metadata persistence failure and keeps the local file intact', async () => {
+    getUploadUrl.mockResolvedValue({
+      status: 200,
+      data: {
+        url: 'https://example.com/upload',
+        filename: 'waldo-image',
+      },
+    });
+    saveImageToAws.mockResolvedValue({ status: 200 });
+    saveImageInfos.mockResolvedValue({
+      status: 409,
+      title: 'Something went wrong, please try again later',
+      message: 'Metadata save failed',
+    });
+
+    const result = await imageUploader({ imageInfos, context });
+
+    expect(result).toEqual({
+      status: 409,
+      title: 'Something went wrong, please try again later',
+      message: 'Metadata save failed',
+    });
+    expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/fileUploader.test.js
+++ b/__tests__/fileUploader.test.js
@@ -88,7 +88,7 @@ describe('imageUploader', () => {
     expect(saveImageToAws).toHaveBeenCalledWith({
       url: 'https://example.com/upload',
       filename: 'waldo-image',
-      uri: 'file:///waldo.png',
+      fileUrl: 'file:///waldo.png',
       fileExtension: 'png',
       contentLength: 4096,
       userId: 'user-42',

--- a/__tests__/frontend-smoke.test.js
+++ b/__tests__/frontend-smoke.test.js
@@ -1,0 +1,74 @@
+import { INSTRUCTIONS } from '../constants/instructions';
+import { RANKING } from '../constants/ranking';
+import { GlobalStyle } from '../constants/theme';
+import Image from '../models/image';
+
+describe('frontend smoke invariants', () => {
+  it('keeps the tutorial instructions map complete for every guided screen', () => {
+    expect(INSTRUCTIONS.Tutorial).toEqual(
+      expect.objectContaining({
+        HomeScreen: expect.any(String),
+        HomeScreenModalBtn: expect.objectContaining({
+          hide: expect.any(String),
+          guess: expect.any(String),
+          finish: expect.any(String),
+        }),
+        HidingPathScreen: expect.any(String),
+        HideScreen: expect.any(String),
+        SetInstructionScreen: expect.any(String),
+        GuessPathScreen: expect.any(String),
+        GuessScreen: expect.any(String),
+        ShowSuccess: expect.any(String),
+        ShowFailure: expect.any(String),
+      })
+    );
+  });
+
+  it('keeps ranking headers and theme tokens available to the UI', () => {
+    expect(RANKING.tableHeaders).toEqual([
+      'Rank',
+      'Name',
+      'Score',
+      'Guess Score',
+      'Guess Count',
+      'Hide Score',
+      'Hide Count',
+    ]);
+    expect(GlobalStyle.color).toEqual(
+      expect.objectContaining({
+        primaryColor500: expect.any(String),
+        secondaryColor: expect.any(String),
+        tertiaryColor: expect.any(String),
+        error500: expect.any(String),
+      })
+    );
+  });
+
+  it('builds image models with the expected public field shape', () => {
+    expect(
+      new Image(
+        'file:///waldo.jpg',
+        'image-1',
+        'Find the goose',
+        1200,
+        800,
+        true,
+        { x: 0.4, y: 0.6 },
+        640,
+        320,
+        9
+      )
+    ).toEqual({
+      imageFile: 'file:///waldo.jpg',
+      pictureId: 'image-1',
+      description: 'Find the goose',
+      imageHeight: 1200,
+      imageWidth: 800,
+      isPortrait: true,
+      touchLocation: { x: 0.4, y: 0.6 },
+      screenHeight: 640,
+      screenWidth: 320,
+      listId: 9,
+    });
+  });
+});

--- a/__tests__/imageDimensions.test.js
+++ b/__tests__/imageDimensions.test.js
@@ -1,0 +1,54 @@
+import { setImageDimensions } from '../utils/imageDimensions';
+
+describe('imageDimensions utilities', () => {
+  it('keeps small portrait images at their intrinsic height while preserving aspect ratio', () => {
+    expect(
+      setImageDimensions({
+        imageHeight: 400,
+        imageWidth: 200,
+        screenHeight: 800,
+        screenWidth: 300,
+        isPortrait: true,
+      })
+    ).toEqual({ maxImageHeight: 400, maxImageWidth: 200 });
+  });
+
+  it('scales large portrait images down to fit the screen width when needed', () => {
+    expect(
+      setImageDimensions({
+        imageHeight: 1600,
+        imageWidth: 900,
+        screenHeight: 800,
+        screenWidth: 400,
+        isPortrait: true,
+      })
+    ).toEqual({
+      maxImageHeight: expect.closeTo(711.1111111111),
+      maxImageWidth: 400,
+    });
+  });
+
+  it('keeps small landscape images bounded by the available height', () => {
+    expect(
+      setImageDimensions({
+        imageHeight: 200,
+        imageWidth: 500,
+        screenHeight: 600,
+        screenWidth: 300,
+        isPortrait: false,
+      })
+    ).toEqual({ maxImageHeight: 200, maxImageWidth: 500 });
+  });
+
+  it('scales large landscape images to remain within the rotated viewport', () => {
+    expect(
+      setImageDimensions({
+        imageHeight: 1200,
+        imageWidth: 2000,
+        screenHeight: 700,
+        screenWidth: 400,
+        isPortrait: false,
+      })
+    ).toEqual({ maxImageHeight: 240, maxImageWidth: 400 });
+  });
+});

--- a/__tests__/imagesRequests.test.js
+++ b/__tests__/imagesRequests.test.js
@@ -1,0 +1,112 @@
+jest.mock('axios', () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+}));
+
+jest.mock('../utils/auth', () => ({
+  getBackendHeaders: jest.fn(),
+  setHeaders: jest.fn(),
+}));
+
+jest.mock('../utils/storageDatum', () => ({
+  saveLastImageUuid: jest.fn(),
+}));
+
+jest.mock('expo-file-system', () => ({
+  cacheDirectory: 'file:///cache/',
+}));
+
+import axios from 'axios';
+
+import { getBackendHeaders, setHeaders } from '../utils/auth';
+import { getImages, getUploadUrl, saveImageInfos } from '../utils/imagesRequests';
+
+describe('imagesRequests utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.EXPO_PUBLIC_APP_BACKEND_URL = 'https://backend.example/';
+    getBackendHeaders.mockResolvedValue({
+      token: 'Bearer token',
+      uid: 'waldo@example.com',
+      expiry: '123',
+      access_token: 'access',
+      client: 'client',
+      userId: '42',
+    });
+    setHeaders.mockReturnValue({ Authorization: 'Bearer token' });
+  });
+
+  it('returns the upload URL payload and derived error title for the current auth state', async () => {
+    axios.get.mockResolvedValue({
+      status: 200,
+      message: 'ok',
+      data: { secure_url: 'https://aws.example/upload' },
+    });
+
+    const response = await getUploadUrl({ token: 'Bearer token' });
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://backend.example/api/v1/aws_requests/get_secure_upload_url',
+      { headers: { Authorization: 'Bearer token' } }
+    );
+    expect(response).toEqual({
+      status: 200,
+      title: 'Something went wrong, please try again later',
+      message: 'ok',
+      data: { secure_url: 'https://aws.example/upload' },
+    });
+  });
+
+  it('returns an auth error when image batch loading is rejected with 401', async () => {
+    axios.get.mockRejectedValueOnce({ request: { status: 401 } });
+
+    const response = await getImages(null, { token: 'Bearer token' });
+
+    expect(response).toEqual({
+      isError: true,
+      title: 'There is an authentication error.',
+      message: 'Please reconnect',
+    });
+  });
+
+  it('returns an empty list without trying to download files when the backend batch is empty', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        data: [],
+      },
+    });
+
+    const response = await getImages(null, { token: 'Bearer token' });
+
+    expect(response).toEqual({ isError: false, images: [] });
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('posts image metadata with backend headers and maps request failures', async () => {
+    axios.post.mockRejectedValueOnce({
+      request: { status: 500 },
+      message: 'Metadata failed',
+    });
+
+    const response = await saveImageInfos({
+      userId: '42',
+      imagesInfos: { name: 'img-1' },
+      token: 'Bearer token',
+      uid: 'waldo@example.com',
+      expiry: '123',
+      access_token: 'access',
+      client: 'client',
+    });
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://backend.example/api/v1/users/42/images',
+      { image: { name: 'img-1' } },
+      { headers: { Authorization: 'Bearer token' } }
+    );
+    expect(response).toEqual({
+      status: 500,
+      title: 'Internal server error, please wait and try again',
+      message: 'Metadata failed',
+    });
+  });
+});

--- a/__tests__/scoreRequests.test.js
+++ b/__tests__/scoreRequests.test.js
@@ -1,0 +1,88 @@
+jest.mock('axios', () => ({
+  get: jest.fn(),
+  put: jest.fn(),
+}));
+
+jest.mock('../utils/auth', () => ({
+  getBackendHeaders: jest.fn(),
+  setHeaders: jest.fn(),
+}));
+
+import axios from 'axios';
+
+import { getBackendHeaders, setHeaders } from '../utils/auth';
+import { getRankingData, getUserScores, updateUserScore } from '../utils/scoreRequests';
+
+describe('scoreRequests utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.EXPO_PUBLIC_APP_BACKEND_URL = 'https://backend.example/';
+    getBackendHeaders.mockResolvedValue({
+      token: 'Bearer token',
+      uid: 'waldo@example.com',
+      expiry: '123',
+      access_token: 'access',
+      client: 'client',
+      userId: '42',
+      scoreId: 'score-1',
+    });
+    setHeaders.mockReturnValue({ Authorization: 'Bearer token' });
+  });
+
+  it('updates the current user score with the expected payload', async () => {
+    axios.put.mockResolvedValue({ status: 200, data: { ok: true } });
+
+    const response = await updateUserScore({
+      score: 1,
+      pictureId: 'image-1',
+      context: { token: 'Bearer token' },
+    });
+
+    expect(axios.put).toHaveBeenCalledWith(
+      'https://backend.example/api/v1/users/42/scores/score-1',
+      {
+        score: {
+          score: 1,
+          image_name: 'image-1',
+        },
+      },
+      { headers: { Authorization: 'Bearer token' } }
+    );
+    expect(response).toEqual({ status: 200, message: { status: 200, data: { ok: true } } });
+  });
+
+  it('loads ranking data with query params for leaderboard mode changes', async () => {
+    axios.get.mockResolvedValue({
+      status: 200,
+      data: { ranking: [] },
+    });
+
+    const response = await getRankingData(
+      { token: 'Bearer token' },
+      { scope: 'global', top: 10, window: 'weekly', page: 2 }
+    );
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://backend.example/api/v1/users/42/scores',
+      {
+        headers: { Authorization: 'Bearer token' },
+        params: { scope: 'global', top: 10, window: 'weekly', page: 2 },
+      }
+    );
+    expect(response).toEqual({ status: 200, data: { ranking: [] } });
+  });
+
+  it('maps getUserScores failures into a status and message without throwing', async () => {
+    axios.get.mockRejectedValue({
+      request: { status: 401 },
+      message: 'Unauthorized',
+    });
+
+    const response = await getUserScores({
+      username: 'waldo',
+      context: { token: 'Bearer token' },
+    });
+
+    expect(response).toEqual({ status: 401, message: 'Unauthorized' });
+  });
+});

--- a/__tests__/storageDatum.test.js
+++ b/__tests__/storageDatum.test.js
@@ -1,0 +1,101 @@
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('expo-file-system', () => ({
+  cacheDirectory: 'file:///cache/',
+  deleteAsync: jest.fn(),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as FileSystem from 'expo-file-system';
+
+import {
+  deleteImageFromStorage,
+  emptyImageList,
+  getLastImageId,
+  getLastImageUuid,
+  getLocalImages,
+  removeImageFromList,
+  saveLastImageUuid,
+  storeImageList,
+  updateImageList,
+} from '../utils/storageDatum';
+
+describe('storageDatum utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AsyncStorage.setItem.mockResolvedValue(undefined);
+    AsyncStorage.removeItem.mockResolvedValue(undefined);
+    FileSystem.deleteAsync.mockResolvedValue(undefined);
+  });
+
+  it('reads the local image list and returns null when none is stored', async () => {
+    AsyncStorage.getItem.mockResolvedValueOnce(null);
+    expect(await getLocalImages()).toBeNull();
+
+    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([{ listId: 1 }]));
+    expect(await getLocalImages()).toEqual([{ listId: 1 }]);
+  });
+
+  it('derives the highest stored image id and falls back to zero for an empty list', async () => {
+    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([
+      { listId: 1 },
+      { listId: 9 },
+      { listId: 4 },
+    ]));
+
+    expect(await getLastImageId()).toBe(9);
+
+    AsyncStorage.getItem.mockResolvedValueOnce('[]');
+    expect(await getLastImageId()).toBe(0);
+  });
+
+  it('stores and reads the last downloaded image uuid', async () => {
+    await saveLastImageUuid('uuid-1');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('lastImageUuid', 'uuid-1');
+
+    AsyncStorage.getItem.mockResolvedValueOnce('uuid-1');
+    expect(await getLastImageUuid()).toBe('uuid-1');
+  });
+
+  it('empties the stored image list, clears cache files, and removes tracking keys', async () => {
+    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([
+      { imageFile: 'file:///cache/a.jpg' },
+      { imageFile: 'file:///cache/b.jpg' },
+    ]));
+
+    await emptyImageList();
+
+    expect(FileSystem.deleteAsync).toHaveBeenCalledWith('file:///cache/a.jpg', { idempotent: true });
+    expect(FileSystem.deleteAsync).toHaveBeenCalledWith('file:///cache/b.jpg', { idempotent: true });
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('imageList');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('lastImageUuid');
+  });
+
+  it('appends new images and removes entries by list id', async () => {
+    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([{ listId: 1 }, { listId: 2 }]));
+
+    const updatedList = await updateImageList([{ listId: 3 }]);
+
+    expect(updatedList).toEqual([{ listId: 1 }, { listId: 2 }, { listId: 3 }]);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('imageList', JSON.stringify(updatedList));
+
+    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([{ listId: 1 }, { listId: 2 }, { listId: 3 }]));
+    await removeImageFromList(2);
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('imageList', JSON.stringify([{ listId: 1 }, { listId: 3 }]));
+  });
+
+  it('stores image lists and deletes both the cached file and ImagePicker mirror', async () => {
+    await storeImageList([{ listId: 7 }]);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('imageList', JSON.stringify([{ listId: 7 }]));
+
+    await deleteImageFromStorage('file:///cache/abc.jpg');
+
+    expect(FileSystem.deleteAsync).toHaveBeenCalledWith('file:///cache/abc.jpg', { idempotent: true });
+    expect(FileSystem.deleteAsync).toHaveBeenCalledWith('file:///cache/ImagePicker/abc.jpg', { idempotent: true });
+  });
+});

--- a/__tests__/targetLocation.test.js
+++ b/__tests__/targetLocation.test.js
@@ -1,0 +1,77 @@
+import {
+  determineImageCorners,
+  handlePicturePress,
+  isOnTarget,
+} from '../utils/targetLocation';
+
+describe('targetLocation utilities', () => {
+  it('computes the image top-left corner from centered dimensions', () => {
+    expect(
+      determineImageCorners({
+        maxImageHeight: 300,
+        maxImageWidth: 200,
+        screenWidth: 400,
+        screenHeight: 800,
+      })
+    ).toEqual({
+      topLeft: {
+        x: 100,
+        y: 250,
+      },
+    });
+  });
+
+  it('normalizes touch coordinates and target styles when the user presses inside the image', () => {
+    const response = handlePicturePress({
+      event: { nativeEvent: { locationX: 50, locationY: 25 } },
+      screenHeight: 600,
+      screenWidth: 300,
+      imageDimensionStyle: { width: 100, height: 50 },
+      topLeft: { x: 0, y: 0 },
+    });
+
+    expect(response.location).toEqual({ x: '0.50', y: '0.50' });
+    expect(response.target).toEqual({
+      targetSize: 15,
+      targetStyle: {
+        position: 'absolute',
+        width: 15,
+        height: 15,
+        left: 42.5,
+        top: 17.5,
+      },
+    });
+  });
+
+  it('ignores touches outside of the rendered image bounds', () => {
+    expect(
+      handlePicturePress({
+        event: { nativeEvent: { locationX: 110, locationY: 20 } },
+        screenHeight: 600,
+        screenWidth: 300,
+        imageDimensionStyle: { width: 100, height: 50 },
+        topLeft: { x: 0, y: 0 },
+      })
+    ).toEqual({ location: null, target: null });
+  });
+
+  it('checks whether a guess falls within the target threshold', () => {
+    expect(
+      isOnTarget({
+        location: { x: 0.5, y: 0.5 },
+        hiddenLocation: { x: 0.52, y: 0.5 },
+        screenWidth: 300,
+        screenHeight: 600,
+      })
+    ).toBe(true);
+
+    expect(
+      isOnTarget({
+        location: { x: 0.1, y: 0.1 },
+        hiddenLocation: { x: 0.8, y: 0.8 },
+        screenWidth: 300,
+        screenHeight: 600,
+      })
+    ).toBe(false);
+  });
+});

--- a/__tests__/tutorialHandler.test.js
+++ b/__tests__/tutorialHandler.test.js
@@ -1,0 +1,74 @@
+jest.mock('axios', () => ({
+  get: jest.fn(),
+  put: jest.fn(),
+}));
+
+jest.mock('../utils/auth', () => ({
+  getBackendHeaders: jest.fn(),
+  setHeaders: jest.fn(),
+}));
+
+import axios from 'axios';
+
+import { getBackendHeaders, setHeaders } from '../utils/auth';
+import { getIsTutorialFinished, isTutorialFinished } from '../utils/tutorialHandler';
+
+describe('tutorialHandler utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.EXPO_PUBLIC_APP_BACKEND_URL = 'https://backend.example/';
+    getBackendHeaders.mockResolvedValue({
+      token: 'Bearer token',
+      uid: 'waldo@example.com',
+      expiry: '123',
+      access_token: 'access',
+      client: 'client',
+      userId: '42',
+    });
+    setHeaders.mockReturnValue({ Authorization: 'Bearer token' });
+  });
+
+  it('loads the persisted tutorial flag for the current user', async () => {
+    axios.get.mockResolvedValue({
+      status: 200,
+      data: { is_tutorial_finished: true },
+    });
+
+    const response = await getIsTutorialFinished({ token: 'Bearer token' });
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://backend.example/api/v1/users/42/get_is_tutorial_finished',
+      { headers: { Authorization: 'Bearer token' } }
+    );
+    expect(response).toEqual({
+      status: 200,
+      data: { is_tutorial_finished: true },
+    });
+  });
+
+  it('injects the current user id into tutorial updates before sending them', async () => {
+    axios.put.mockResolvedValue({
+      status: 200,
+      data: { ok: true },
+    });
+
+    const payload = {
+      user: {
+        is_tutorial_finished: true,
+      },
+    };
+
+    const response = await isTutorialFinished({
+      context: { token: 'Bearer token' },
+      data: payload,
+    });
+
+    expect(payload.user.user_id).toBe('42');
+    expect(axios.put).toHaveBeenCalledWith(
+      'https://backend.example/api/v1/users/42/set_is_tutorial_finished',
+      payload,
+      { headers: { Authorization: 'Bearer token' } }
+    );
+    expect(response).toBeUndefined();
+  });
+});

--- a/components/Auth/AuthContent.js
+++ b/components/Auth/AuthContent.js
@@ -82,8 +82,10 @@ const AuthContent = ({ isLogin, onAuthenticate }) => {
         />
         <View style={styles.buttons}>
           <Button
+            accessibilityLabel={isLogin ? 'Switch to signup' : 'Switch to login'}
             onPress={switchAuthModeHandler}
             mode={Platform.OS === "ios" ? "flat" : null}
+            testID={isLogin ? 'auth.button.switch-to-signup' : 'auth.button.switch-to-login'}
             thin={true}
           >
             {isLogin ? 'Create a new user' : 'Log in instead'}

--- a/components/Auth/AuthForm.js
+++ b/components/Auth/AuthForm.js
@@ -52,54 +52,66 @@ const AuthForm = ({ isLogin, onSubmit, credentialsInvalid, height }) => {
     <View>
       <View>
         <Input
+          accessibilityLabel="Email Address"
           label="Email Address"
           onUpdateValue={updateInputValueHandler.bind(this, 'email')}
+          testID="auth.input.email"
           value={enteredEmail}
           keyboardType="email-address"
           isInvalid={emailIsInvalid}
         />
         {!isLogin && (
           <Input
+            accessibilityLabel="Confirm Email Address"
             label="Confirm Email Address"
             onUpdateValue={updateInputValueHandler.bind(this, 'confirmEmail')}
+            testID="auth.input.confirm-email"
             value={enteredConfirmEmail}
             keyboardType="email-address"
             isInvalid={emailsDontMatch}
           />
         )}
         <Input
+          accessibilityLabel="Password"
           label="Password"
           onUpdateValue={updateInputValueHandler.bind(this, 'password')}
           secure
+          testID="auth.input.password"
           value={enteredPassword}
           isInvalid={passwordIsInvalid}
         />
         {!isLogin && (
           <>
             <Input
+              accessibilityLabel="Confirm Password"
               label="Confirm Password"
               onUpdateValue={updateInputValueHandler.bind(
                 this,
                 'confirmPassword'
               )}
               secure
+              testID="auth.input.confirm-password"
               value={enteredConfirmPassword}
               isInvalid={passwordsDontMatch}
             />
             <Input
+              accessibilityLabel="Username"
               label="Username"
               onUpdateValue={updateInputValueHandler.bind(
                 this,
                 'username'
               )}
+              testID="auth.input.username"
               value={enteredUsername}
             />
           </>
         )}
         <View style={{ marginTop: height * 0.02 }}>
           <Button
+            accessibilityLabel={isLogin ? 'Submit Login' : 'Submit Signup'}
             onPress={submitHandler}
             mode={Platform.OS === "ios" ? "flat" : null}
+            testID={isLogin ? 'auth.button.login-submit' : 'auth.button.signup-submit'}
             thin={true}
             >
             {isLogin ? 'Log In' : 'Sign Up'}

--- a/components/Auth/Input.js
+++ b/components/Auth/Input.js
@@ -9,6 +9,8 @@ export default function Input({
   onUpdateValue,
   value,
   isInvalid,
+  testID,
+  accessibilityLabel,
 }) {
   return (
     <View style={styles.inputContainer}>
@@ -16,11 +18,13 @@ export default function Input({
         {label}
       </Text>
       <TextInput
+        accessibilityLabel={accessibilityLabel ?? label}
         style={[styles.input, isInvalid && styles.inputInvalid]}
         autoCapitalize="none"
         keyboardType={keyboardType}
         secureTextEntry={secure}
         onChangeText={onUpdateValue}
+        testID={testID}
         value={value}
       />
     </View>

--- a/components/Instructions/SwipeInstructions.js
+++ b/components/Instructions/SwipeInstructions.js
@@ -24,7 +24,7 @@ export default function SwipeInstructions({ screenWidth, handleFilterClick }) {
           </View>
 
           <View style={styles.marginTop}>
-            <BigButton text="Let's go!" onPress={handleFilterClick} buttonStyle="ranking" />
+            <BigButton accessibilityLabel="Start guessing" testID="guess-path.button.start" text="Let's go!" onPress={handleFilterClick} buttonStyle="ranking" />
           </View>
 
 

--- a/components/Picture/Descriptions/ShowHideDescription.js
+++ b/components/Picture/Descriptions/ShowHideDescription.js
@@ -12,15 +12,17 @@ export default function ShowHideDescription({ inputChangeHandler, submitHandler,
           invalid={false}
           style={styles.input}
           textInputConfig={{
+            accessibilityLabel: "Hidden point description",
             placeholder: "How is your hiding location?",
             placeholderTextColor: "white",
             keyboardType: "default",
             onChangeText: inputChangeHandler,
             maxLength: 800,
-            multiline: true }}/>
+            multiline: true,
+            testID: 'set-instructions.input.description' }}/>
         <View style={styles.buttonContainer}>
-          <Button style={styles.button} thin={true} onPress={submitHandler}>Confirm ?</Button>
-          <Button style={styles.button} thin={true} onPress={onCancel}>Cancel</Button>
+          <Button accessibilityLabel="Confirm hidden point description" style={styles.button} thin={true} onPress={submitHandler} testID="set-instructions.button.confirm-description">Confirm ?</Button>
+          <Button accessibilityLabel="Cancel hidden point description" style={styles.button} thin={true} onPress={onCancel} testID="set-instructions.button.cancel-description">Cancel</Button>
         </View>
       </View>
     </View>

--- a/components/Picture/ShowImagePicker.js
+++ b/components/Picture/ShowImagePicker.js
@@ -18,22 +18,26 @@ export default function ShowImagePicker(
       <View style={[styles.buttonsContainer, {marginTop: image ? 10 : 0,}]}>
         {isTutorial ?
             <BigButton 
+              accessibilityLabel="Take a picture"
+              testID="image-picker.button.take-picture"
               text="Take a Picture" 
               onPress={takePictureHandler}
               />
           : 
             <>
               <BigButton 
+                accessibilityLabel="Take a picture"
+                testID="image-picker.button.take-picture"
                 text="Take a Picture" 
                 onPress={takePictureHandler}
               /> 
-              <BigButton text="Select an Image" onPress={pickImage} />
+              <BigButton accessibilityLabel="Select an image" testID="image-picker.button.select-image" text="Select an Image" onPress={pickImage} />
             </>
         } 
       </View>
       {image && (
         <View style={styles.imageContainer}>
-          <Image source={{uri: image}} style={[styles.image, { width: imageWidth, height: imageHeight }]} />
+          <Image accessibilityLabel="Selected image preview" source={{uri: image}} style={[styles.image, { width: imageWidth, height: imageHeight }]} testID="image-picker.preview" />
         </View>
       )}
       {isTutorial && (

--- a/components/Picture/ShowPicture.js
+++ b/components/Picture/ShowPicture.js
@@ -38,15 +38,17 @@ export default function ShowPicture({ /* hiddenLocation,  showDebugModal, setSho
 
   return (
     <View style={styles.container} >
-      <Pressable onPress={handlePress}  style={styles.pressable} >
+      <Pressable accessibilityLabel={guess ? 'Guess picture surface' : 'Hide picture surface'} onPress={handlePress}  style={styles.pressable} testID={guess ? 'game.picture.guess-surface' : 'game.picture.hide-surface'} >
         <ImageBackground
+          accessibilityLabel={guess ? 'Guess picture image' : 'Hide picture image'}
           source={{uri : uri}}
           resizeMode='stretch'
           style={[styles.image, imageDimensionStyle ]}
+          testID={guess ? 'game.picture.guess-image' : 'game.picture.hide-image'}
           >
 {/* no cross, when guess, if null  */}
           {touchLocation && (
-            <IconButton icon={"close-circle-outline"} color={"white"} size={target.targetSize} onPress={handleIconPress} style={target.targetStyle}/>
+            <IconButton accessibilityLabel="Clear selected point" icon={"close-circle-outline"} color={"white"} size={target.targetSize} onPress={handleIconPress} style={target.targetStyle} testID={guess ? 'game.picture.clear-guess' : 'game.picture.clear-hide'}/>
           )}
 {/* target not showing for guessscreen */}
           { guess ? (
@@ -70,6 +72,7 @@ export default function ShowPicture({ /* hiddenLocation,  showDebugModal, setSho
             onPress={handleConfirm} 
             onCancel={onCancel} 
             isModalVisible={showModal}
+            testIDPrefix={guess ? 'game.picture.guess-modal' : 'game.picture.hide-modal'}
           >
             {"Do you want to validate this ?"}
           </CenteredModal>

--- a/components/UI/BigButton.js
+++ b/components/UI/BigButton.js
@@ -8,10 +8,13 @@ const screenWidth = Dimensions.get('window').width;
 const hideGuessButtonWidth = screenWidth * 0.75;
 const rankingButtonWidth = screenWidth * 0.75;
 
-const BigButton = (({ text, onPress, buttonStyle }) => {
+const BigButton = (({ text, onPress, buttonStyle, testID, accessibilityLabel }) => {
   return (
     <View>
         <Pressable
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole='button'
+        testID={testID}
         style={({ pressed }) =>
           [
             styles.homeButton,

--- a/components/UI/Button.js
+++ b/components/UI/Button.js
@@ -1,7 +1,7 @@
 import { Pressable, Text, StyleSheet, View, Platform } from 'react-native';
 import { GlobalStyle } from '../../constants/theme';
 
-export default function Button({ children, style, onPress, mode, thin, cancel }) {
+export default function Button({ children, style, onPress, mode, thin, cancel, testID, accessibilityLabel }) {
 
 
   return (
@@ -11,7 +11,13 @@ export default function Button({ children, style, onPress, mode, thin, cancel })
       mode === "flat" && { backgroundColor: "transparent" },
       cancel && mode !== "flat" && { backgroundColor: "red" }]}
     >
-      <Pressable onPress={onPress} style={({pressed}) => pressed && styles.pressed} >
+      <Pressable
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole="button"
+        onPress={onPress}
+        style={({pressed}) => pressed && styles.pressed}
+        testID={testID}
+      >
         <View style={[mode === "flat" && styles.flat]}>
           <Text style={[
             styles.buttonText,

--- a/components/UI/CenteredModal.js
+++ b/components/UI/CenteredModal.js
@@ -2,29 +2,33 @@ import { Modal, View, Text,  StyleSheet, Platform } from 'react-native';
 import Button from './Button';
 
 
-export default function CenteredModal({ children, onCancel, onPress , isModalVisible}) {
+export default function CenteredModal({ children, onCancel, onPress , isModalVisible, testIDPrefix = 'modal'}) {
   return (
     <Modal
       visible={isModalVisible}
       animationType="fade"
       transparent={true}
     >
-      <View style={styles.modalContainer}>
-        <View style={styles.modalContent}>
+      <View style={styles.modalContainer} testID={`${testIDPrefix}.backdrop`}>
+        <View accessibilityLabel={`${testIDPrefix} content`} style={styles.modalContent} testID={`${testIDPrefix}.content`}>
 
           <Text style={styles.modalText}>{children}</Text>
 
           <View style={styles.buttonContainer}>
           <View style={styles.space}>
             <Button
+              accessibilityLabel={`${testIDPrefix} confirm`}
               onPress={onPress}
               mode={Platform.OS === "ios" ? "flat" : null}
+              testID={`${testIDPrefix}.confirm`}
               thin={true}>Confirm</Button>
           </View>
           <View style={styles.space}>
             <Button
+              accessibilityLabel={`${testIDPrefix} close`}
               onPress={onCancel}
               mode={Platform.OS === "ios" ? "flat" : null}
+              testID={`${testIDPrefix}.close`}
               thin={true}
               cancel={true}>Close</Button>
           </View>

--- a/components/UI/IconButton.js
+++ b/components/UI/IconButton.js
@@ -1,9 +1,15 @@
 import { Pressable, StyleSheet, View } from "react-native";
 import Ionicons from '@expo/vector-icons/Ionicons';
 
-export default function IconButton({ icon, color, size, onPress, style}) {
+export default function IconButton({ icon, color, size, onPress, style, testID, accessibilityLabel }) {
   return (
-    <Pressable onPress={onPress} style={(pressed) => pressed ? [styles.pressed, style] : [styles.button, style]}>
+    <Pressable
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      onPress={onPress}
+      style={(pressed) => pressed ? [styles.pressed, style] : [styles.button, style]}
+      testID={testID}
+    >
       <View style={styles.iconContainer}>
         <Ionicons name={icon} size={size} color={color} />
       </View>

--- a/components/UI/SwipeImage.js
+++ b/components/UI/SwipeImage.js
@@ -183,7 +183,7 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing })
   }, [imageList]);
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView style={{ flex: 1 }} testID="guess-path.swipe-stack">
       {(imageList === null) || (imageList !== null && imageList?.length === 0 && asyncImagesAreLoading) ? (
         showIsLoading()
       ) : ((noMoreCard === true) && (imageList?.length === 0) && (!asyncImagesAreLoading)) ? (

--- a/components/UI/SwipeableCard.js
+++ b/components/UI/SwipeableCard.js
@@ -211,6 +211,8 @@ export default function SwipeableCard({ item, removeCard, swipedDirection, scree
   return (
     <Animated.View
       {...panResponder.panHandlers}
+      accessibilityLabel={`Swipeable card ${item.listId}`}
+      testID={`guess-path.card.${item.listId}`}
       style={[
         styles.cardStyle,
         styles.expanded,
@@ -224,9 +226,11 @@ export default function SwipeableCard({ item, removeCard, swipedDirection, scree
       ]}>
 
         <ImageBackground
+          accessibilityLabel={`Guess path image ${item.listId}`}
           source={{ uri: item.imageFile}}
           resizeMode='contain'
-          style={[styles.imageStyle, styles.expanded]} >
+          style={[styles.imageStyle, styles.expanded]}
+          testID={`guess-path.card-image.${item.listId}`} >
           
           <GuessDescription
             item={item}

--- a/screens/GuessScreens/AdScreen.js
+++ b/screens/GuessScreens/AdScreen.js
@@ -118,7 +118,7 @@ export default function AdScreen({navigation, route}){
 
 
   return(
-     <View style={{flex: 1}}>
+     <View style={{flex: 1}} testID="ad.screen">
       {__DEV__ ? (
         isLoaded ? (
           show()

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -170,18 +170,24 @@ export default function HomeScreen({ navigation, route }) {
     <>
       <View style={styles.homeContainer}>
         <BigButton
+          accessibilityLabel="Hide Waldo"
           text="Hide Waldo"
           onPress={toHidingPathScreen}
           buttonStyle="big"
+          testID="home.button.hide"
           />
         <BigButton
+          accessibilityLabel="Find Waldo"
           text="Find Waldo"
           onPress={toGuessPathScreen}
           buttonStyle="big" 
+          testID="home.button.guess"
           />
         <BigButton
+          accessibilityLabel="Open Ranking"
           text="Ranking"
-          onPress={toRankingScreen} />
+          onPress={toRankingScreen}
+          testID="home.button.ranking" />
         {
           showModal && 
           <CenteredModal 
@@ -189,6 +195,7 @@ export default function HomeScreen({ navigation, route }) {
             children={"Welcome, do you want to do the tutorial? \n\n It will help you to learn how to play the game in 5 minutes. \n\n Later it is possible to do it again."} 
             onCancel={() => cancelTutorial()} 
             onPress={() => startTutorial()}
+            testIDPrefix="home.tutorial-modal"
             />
         }
         {
@@ -205,11 +212,13 @@ export default function HomeScreen({ navigation, route }) {
 
       </View>
       <IconButton
+        accessibilityLabel="Open tutorial"
         icon={"book"}
         color={"white"}
         size={24}
         style={styles.tutorialButton}
         onPress={() => setIsTutorial(true)}
+        testID="home.button.tutorial"
       />
   </>
     

--- a/screens/RankingScreen.js
+++ b/screens/RankingScreen.js
@@ -171,7 +171,7 @@ export default function RankingScreen() {
   return (
     <>
       {rankingDatum ? (
-        <View>
+        <View testID="ranking.screen">
           <TableComponent data={rankingDatum}  onPress={showSpecificDatum}  />
         </View>
       ) : (

--- a/screens/SetInstructionScreen.js
+++ b/screens/SetInstructionScreen.js
@@ -148,11 +148,13 @@ export default function SetInstructionsScreen({ navigation, route }) {
 
 
   return (
-    <View style={styles.container}>
+    <View style={styles.container} testID="set-instructions.screen">
       <ImageBackground
+        accessibilityLabel="Set instructions image"
         source={{uri : uri}}
         resizeMode='stretch'
         style={imageDimensionStyle}
+        testID="set-instructions.image"
       >
         <HideDescription
           onSubmit={handlePressDescription}
@@ -168,6 +170,7 @@ export default function SetInstructionsScreen({ navigation, route }) {
             onPress={handleConfirmModal} 
             onCancel={onCancelModal} 
             isModalVisible={showModal}
+            testIDPrefix="set-instructions.confirm-modal"
           >
             <ModalContent
               description={description}

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -199,22 +199,26 @@ export default SettingsScreen = () => {
     return (
       <SafeAreaView style={styles.container}>
         <ScrollView contentContainerStyle={styles.scrollContainer}>
-          <View style={styles.boxContainer}>
+          <View style={styles.boxContainer} testID="settings.screen">
             <Text style={styles.title}>Change Email:</Text>
             <TextInput
+              accessibilityLabel="Settings email"
+              testID="settings.input.email"
               value={email}
               onChangeText={setEmail}
               style={styles.textInput}
             />
-            <Button children="Save" onPress={() => handleButtonClick('email')} style={styles.button} />
+            <Button accessibilityLabel="Save email" children="Save" onPress={() => handleButtonClick('email')} style={styles.button} testID="settings.button.save-email" />
   
             <Text style={styles.title}>Change Username:</Text>
             <TextInput
+              accessibilityLabel="Settings username"
+              testID="settings.input.username"
               value={username}
               onChangeText={setUsername}
               style={styles.textInput}
             />
-            <Button children="Save" onPress={() => handleButtonClick('username')} style={styles.button} />
+            <Button accessibilityLabel="Save username" children="Save" onPress={() => handleButtonClick('username')} style={styles.button} testID="settings.button.save-username" />
   
           </View>
   
@@ -222,6 +226,8 @@ export default SettingsScreen = () => {
             
             <Text style={styles.title}>Change Password:</Text>
             <TextInput
+              accessibilityLabel="Current password"
+              testID="settings.input.current-password"
               value={oldPassword}
               onChangeText={setOldPassword}
               placeholder="Enter your current password"
@@ -229,6 +235,8 @@ export default SettingsScreen = () => {
               style={styles.textInput}
             />
             <TextInput
+              accessibilityLabel="New password"
+              testID="settings.input.new-password"
               value={password}
               onChangeText={setPassword}
               placeholder="Enter new password"
@@ -236,6 +244,8 @@ export default SettingsScreen = () => {
               style={styles.textInput}
             />
             <TextInput
+              accessibilityLabel="Confirm new password"
+              testID="settings.input.confirm-password"
               value={confirmPassword}
               onChangeText={setConfirmPassword}
               placeholder="Confirm new password"
@@ -243,24 +253,29 @@ export default SettingsScreen = () => {
               style={styles.textInput}
             />
             <Button 
+              accessibilityLabel="Save password"
               children="Save" 
               onPress={() => handleButtonClick('password')} 
               style={styles.button} 
+              testID="settings.button.save-password"
             />
           </View>
   
           <View style={styles.dangerZoneContainer}>
             <Text style={[styles.title,styles.dangerZoneText]}>Danger Zone:</Text>
             <Button 
+              accessibilityLabel="Delete account"
               children="Delete Account" 
               onPress={() => handleButtonClick('delete')} 
               cancel={true} 
-              style={styles.button} /* add flat */ />
+              style={styles.button}
+              testID="settings.button.delete-account" /* add flat */ />
           </View>
           <CenteredModal 
             isModalVisible={isModalVisible} 
             onPress={handleConfirm} 
             onCancel={handleCancel} 
+            testIDPrefix="settings.confirm-modal"
             children={confirmMessage}
           />
         </ScrollView>

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -77,10 +77,15 @@ export default SettingsScreen = () => {
     const response = await updateUser({ context, data });
     console.log("handleChangeEmail setting response", response?.status);
     console.log("email", response?.data?.email);
-    response?.status === 200
-      && context.changeUserEmail(response?.data?.email) 
-      && Alert.alert('Email changed successfully!', `Your new email is: ${response?.data?.email}`);
-    response?.status !== 200 && Alert.alert(`Error status code: ${response?.status}`, `There is an an error: ${response?.data}.`);
+
+    if (response?.status === 200) {
+      await context.changeUserEmail(response?.data?.email);
+      Alert.alert('Email changed successfully!', `Your new email is: ${response?.data?.email}`);
+      console.log("setting response", response?.status);
+      return;
+    }
+
+    Alert.alert(`Error status code: ${response?.status}`, `There is an an error: ${response?.data}.`);
     console.log("setting response", response?.status);
   };
 
@@ -91,10 +96,14 @@ export default SettingsScreen = () => {
 
     const response = await updateUser({ context, data });
     console.log("handleChangeUsername setting response", response);
-    response?.status === 200
-      && context.changeUsername(username)
-      && Alert.alert('Username changed successfully!', `Your new username is ${response?.data?.username}`);
-    response?.status !== 200 && Alert.alert(`Error status code: ${response?.status}`,`There is an an error: ${response?.data}\n\nYou can retry later or your username is already taken.`);
+
+    if (response?.status === 200) {
+      await context.changeUsername(response?.data?.username ?? username);
+      Alert.alert('Username changed successfully!', `Your new username is ${response?.data?.username}`);
+      return;
+    }
+
+    Alert.alert(`Error status code: ${response?.status}`,`There is an an error: ${response?.data}\n\nYou can retry later or your username is already taken.`);
 
   };
 

--- a/utils/adHandling.js
+++ b/utils/adHandling.js
@@ -9,9 +9,9 @@ Error: Publisher misconfiguration: Failed to read publisher's account configurat
 
 */
 
-async function adConfig() {
+async function adConfig(adsClient = mobileAds) {
 
-  const config = await mobileAds()
+  const config = await adsClient()
     .setRequestConfiguration({
       // Update all future requests suitable for parental guidance
       maxAdContentRating: MaxAdContentRating.PG,
@@ -28,7 +28,7 @@ async function adConfig() {
     })
     .then(() => {
       console.log("Request config successfully set!");
-      const adapterStatusesResult = mobileAds()
+      const adapterStatusesResult = adsClient()
       .initialize()
       .then(adapterStatuses => {
         console.log("Initialization complete!");
@@ -48,8 +48,8 @@ export async function loadAds() {
   __DEV__ && !isLoaded ? load() : null;
 };
 
-export async function getUserConsent() {
-  const config = await adConfig();
+export async function getUserConsent({ adsClient = mobileAds, consentApi = AdsConsent } = {}) {
+  const config = await adConfig(adsClient);
   console.log("config", config);
 
   /*
@@ -59,12 +59,12 @@ export async function getUserConsent() {
   const iosId = await syncUniqueId();
    */
 
-  const consentInfo = await AdsConsent.requestInfoUpdate({
+  const consentInfo = await consentApi.requestInfoUpdate({
     debugGeography: AdsConsentDebugGeography.EEA,
     testDeviceIdentifiers: ['TEST-DEVICE-HASHED-ID'],
   });
 
-  const { status } = await AdsConsent.loadAndShowConsentFormIfRequired();
+  const { status } = await consentApi.loadAndShowConsentFormIfRequired();
   /* put it in context */
 
   return { status };


### PR DESCRIPTION
This pull request introduces an initial Maestro E2E (end-to-end) test scaffold for the app, adds comprehensive test coverage for key screens, and improves testability and accessibility in the UI. The main themes are: (1) adding Maestro E2E flows and documentation, (2) expanding and improving unit test coverage with better component mocking, and (3) enhancing UI accessibility and test selectors.

**Maestro E2E Test Scaffold and Documentation**

* Added `.maestro/README.md` documenting the Maestro test scaffold, current blockers, and recommendations for reliable execution.
* Added `.maestro/auth-boot-login.yml` and `.maestro/hide-to-guess-to-result.yml` flows, covering login and main gameplay journeys using stable selectors. [[1]](diffhunk://#diff-b9eee91f17c684448ada113524f555e1dc4a3b7f8c7b1107e5972409fd54bc1bR1-R45) [[2]](diffhunk://#diff-4535f039d4b59d558485aeaebb8452c8ab94f6dcd20d4cc3e2a2a99b7ae3ba93R1-R66)
* Added `.maestro/e2e.env.example.yaml` with sample environment variables for test credentials and descriptions.

**Unit Test Coverage and Component Mocking**

* Added new test suites for `AdScreen`, `GuessScreen`, and expanded `App.test.js` and `HomeScreen.test.js` to cover navigation, header actions, and session validation. These tests use explicit component mocks for better isolation and assertion. [[1]](diffhunk://#diff-586280d54f8a43a16426e30df552db6b9597e5b4e0d89dfe1f35948139eac99bR1-R79) [[2]](diffhunk://#diff-993940aeab70aa4f215e9071ddd39c9fc839727234dbd957fc34daa32f3444abR1-R88) [[3]](diffhunk://#diff-ab4c5274f7c148ce3d5bb2087250258da609f195f0100dff58b79532a5fc58b1R1-R192) [[4]](diffhunk://#diff-935440b4f6ddd1341b8ff876a28ed358298bedf3b2052e116f31c1a2bc284af5R1-R5)
* Refactored component mocks in `HomeScreen.test.js` to use function mocks for `BigButton`, `CenteredModal`, `TutorialOverlay`, and `IconButton`, allowing for detailed prop assertions.

**UI Accessibility and Test Selectors**

* Added `accessibilityLabel` and `testID` props to the `IconButton` components for settings and logout in the authenticated stack header, improving accessibility and enabling reliable test selection.

**Test Utility Improvements**

* Added utility functions in tests (e.g., `renderScreen`, `getBigButtonProps` in `HomeScreen.test.js`) to streamline rendering and prop inspection for component-based assertions.

These changes lay the groundwork for automated E2E testing, improve reliability and maintainability of unit tests, and enhance the app’s accessibility and testability.