### PR TITLE
Fix/private group UI

### DIFF
--- a/__tests__/CreateGroupScreen.test.js
+++ b/__tests__/CreateGroupScreen.test.js
@@ -145,4 +145,27 @@ describe('CreateGroupScreen store entry point (TIER-0)', () => {
       scope: { kind: 'private', groupId: 'g-owned' },
     });
   });
+
+  it('shows the already-owns message without the unlock CTA even when the user is not Premium+', async () => {
+    const setActive = jest.fn().mockResolvedValue(undefined);
+    useGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-owned' }], joined: [] },
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    jest.requireMock('../hooks/useActiveGroup').useActiveGroup.mockReturnValue({
+      setActive,
+      clear: jest.fn(),
+      scope: { kind: 'public' },
+      activeGroupId: null,
+    });
+
+    const { renderer } = await renderScreen({ premiumTier: 0 });
+
+    expect(renderer.root.findByProps({ testID: 'create-group.message.already-owns' })).toBeTruthy();
+    expect(renderer.root.findByProps({ testID: 'create-group.message.already-owns' }).props.children).toBe('You can only create 1 group.');
+
+    expect(getBigButtonProps('create-group.button.unlock')).toBeFalsy();
+  });
 });

--- a/__tests__/CreateGroupScreen.test.js
+++ b/__tests__/CreateGroupScreen.test.js
@@ -68,6 +68,7 @@ import { act, create } from 'react-test-renderer';
 
 import CreateGroupScreen from '../screens/Groups/CreateGroupScreen';
 import { AuthContext } from '../store/auth-context';
+import { useGroupsHub } from '../hooks/useGroupsHub';
 
 describe('CreateGroupScreen store entry point (TIER-0)', () => {
   beforeEach(() => {
@@ -110,5 +111,38 @@ describe('CreateGroupScreen store entry point (TIER-0)', () => {
     });
 
     expect(navigation.replace).toHaveBeenCalledWith('PaywallScreen', { intent: 'create-group' });
+  });
+
+  it('shows the already-owns message and not the unlock CTA when a Premium+ user owns a group', async () => {
+    const setActive = jest.fn().mockResolvedValue(undefined);
+    useGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-owned' }], joined: [] },
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    jest.requireMock('../hooks/useActiveGroup').useActiveGroup.mockReturnValue({
+      setActive,
+      clear: jest.fn(),
+      scope: { kind: 'public' },
+      activeGroupId: null,
+    });
+
+    const { renderer, navigation } = await renderScreen({ premiumTier: 2 });
+
+    expect(renderer.root.findByProps({ testID: 'create-group.message.already-owns' })).toBeTruthy();
+
+    expect(getBigButtonProps('create-group.button.unlock')).toBeFalsy();
+
+    const goToGroupProps = renderer.root.findByProps({ testID: 'create-group.button.go-to-group' }).props;
+    await act(async () => {
+      await goToGroupProps.onPress();
+      await Promise.resolve();
+    });
+
+    expect(setActive).toHaveBeenCalledWith('g-owned');
+    expect(navigation.replace).toHaveBeenCalledWith('PrivateHomeScreen', {
+      scope: { kind: 'private', groupId: 'g-owned' },
+    });
   });
 });

--- a/__tests__/hooks/useActiveGroup.test.js
+++ b/__tests__/hooks/useActiveGroup.test.js
@@ -59,7 +59,7 @@ describe('useActiveGroup — scope derivation', () => {
     expect(result.current.scope).toEqual({ kind: 'private', groupId: 'group-123' });
   });
 
-  it('reverts to {kind:"public"} after clear()', async () => {
+  it('reverts to {kind:"public"} after clear() while retaining activeGroupId', async () => {
     setActiveGroup.mockResolvedValue({
       status: 200,
       data: { active_group_id: 'group-123' },
@@ -79,6 +79,8 @@ describe('useActiveGroup — scope derivation', () => {
       await result.current.clear();
     });
 
+    expect(setActiveGroup).toHaveBeenCalledTimes(1);
     expect(result.current.scope).toEqual({ kind: 'public' });
+    expect(result.current.activeGroupId).toBe('group-123');
   });
 });

--- a/__tests__/screens/CreateGroupScreen.test.js
+++ b/__tests__/screens/CreateGroupScreen.test.js
@@ -211,4 +211,24 @@ describe('CreateGroupScreen', () => {
       scope: { kind: 'private', groupId: 'g-owned' },
     });
   });
+
+  it('shows the already-owns message without the unlock CTA even when the user is not Premium+', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-owned' }], joined: [], pendingInvites: [] },
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    mockUseActiveGroup.mockReturnValue({ setActive: jest.fn().mockResolvedValue(undefined) });
+
+    const navigation = { replace: jest.fn(), navigate: jest.fn() };
+    const { renderer } = await renderScreen({ authContext: { premiumTier: 0 }, navigation });
+
+    expect(renderer.root.findByProps({ testID: 'create-group.message.already-owns' })).toBeTruthy();
+    expect(renderer.root.findByProps({ testID: 'create-group.message.already-owns' }).props.children).toBe('You can only create 1 group.');
+
+    expect(() =>
+      renderer.root.findByProps({ testID: 'create-group.button.unlock' })
+    ).toThrow();
+  });
 });

