### PR TITLE
Fix/e2e signup

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -9,7 +9,7 @@ This directory contains login-first Maestro flows for the deterministic app runt
 - `guess-login-saved-picture-success.yml`: logs in, opens the guess path, reuses the saved hide payload, and verifies the success result.
 - `guess-login-saved-picture-failure.yml`: logs in, opens the guess path, reuses the saved hide payload, long-presses the guess surface to select the E2E wrong point, and verifies the failure result.
 - `hide-to-guess-to-result.yml`: full deterministic login -> hide -> guess -> ranking journey using the saved hide payload bridge.
-- `auth-boot-signup.yml`: legacy signup smoke flow retained for manual use only; it is not part of the recommended coverage because it creates backend rows every run.
+- `auth-boot-signup.yml`: signup smoke flow that generates unique credentials at runtime so it can be rerun without email or username collisions.
 - `e2e.env.example.yaml`: sample Maestro flow variables only.
 
 ## Runtime Requirement

--- a/.maestro/auth-boot-signup.yml
+++ b/.maestro/auth-boot-signup.yml
@@ -1,7 +1,7 @@
 appId: com.alegarn.WoIstWaldoProject
 ---
-# Smoke: boot on a clean app state, verify the auth selectors, and create a fresh
-# account that lands on the home screen.
+# Smoke: boot on a clean app state, generate unique signup credentials, and
+# verify the account can be created without colliding with existing rows.
 
 - launchApp:
     appId: com.alegarn.WoIstWaldoProject
@@ -55,21 +55,22 @@ appId: com.alegarn.WoIstWaldoProject
     id: auth.input.confirm-password
 - assertVisible:
     id: auth.input.username
+- runScript: scripts/generate-signup-credentials.js
 - tapOn:
     id: auth.input.email
-- inputText: ${SIGNUP_EMAIL}
+- inputText: ${output.signup.email}
 - tapOn:
     id: auth.input.confirm-email
-- inputText: ${SIGNUP_EMAIL}
+- inputText: ${output.signup.email}
 - tapOn:
     id: auth.input.password
-- inputText: ${SIGNUP_PASSWORD}
+- inputText: ${output.signup.password}
 - tapOn:
     id: auth.input.confirm-password
-- inputText: ${SIGNUP_PASSWORD}
+- inputText: ${output.signup.password}
 - tapOn:
     id: auth.input.username
-- inputText: ${SIGNUP_USERNAME}
+- inputText: ${output.signup.username}
 - hideKeyboard
 - tapOn:
     id: auth.button.signup-submit


### PR DESCRIPTION
This pull request updates the Maestro end-to-end signup flow to ensure each test run uses unique credentials, preventing collisions with existing accounts. The main changes involve modifying the `.maestro/auth-boot-signup.yml` flow to generate and use dynamic credentials at runtime, and updating documentation to reflect this improvement.

**Signup Flow Improvements:**

* [`.maestro/auth-boot-signup.yml`](diffhunk://#diff-68c9f28e9120bb2acd8259832f75dcb8f3aab88705753b567407e2e9479c02a1R58-R73): Added a step to run the `scripts/generate-signup-credentials.js` script, which creates unique signup credentials for each test run. Updated all input fields to use the dynamically generated values from `${output.signup}` instead of static environment variables. This ensures the signup test can be rerun without email or username collisions.

**Documentation Updates:**

* [`.maestro/README.md`](diffhunk://#diff-bac010a359d10f3ad99107f1772028c0d9271afc953a1f2b6a1b2630f666107bL12-R12): Revised the description of the `auth-boot-signup.yml` flow to clarify that it now generates unique credentials at runtime and can be rerun without colliding with existing backend rows.
* [`.maestro/auth-boot-signup.yml`](diffhunk://#diff-68c9f28e9120bb2acd8259832f75dcb8f3aab88705753b567407e2e9479c02a1L3-R4): Updated comments to reflect the new approach of generating unique credentials and avoiding collisions with existing accounts.