--- a/__tests__/screens/CreateGroupScreen.test.js
+++ b/__tests__/screens/CreateGroupScreen.test.js
@@ -1,8 +1,16 @@
 const mockButton = jest.fn(() => null);
+const mockBigButton = jest.fn(() => null);
 const mockCenteredModal = jest.fn(() => null);
 const mockLoadingOverlay = jest.fn(() => null);
 const mockUseGroupsHub = jest.fn();
 const mockUseActiveGroup = jest.fn();
+
+jest.mock('../../components/UI/BigButton', () => {
+  return function MockBigButton(props) {
+    mockBigButton(props);
+    return null;
+  };
+});
 
 jest.mock('../../components/UI/Button', () => {
   return function MockButton(props) {
@@ -169,5 +177,38 @@ describe('CreateGroupScreen', () => {
     expect(Alert.alert).toHaveBeenCalled();
 
     expect(renderer.root.findByProps({ testID: 'create-group.button.submit' })).toBeTruthy();
+  });
+
+  it('shows the already-owns message without the unlock CTA when a Premium+ user owns a group', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-owned' }], joined: [], pendingInvites: [] },
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const setActive = jest.fn().mockResolvedValue(undefined);
+    mockUseActiveGroup.mockReturnValue({ setActive });
+
+    const navigation = { replace: jest.fn(), navigate: jest.fn() };
+    const { renderer } = await renderScreen({ authContext: { premiumTier: 2 }, navigation });
+
+    expect(renderer.root.findByProps({ testID: 'create-group.message.already-owns' })).toBeTruthy();
+
+    expect(() =>
+      renderer.root.findByProps({ testID: 'create-group.button.unlock' })
+    ).toThrow();
+
+    const goToGroupProps = renderer.root.findByProps({ testID: 'create-group.button.go-to-group' }).props;
+    expect(goToGroupProps).toBeTruthy();
+
+    await act(async () => {
+      await goToGroupProps.onPress();
+      await Promise.resolve();
+    });
+
+    expect(setActive).toHaveBeenCalledWith('g-owned');
+    expect(navigation.replace).toHaveBeenCalledWith('PrivateHomeScreen', {
+      scope: { kind: 'private', groupId: 'g-owned' },
+    });
   });
 });

--- a/__tests__/screens/HomeHeaderRight.test.js
+++ b/__tests__/screens/HomeHeaderRight.test.js
@@ -119,4 +119,51 @@ describe('HomeHeaderRight', () => {
     expect(Alert.alert).toHaveBeenCalled();
     expect(navigation.navigate).not.toHaveBeenCalled();
   });
+
+  it('keeps the toggle enabled when the user has a membership but no active group', () => {
+    const { renderer } = renderHeader({
+      activeGroup: {
+        scope: { kind: 'public' },
+        activeGroupId: null,
+        setActive: jest.fn(),
+        clear: jest.fn(),
+      },
+      groupsHubData: {
+        owned: [],
+        joined: [{ id: 'g-2', role: 'member' }],
+      },
+    });
+
+    openMenu(renderer);
+
+    const toggle = getToggle(renderer);
+    expect(toggle.props.disabled).toBe(false);
+  });
+
+  it('navigates to GroupsListScreen when toggling from public to private without an active group', async () => {
+    const setActive = jest.fn();
+    const { renderer, navigation } = renderHeader({
+      activeGroup: {
+        scope: { kind: 'public' },
+        activeGroupId: null,
+        setActive,
+        clear: jest.fn(),
+      },
+      groupsHubData: {
+        owned: [],
+        joined: [{ id: 'g-2', role: 'member' }],
+      },
+    });
+
+    openMenu(renderer);
+
+    await act(async () => {
+      await getToggle(renderer).props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(setActive).not.toHaveBeenCalled();
+    expect(navigation.navigate).toHaveBeenCalledWith('GroupsListScreen');
+    expect(navigation.navigate).not.toHaveBeenCalledWith('PrivateHomeScreen', expect.anything());
+  });
 });

--- a/__tests__/screens/PrivateHomeScreen.test.js
+++ b/__tests__/screens/PrivateHomeScreen.test.js
@@ -1,5 +1,6 @@
 const mockHomeCard = jest.fn(() => null);
 const mockBigButton = jest.fn(() => null);
+const mockIconButton = jest.fn(() => null);
 const mockUseActiveGroup = jest.fn();
 const mockUseGroupsHub = jest.fn();
 
@@ -28,6 +29,13 @@ jest.mock('../../components/UI/BigButton', () => {
   };
 });
 
+jest.mock('../../components/UI/IconButton', () => {
+  return function MockIconButton(props) {
+    mockIconButton(props);
+    return null;
+  };
+});
+
 jest.mock('../../hooks/useActiveGroup', () => ({
   useActiveGroup: () => mockUseActiveGroup(),
 }));
@@ -38,6 +46,7 @@ jest.mock('../../hooks/useGroupsHub', () => ({
 
 import React from 'react';
 import { act, create } from 'react-test-renderer';
+import { Share, Alert } from 'react-native';
 
 import PrivateHomeScreen from '../../screens/Groups/PrivateHomeScreen';
 import { handleOrientation } from '../../utils/orientation';
@@ -45,28 +54,40 @@ import { handleOrientation } from '../../utils/orientation';
 describe('PrivateHomeScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
   });
 
-  async function renderScreen({ scope = { kind: 'private', groupId: 'g-7' }, clear = jest.fn(), groupsData = { owned: [], joined: [] } } = {}) {
-    mockUseActiveGroup.mockReturnValue({ scope, clear });
+  async function renderScreen({
+    scope = { kind: 'private', groupId: 'g-7' },
+    groupsData = { owned: [], joined: [] },
+  } = {}) {
+    mockUseActiveGroup.mockReturnValue({ scope });
     mockUseGroupsHub.mockReturnValue({ data: groupsData, refresh: jest.fn() });
+
+    const navigation = { navigate: jest.fn(), setOptions: jest.fn() };
 
     let renderer;
     await act(async () => {
       renderer = create(
         <PrivateHomeScreen
-          navigation={{ navigate: jest.fn(), setOptions: jest.fn() }}
+          navigation={navigation}
           route={{ params: { scope } }}
         />
       );
       await Promise.resolve();
     });
 
-    return renderer;
+    return { renderer, navigation };
   }
 
-  it('renders the active group name in private-home.title and shows the back-to-public button', async () => {
-    const renderer = await renderScreen({
+  function lastSetOptions(navigation) {
+    const calls = navigation.setOptions.mock.calls;
+    return calls[calls.length - 1][0];
+  }
+
+  it('renders the active group name in private-home.title and forces portrait orientation', async () => {
+    const { renderer } = await renderScreen({
       scope: { kind: 'private', groupId: 'g-7' },
       groupsData: {
         owned: [{ id: 'g-7', name: 'Waldos Of The World', role: 'owner' }],
@@ -76,40 +97,97 @@ describe('PrivateHomeScreen', () => {
 
     const titleNode = renderer.root.findByProps({ testID: 'private-home.title' });
     expect(titleNode.props.children).toBe('Waldos Of The World');
-    expect(renderer.root.findByProps({ testID: 'private-home.button.back-to-public' })).toBeTruthy();
     expect(handleOrientation).toHaveBeenCalledWith('portrait');
   });
 
-  it('clears the active scope and routes back to HomeScreen when the back-to-public button is pressed', async () => {
-    const navigation = { navigate: jest.fn(), setOptions: jest.fn() };
-    const clear = jest.fn().mockResolvedValue(undefined);
-
-    mockUseActiveGroup.mockReturnValue({
-      scope: { kind: 'private', groupId: 'g-7' },
-      clear,
-    });
-    mockUseGroupsHub.mockReturnValue({
-      data: { owned: [{ id: 'g-7', name: 'Waldos', role: 'owner' }], joined: [] },
-      refresh: jest.fn(),
+  it('does not render the legacy back-to-public button', async () => {
+    const { renderer } = await renderScreen({
+      groupsData: {
+        owned: [{ id: 'g-7', name: 'Waldos', role: 'owner' }],
+        joined: [],
+      },
     });
 
-    let renderer;
-    await act(async () => {
-      renderer = create(
-        <PrivateHomeScreen
-          navigation={navigation}
-          route={{ params: { scope: { kind: 'private', groupId: 'g-7' } } }}
-        />
+    expect(() => renderer.root.findByProps({ testID: 'private-home.button.back-to-public' })).toThrow();
+  });
+
+  describe('owner', () => {
+    const ownerData = {
+      owned: [{ id: 'g-7', name: 'Waldos', role: 'owner', joining_code: 'WALDO42' }],
+      joined: [],
+    };
+
+    it('exposes the settings gear via headerRight', async () => {
+      const { navigation } = await renderScreen({ groupsData: ownerData });
+
+      const options = lastSetOptions(navigation);
+      expect(options.title).toBe('Waldos');
+      expect(options.headerRight).toBeInstanceOf(Function);
+
+      let headerRoot;
+      await act(async () => {
+        headerRoot = create(options.headerRight());
+      });
+
+      const gear = headerRoot.root.findByProps({ testID: 'private-home.button.settings' });
+      expect(gear.props.accessibilityLabel).toBe('Group settings');
+    });
+
+    it('navigates to GroupSettingsScreen when the gear is pressed', async () => {
+      const { navigation } = await renderScreen({ groupsData: ownerData });
+
+      const options = lastSetOptions(navigation);
+      let headerRoot;
+      await act(async () => {
+        headerRoot = create(options.headerRight());
+      });
+
+      await act(async () => {
+        headerRoot.root.findByProps({ testID: 'private-home.button.settings' }).props.onPress();
+      });
+
+      expect(navigation.navigate).toHaveBeenCalledWith('GroupSettingsScreen');
+    });
+
+    it('renders the share-code button', async () => {
+      const { renderer } = await renderScreen({ groupsData: ownerData });
+
+      const button = renderer.root.findByProps({ testID: 'private-home.button.share-code' });
+      expect(button.props.text).toBe('Share invite code');
+    });
+
+    it('shares the joining code via Share.share when the share-code button is pressed', async () => {
+      const { renderer } = await renderScreen({ groupsData: ownerData });
+
+      await act(async () => {
+        renderer.root.findByProps({ testID: 'private-home.button.share-code' }).props.onPress();
+        await Promise.resolve();
+      });
+
+      expect(Share.share).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('WALDO42') })
       );
-      await Promise.resolve();
+      expect(Alert.alert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('non-owner member', () => {
+    const memberData = {
+      owned: [],
+      joined: [{ id: 'g-7', name: 'Waldos', role: 'member', joining_code: 'WALDO42' }],
+    };
+
+    it('does not expose a settings gear via headerRight', async () => {
+      const { navigation } = await renderScreen({ groupsData: memberData });
+
+      const options = lastSetOptions(navigation);
+      expect(options.headerRight).toBeUndefined();
     });
 
-    await act(async () => {
-      renderer.root.findByProps({ testID: 'private-home.button.back-to-public' }).props.onPress();
-      await Promise.resolve();
-    });
+    it('does not render the share-code button', async () => {
+      const { renderer } = await renderScreen({ groupsData: memberData });
 
-    expect(clear).toHaveBeenCalledTimes(1);
-    expect(navigation.navigate).toHaveBeenCalledWith('HomeScreen');
+      expect(() => renderer.root.findByProps({ testID: 'private-home.button.share-code' })).toThrow();
+    });
   });
 });

--- a/__tests__/screens/PrivateHomeScreen.test.js
+++ b/__tests__/screens/PrivateHomeScreen.test.js
@@ -62,7 +62,7 @@ describe('PrivateHomeScreen', () => {
     scope = { kind: 'private', groupId: 'g-7' },
     groupsData = { owned: [], joined: [] },
   } = {}) {
-    mockUseActiveGroup.mockReturnValue({ scope });
+    mockUseActiveGroup.mockReturnValue({ scope, clear: jest.fn() });
     mockUseGroupsHub.mockReturnValue({ data: groupsData, refresh: jest.fn() });
 
     const navigation = { navigate: jest.fn(), setOptions: jest.fn() };
@@ -84,6 +84,15 @@ describe('PrivateHomeScreen', () => {
   function lastSetOptions(navigation) {
     const calls = navigation.setOptions.mock.calls;
     return calls[calls.length - 1][0];
+  }
+
+  async function renderHeader(navigation) {
+    const options = lastSetOptions(navigation);
+    let headerRoot;
+    await act(async () => {
+      headerRoot = create(options.headerRight());
+    });
+    return headerRoot;
   }
 
   it('renders the active group name in private-home.title and forces portrait orientation', async () => {
@@ -124,10 +133,7 @@ describe('PrivateHomeScreen', () => {
       expect(options.title).toBe('Waldos');
       expect(options.headerRight).toBeInstanceOf(Function);
 
-      let headerRoot;
-      await act(async () => {
-        headerRoot = create(options.headerRight());
-      });
+      const headerRoot = await renderHeader(navigation);
 
       const gear = headerRoot.root.findByProps({ testID: 'private-home.button.settings' });
       expect(gear.props.accessibilityLabel).toBe('Group settings');
@@ -136,11 +142,7 @@ describe('PrivateHomeScreen', () => {
     it('navigates to GroupSettingsScreen when the gear is pressed', async () => {
       const { navigation } = await renderScreen({ groupsData: ownerData });
 
-      const options = lastSetOptions(navigation);
-      let headerRoot;
-      await act(async () => {
-        headerRoot = create(options.headerRight());
-      });
+      const headerRoot = await renderHeader(navigation);
 
       await act(async () => {
         headerRoot.root.findByProps({ testID: 'private-home.button.settings' }).props.onPress();
@@ -149,18 +151,22 @@ describe('PrivateHomeScreen', () => {
       expect(navigation.navigate).toHaveBeenCalledWith('GroupSettingsScreen');
     });
 
-    it('renders the share-code button', async () => {
-      const { renderer } = await renderScreen({ groupsData: ownerData });
+    it('renders the share-code icon in the header', async () => {
+      const { navigation } = await renderScreen({ groupsData: ownerData });
 
-      const button = renderer.root.findByProps({ testID: 'private-home.button.share-code' });
-      expect(button.props.text).toBe('Share invite code');
+      const headerRoot = await renderHeader(navigation);
+
+      const button = headerRoot.root.findByProps({ testID: 'private-home.button.share-code' });
+      expect(button.props.accessibilityLabel).toBe('Share invite code');
     });
 
-    it('shares the joining code via Share.share when the share-code button is pressed', async () => {
-      const { renderer } = await renderScreen({ groupsData: ownerData });
+    it('shares the joining code via Share.share when the share-code icon is pressed', async () => {
+      const { navigation } = await renderScreen({ groupsData: ownerData });
+
+      const headerRoot = await renderHeader(navigation);
 
       await act(async () => {
-        renderer.root.findByProps({ testID: 'private-home.button.share-code' }).props.onPress();
+        headerRoot.root.findByProps({ testID: 'private-home.button.share-code' }).props.onPress();
         await Promise.resolve();
       });
 
@@ -168,6 +174,15 @@ describe('PrivateHomeScreen', () => {
         expect.objectContaining({ message: expect.stringContaining('WALDO42') })
       );
       expect(Alert.alert).not.toHaveBeenCalled();
+    });
+
+    it('renders the switch-to-public icon in the header', async () => {
+      const { navigation } = await renderScreen({ groupsData: ownerData });
+
+      const headerRoot = await renderHeader(navigation);
+
+      const button = headerRoot.root.findByProps({ testID: 'private-home.button.switch-to-public' });
+      expect(button.props.accessibilityLabel).toBe('Switch to public');
     });
   });
 
@@ -177,17 +192,21 @@ describe('PrivateHomeScreen', () => {
       joined: [{ id: 'g-7', name: 'Waldos', role: 'member', joining_code: 'WALDO42' }],
     };
 
-    it('does not expose a settings gear via headerRight', async () => {
+    it('renders the switch-to-public icon but no owner-only icons', async () => {
       const { navigation } = await renderScreen({ groupsData: memberData });
 
       const options = lastSetOptions(navigation);
-      expect(options.headerRight).toBeUndefined();
-    });
+      expect(options.headerRight).toBeInstanceOf(Function);
 
-    it('does not render the share-code button', async () => {
-      const { renderer } = await renderScreen({ groupsData: memberData });
+      const headerRoot = await renderHeader(navigation);
 
-      expect(() => renderer.root.findByProps({ testID: 'private-home.button.share-code' })).toThrow();
+      const switchButton = headerRoot.root.findByProps({
+        testID: 'private-home.button.switch-to-public',
+      });
+      expect(switchButton.props.accessibilityLabel).toBe('Switch to public');
+
+      expect(() => headerRoot.root.findByProps({ testID: 'private-home.button.share-code' })).toThrow();
+      expect(() => headerRoot.root.findByProps({ testID: 'private-home.button.settings' })).toThrow();
     });
   });
 });

--- a/__tests__/useActiveGroup.test.js
+++ b/__tests__/useActiveGroup.test.js
@@ -94,7 +94,7 @@ describe('useActiveGroup', () => {
     };
   }
 
-  it('clear() clears the active group both server-side and locally', async () => {
+  it('clear() flips to public view but retains the active group id', async () => {
     setActiveGroup.mockResolvedValue({
       status: 204,
       data: { active_group_id: null },
@@ -112,13 +112,10 @@ describe('useActiveGroup', () => {
       await getLatestValue().clear();
     });
 
-    expect(setActiveGroup).toHaveBeenCalledWith(
-      { token: 'Bearer token-1', userId: 'user-1' },
-      null
-    );
-    expect(setActiveGroupIdCalls).toEqual([null]);
+    expect(setActiveGroup).not.toHaveBeenCalled();
+    expect(setActiveGroupIdCalls).toEqual([]);
     expect(setPrivateModeCalls).toEqual([false]);
-    expect(getLatestValue().activeGroupId).toBeNull();
+    expect(getLatestValue().activeGroupId).toBe('group-7');
     expect(getLatestValue().scope).toEqual({ kind: 'public' });
   });
 

--- a/hooks/useActiveGroup.js
+++ b/hooks/useActiveGroup.js
@@ -25,10 +25,8 @@ export function useActiveGroup() {
   }, [token, userId, setActiveGroupId, setPrivateMode]);
 
   const clear = useCallback(() => {
-    setActiveGroup({ token, userId }, null).catch(() => {});
-    setActiveGroupId(null);
     return setPrivateMode(false);
-  }, [token, userId, setActiveGroupId, setPrivateMode]);
+  }, [setPrivateMode]);
 
   const scope = useMemo(
     () => (isPrivateMode && activeGroupId)

--- a/screens/Groups/CreateGroupScreen.js
+++ b/screens/Groups/CreateGroupScreen.js
@@ -24,9 +24,38 @@ export default function CreateGroupScreen({ navigation }) {
   const [isConfirmVisible, setIsConfirmVisible] = useState(false);
 
   const owned = data?.owned ?? [];
-  const canCreateGroup = (authContext?.premiumTier ?? 0) >= 2 && owned.length === 0;
+  const isPremiumPlus = (authContext?.premiumTier ?? 0) >= 2;
+  const alreadyOwns = owned.length > 0;
 
-  if (!canCreateGroup) {
+  if (isPremiumPlus && alreadyOwns) {
+    const goToGroup = async () => {
+      const groupId = owned[0]?.id;
+      if (!groupId) return;
+      await setActive(groupId);
+      navigation.replace('PrivateHomeScreen', {
+        scope: { kind: 'private', groupId },
+      });
+    };
+
+    return (
+      <View style={styles.lockedContainer}>
+        <Text
+          style={styles.lockedMessage}
+          testID="create-group.message.already-owns"
+        >
+          You already own a group.
+        </Text>
+        <BigButton
+          text="Go to my group"
+          onPress={goToGroup}
+          testID="create-group.button.go-to-group"
+          accessibilityLabel="Go to my group"
+        />
+      </View>
+    );
+  }
+
+  if (!isPremiumPlus) {
     return (
       <View style={styles.lockedContainer}>
         <Text style={styles.lockedMessage}>

--- a/screens/Groups/CreateGroupScreen.js
+++ b/screens/Groups/CreateGroupScreen.js
@@ -14,7 +14,7 @@ import { createGroup } from '../../services/groups/groupApi';
 
 export default function CreateGroupScreen({ navigation }) {
   const authContext = useContext(AuthContext);
-  const { data } = useGroupsHub();
+  const { data, isLoading } = useGroupsHub();
   const { setActive } = useActiveGroup();
 
   const [name, setName] = useState('');
@@ -27,7 +27,11 @@ export default function CreateGroupScreen({ navigation }) {
   const isPremiumPlus = (authContext?.premiumTier ?? 0) >= 2;
   const alreadyOwns = owned.length > 0;
 
-  if (isPremiumPlus && alreadyOwns) {
+  if (isLoading && !data) {
+    return <LoadingOverlay message="Loading..." />;
+  }
+
+  if (alreadyOwns) {
     const goToGroup = async () => {
       const groupId = owned[0]?.id;
       if (!groupId) return;
@@ -43,7 +47,7 @@ export default function CreateGroupScreen({ navigation }) {
           style={styles.lockedMessage}
           testID="create-group.message.already-owns"
         >
-          You already own a group.
+          You can only create 1 group.
         </Text>
         <BigButton
           text="Go to my group"

--- a/screens/Groups/HomeHeaderRight.js
+++ b/screens/Groups/HomeHeaderRight.js
@@ -15,8 +15,7 @@ export function HomeHeaderRight({ navigation, tintColor, onStartTutorial }) {
   const joined = data?.joined ?? [];
   const isPrivate = scope.kind === 'private';
   const hasAnyMembership = owned.length > 0 || joined.length > 0;
-  const hasActiveGroup = !!activeGroupId;
-  const canToggleScope = isPrivate ? hasAnyMembership : hasAnyMembership && hasActiveGroup;
+  const canToggleScope = hasAnyMembership;
 
   const toggleScope = () => {
     if (isPrivate) {
@@ -25,19 +24,20 @@ export function HomeHeaderRight({ navigation, tintColor, onStartTutorial }) {
       return;
     }
 
-    if (!activeGroupId) {
+    if (activeGroupId) {
+      setActive(activeGroupId).then((response) => {
+        if (response?.status === 200 || response?.status === 204) {
+          navigation.navigate('PrivateHomeScreen', {
+            scope: { kind: 'private', groupId: activeGroupId },
+          });
+        }
+      }).catch((err) => {
+        Alert.alert('Error', err?.message ?? 'Could not switch scope.');
+      });
       return;
     }
 
-    setActive(activeGroupId).then((response) => {
-      if (response?.status === 200 || response?.status === 204) {
-        navigation.navigate('PrivateHomeScreen', {
-          scope: { kind: 'private', groupId: activeGroupId },
-        });
-      }
-    }).catch((err) => {
-      Alert.alert('Error', err?.message ?? 'Could not switch scope.');
-    });
+    navigation.navigate('GroupsListScreen');
   };
 
   const select = (action) => () => {

--- a/screens/Groups/PrivateHomeScreen.js
+++ b/screens/Groups/PrivateHomeScreen.js
@@ -1,14 +1,14 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useContext, useEffect } from 'react';
 import { View, Text, StyleSheet, Share, Alert } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 
 import HomeCard from '../../components/UI/HomeCard';
-import BigButton from '../../components/UI/BigButton';
 import IconButton from '../../components/UI/IconButton';
 import { GlobalStyle } from '../../constants/theme';
 import { handleOrientation } from '../../utils/orientation';
 import { useActiveGroup } from '../../hooks/useActiveGroup';
 import { useGroupsHub } from '../../hooks/useGroupsHub';
+import { AuthContext } from '../../store/auth-context';
 
 const HideImage = require('../../assets/home/WoIstWaldo-character-hide.webp');
 const FindImage = require('../../assets/home/WoIstWaldo-character-guess-4-3.webp');
@@ -16,7 +16,8 @@ const RankingImage = require('../../assets/home/WoIstWaldo-character-stats.webp'
 
 export default function PrivateHomeScreen({ navigation, route }) {
   const routeScope = route?.params?.scope;
-  const { scope } = useActiveGroup();
+  const { scope, clear } = useActiveGroup();
+  const { setPrivateMode } = useContext(AuthContext);
   const activeScope = routeScope ?? scope;
   const { data, refresh } = useGroupsHub();
   const group = activeScope?.kind === 'private'
@@ -25,41 +26,6 @@ export default function PrivateHomeScreen({ navigation, route }) {
   const isLocked = group?.locked === true;
   const isOwner = group?.role === 'owner';
   const groupId = activeScope?.kind === 'private' ? activeScope.groupId : null;
-
-  useEffect(() => {
-    navigation.setOptions({
-      title: group?.name ?? '',
-      headerRight: isOwner
-        ? () => (
-          <IconButton
-            icon="settings-outline"
-            color="#fff"
-            size={26}
-            onPress={() => navigation.navigate('GroupSettingsScreen')}
-            testID="private-home.button.settings"
-            accessibilityLabel="Group settings"
-          />
-        )
-        : undefined,
-    });
-  }, [navigation, group?.name, isOwner]);
-
-  useFocusEffect(
-    useCallback(() => {
-      handleOrientation('portrait');
-    }, [])
-  );
-
-  useFocusEffect(
-    useCallback(() => {
-      refresh();
-    }, [refresh])
-  );
-
-  const goScoped = (target) =>
-    navigation.navigate(target, {
-      scope: { kind: 'private', groupId },
-    });
 
   const shareCode = useCallback(async () => {
     const code = group?.joining_code;
@@ -74,6 +40,72 @@ export default function PrivateHomeScreen({ navigation, route }) {
       Alert.alert('Invite code', message);
     }
   }, [group?.joining_code]);
+
+  useEffect(() => {
+    navigation.setOptions({
+      title: group?.name ?? '',
+      headerRight: () => (
+        <View style={{ flexDirection: 'row' }}>
+          <IconButton
+            icon="home-outline"
+            color="#fff"
+            size={26}
+            onPress={() => {
+              clear();
+              navigation.navigate('HomeScreen');
+            }}
+            testID="private-home.button.switch-to-public"
+            accessibilityLabel="Switch to public"
+            style={{ marginRight: 12 }}
+          />
+          {isOwner && (
+            <IconButton
+              icon="person-add-outline"
+              color="#fff"
+              size={26}
+              onPress={shareCode}
+              testID="private-home.button.share-code"
+              accessibilityLabel="Share invite code"
+              style={{ marginRight: 12 }}
+            />
+          )}
+          {isOwner && (
+            <IconButton
+              icon="settings-outline"
+              color="#fff"
+              size={26}
+              onPress={() => navigation.navigate('GroupSettingsScreen')}
+              testID="private-home.button.settings"
+              accessibilityLabel="Group settings"
+            />
+          )}
+        </View>
+      ),
+    });
+  }, [navigation, group?.name, group?.joining_code, isOwner, clear, shareCode]);
+
+  useFocusEffect(
+    useCallback(() => {
+      handleOrientation('portrait');
+    }, [])
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      refresh();
+    }, [refresh])
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      setPrivateMode?.(true);
+    }, [setPrivateMode])
+  );
+
+  const goScoped = (target) =>
+    navigation.navigate(target, {
+      scope: { kind: 'private', groupId },
+    });
 
   return (
     <View
@@ -113,13 +145,6 @@ export default function PrivateHomeScreen({ navigation, route }) {
         heightPercent={20}
         testID="private-home.button.ranking"
       />
-      {isOwner && (
-        <BigButton
-          text="Share invite code"
-          onPress={shareCode}
-          testID="private-home.button.share-code"
-        />
-      )}
     </View>
   );
 }

--- a/screens/Groups/PrivateHomeScreen.js
+++ b/screens/Groups/PrivateHomeScreen.js
@@ -1,9 +1,10 @@
 import { useCallback, useEffect } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Share, Alert } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 
 import HomeCard from '../../components/UI/HomeCard';
 import BigButton from '../../components/UI/BigButton';
+import IconButton from '../../components/UI/IconButton';
 import { GlobalStyle } from '../../constants/theme';
 import { handleOrientation } from '../../utils/orientation';
 import { useActiveGroup } from '../../hooks/useActiveGroup';
@@ -15,18 +16,33 @@ const RankingImage = require('../../assets/home/WoIstWaldo-character-stats.webp'
 
 export default function PrivateHomeScreen({ navigation, route }) {
   const routeScope = route?.params?.scope;
-  const { scope, clear } = useActiveGroup();
+  const { scope } = useActiveGroup();
   const activeScope = routeScope ?? scope;
   const { data, refresh } = useGroupsHub();
   const group = activeScope?.kind === 'private'
     ? [...(data?.owned ?? []), ...(data?.joined ?? [])].find((g) => g.id === activeScope.groupId)
     : null;
   const isLocked = group?.locked === true;
+  const isOwner = group?.role === 'owner';
   const groupId = activeScope?.kind === 'private' ? activeScope.groupId : null;
 
   useEffect(() => {
-    navigation.setOptions({ title: group?.name ?? '' });
-  }, [navigation, group?.name]);
+    navigation.setOptions({
+      title: group?.name ?? '',
+      headerRight: isOwner
+        ? () => (
+          <IconButton
+            icon="settings-outline"
+            color="#fff"
+            size={26}
+            onPress={() => navigation.navigate('GroupSettingsScreen')}
+            testID="private-home.button.settings"
+            accessibilityLabel="Group settings"
+          />
+        )
+        : undefined,
+    });
+  }, [navigation, group?.name, isOwner]);
 
   useFocusEffect(
     useCallback(() => {
@@ -44,6 +60,20 @@ export default function PrivateHomeScreen({ navigation, route }) {
     navigation.navigate(target, {
       scope: { kind: 'private', groupId },
     });
+
+  const shareCode = useCallback(async () => {
+    const code = group?.joining_code;
+    if (!code) {
+      Alert.alert('No invite code available.');
+      return;
+    }
+    const message = `Join my private Waldo group! Code: ${code}`;
+    try {
+      await Share.share({ message });
+    } catch (_) {
+      Alert.alert('Invite code', message);
+    }
+  }, [group?.joining_code]);
 
   return (
     <View
@@ -83,14 +113,13 @@ export default function PrivateHomeScreen({ navigation, route }) {
         heightPercent={20}
         testID="private-home.button.ranking"
       />
-      <BigButton
-        text="Back to public"
-        onPress={() => {
-          clear();
-          navigation.navigate('HomeScreen');
-        }}
-        testID="private-home.button.back-to-public"
-      />
+      {isOwner && (
+        <BigButton
+          text="Share invite code"
+          onPress={shareCode}
+          testID="private-home.button.share-code"
+        />
+      )}
     </View>
   );
 }

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -175,6 +175,10 @@ export default function HomeScreen({ navigation, route }) {
     void verifyLoginInfos();
   });
 
+  useFocusEffect(() => {
+    context.setPrivateMode?.(false);
+  });
+
   return (
     <>
       <View style={styles.homeContainer}>


### PR DESCRIPTION
This pull request primarily updates group-related UI logic and tests to improve the user experience when handling group ownership, toggling between public/private scopes, and group membership. The most significant changes ensure that users who already own a group see the correct messaging and navigation options, and that scope toggling and group switching are more intuitive and robust. Several tests are added or updated to verify these behaviors.

**Group Ownership & Create Group Flow:**
* [`CreateGroupScreen.js`](diffhunk://#diff-a7acfd3f75fba746bfec6726b2b218c2f4262507978763ac318b857fd1e7704fL27-R62): Users who already own a group now see a message and a "Go to my group" button instead of the unlock CTA, regardless of their premium status. The screen also handles loading states more gracefully.
* `__tests__/CreateGroupScreen.test.js`, `__tests__/screens/CreateGroupScreen.test.js`: Tests are added and updated to verify the new ownership logic and UI, including navigation to the owned group and absence of the unlock button. [[1]](diffhunk://#diff-47a7ff76f2900274b2b390edb32b12c5be767336b20c6ccf7a42b4f480aab6adR115-R170) [[2]](diffhunk://#diff-173cb2e5a8c9ded8e46522d16bd4ce46d1850d0c7992fa9b03478a44e18ae2a8R181-R233)

**Scope Toggling & Active Group Logic:**
* [`HomeHeaderRight.js`](diffhunk://#diff-d1ade794edcde4dca101c0352120f6d6a2adb4f25fe508be932e8698eba16b1eL18-R18): The toggle between public and private scopes is now enabled for any user with group membership, not just those with an active group. The logic for toggling has been simplified to allow navigation to the group list when no active group is set. [[1]](diffhunk://#diff-d1ade794edcde4dca101c0352120f6d6a2adb4f25fe508be932e8698eba16b1eL18-R18) [[2]](diffhunk://#diff-d1ade794edcde4dca101c0352120f6d6a2adb4f25fe508be932e8698eba16b1eL28-R27)
* [`__tests__/screens/HomeHeaderRight.test.js`](diffhunk://#diff-f36c64a2c761d9c061a63ba05e4f6b399af228d82ddbcefd40b6108747c07ebaR122-R168): Tests are added to confirm the toggle remains enabled for members without an active group and that navigation to the group list occurs as expected.

**Active Group Clearing Behavior:**
* `useActiveGroup.js`, `__tests__/hooks/useActiveGroup.test.js`, `__tests__/useActiveGroup.test.js`: The `clear()` method now only switches to public view but retains the last active group ID, improving consistency across the app. Corresponding tests are updated to reflect this new behavior. [[1]](diffhunk://#diff-0e1a57c816c0201dbb29114007a8592ca2184fb671d30571da468b13ee9b8ef5L28-R29) [[2]](diffhunk://#diff-e0655050bd86e0ee00fddcb33bcaf31d5b94dbe4aee7aed19731dbfb4b323813L62-R62) [[3]](diffhunk://#diff-e0655050bd86e0ee00fddcb33bcaf31d5b94dbe4aee7aed19731dbfb4b323813R82-R84) [[4]](diffhunk://#diff-68abc8bd1aef2741d26886ecdd1d3a5481e1fa581fb2e51743948125879a9b29L97-R97) [[5]](diffhunk://#diff-68abc8bd1aef2741d26886ecdd1d3a5481e1fa581fb2e51743948125879a9b29L115-R118)

**Private Home Screen Header & Owner Actions:**
* [`__tests__/screens/PrivateHomeScreen.test.js`](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645R49-R99): The legacy back-to-public button is removed. New tests verify the presence of owner-only header actions (settings gear, share invite code) and member-specific UI, including sharing the invite code and switching scopes. [[1]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645R49-R99) [[2]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645L79-R210)

**Test and Mock Enhancements:**
* Additional mocks and test helpers are introduced for UI components and navigation to support the expanded test coverage and new UI flows. [[1]](diffhunk://#diff-173cb2e5a8c9ded8e46522d16bd4ce46d1850d0c7992fa9b03478a44e18ae2a8R2-R14) [[2]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645R3) [[3]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645R32-R38)

These changes collectively improve the clarity and correctness of group-related user flows, especially around group creation, ownership, and navigation between group scopes.