### PR TITLE
Fix/private group color palettes

### DIFF
--- a/__tests__/colorShades.test.js
+++ b/__tests__/colorShades.test.js
@@ -1,0 +1,90 @@
+import {
+  normalizeHex,
+  hexToRgb,
+  rgbToHex,
+  hexToHsl,
+  hslToHex,
+  generateShades,
+} from '../utils/colorShades';
+
+describe('colorShades', () => {
+  describe('normalizeHex', () => {
+    it.each([
+      ['#6528F7', '#6528F7'],
+      ['6528f7', '#6528F7'],
+      ['#6528f7', '#6528F7'],
+      ['abc', '#AABBCC'],
+      ['#abc', '#AABBCC'],
+      ['  #FFCC00  ', '#FFCC00'],
+    ])('normalizes %p to %p', (input, expected) => {
+      expect(normalizeHex(input)).toBe(expected);
+    });
+
+    it('falls back to black for unparseable input', () => {
+      expect(normalizeHex('nope')).toBe('#000000');
+      expect(normalizeHex(null)).toBe('#000000');
+      expect(normalizeHex(undefined)).toBe('#000000');
+    });
+  });
+
+  describe('rgb / hex round trip', () => {
+    it('converts hex to rgb and back', () => {
+      expect(hexToRgb('#6528F7')).toEqual({ r: 0x65, g: 0x28, b: 0xF7 });
+      expect(rgbToHex(0x65, 0x28, 0xf7)).toBe('#6528F7');
+    });
+
+    it('clamps rgb values into range', () => {
+      expect(rgbToHex(-10, 300, 128)).toBe('#00FF80');
+    });
+  });
+
+  describe('hsl / hex round trip', () => {
+    it('converts black and white without NaN', () => {
+      expect(hslToHex(0, 0, 0)).toBe('#000000');
+      expect(hslToHex(0, 0, 1)).toBe('#FFFFFF');
+    });
+
+    it('round-trips a saturated color within a small tolerance', () => {
+      const [h, s, l] = hexToHsl('#6528F7');
+      // Re-quantizing introduces up to ~1/255 per channel error, so allow a
+      // tiny lightness drift rather than asserting exact equality.
+      const roundTrip = hexToHsl(hslToHex(h, s, l));
+      expect(roundTrip[0]).toBeCloseTo(h, 0);
+      expect(roundTrip[1]).toBeCloseTo(s, 1);
+      expect(roundTrip[2]).toBeCloseTo(l, 1);
+    });
+  });
+
+  describe('generateShades', () => {
+    it('returns the requested count of valid hexes', () => {
+      const shades = generateShades('#6528F7', 10);
+      expect(shades).toHaveLength(10);
+      shades.forEach((hex) => expect(hex).toMatch(/^#[0-9A-F]{6}$/));
+    });
+
+    it('always includes the exact input color (uppercased)', () => {
+      expect(generateShades('#6528F7', 10)).toContain('#6528F7');
+      expect(generateShades('a076f9', 10)).toContain('#A076F9');
+    });
+
+    it('orders shades dark -> light by lightness', () => {
+      const shades = generateShades('#6528F7', 10);
+      const lightness = shades.map((hex) => hexToHsl(hex)[2]);
+      for (let i = 1; i < lightness.length; i++) {
+        expect(lightness[i]).toBeGreaterThanOrEqual(lightness[i - 1]);
+      }
+    });
+
+    it('clamps absurd counts to a minimum of two', () => {
+      expect(generateShades('#6528F7', 0)).toHaveLength(2);
+      expect(generateShades('#6528F7', -5)).toHaveLength(2);
+    });
+
+    it('keeps two different bases distinct', () => {
+      const purple = generateShades('#6528F7', 10);
+      const blue = generateShades('#7895CB', 10);
+      expect(new Set(purple).size).toBe(10);
+      expect(new Set(blue).size).toBe(10);
+    });
+  });
+});

--- a/__tests__/screens/PrivateHomeScreen.test.js
+++ b/__tests__/screens/PrivateHomeScreen.test.js
@@ -159,7 +159,7 @@ describe('PrivateHomeScreen', () => {
 
   describe('owner', () => {
     const ownerData = {
-      owned: [{ id: 'g-7', name: 'Waldos', role: 'owner', joining_code: 'WALDO42' }],
+      owned: [{ id: 'g-7', name: 'Waldos', role: 'owner', joining_code: 'WALDO42', primary_color: '#6528F7' }],
       joined: [],
     };
 
@@ -222,25 +222,35 @@ describe('PrivateHomeScreen', () => {
       expect(button.props.accessibilityLabel).toBe('Switch to public');
     });
 
-    it('lets the owner change colors via a hidden long-press on the title (no visible button)', async () => {
+    it('wires the header background to the group primary_color', async () => {
+      const { navigation } = await renderScreen({ groupsData: ownerData });
+
+      const options = lastSetOptions(navigation);
+      expect(options.headerStyle.backgroundColor).toBe('#6528F7');
+      expect(options.headerTintColor).toBe('#fff');
+    });
+
+    it('lets the owner customize colors via the header button', async () => {
       updateGroupSettings.mockResolvedValue({ status: 200 });
-      const { renderer } = await renderScreen({ groupsData: ownerData });
+      const { navigation } = await renderScreen({ groupsData: ownerData });
 
-      // No visible color button anywhere in the UI.
-      expect(() => renderer.root.findByProps({ testID: 'private-home.color-editor.confirm.ok' })).toThrow();
+      const headerRoot = await renderHeader(navigation);
 
-      // Hidden trigger: long-press the title (owner only).
+      // Editor not visible initially.
+      expect(() => headerRoot.root.findByProps({ testID: 'private-home.color-editor.confirm.ok' })).toThrow();
+
+      // Open editor via header customize button.
       await act(async () => {
-        renderer.root.findByProps({ testID: 'private-home.title' }).props.onLongPress();
+        headerRoot.root.findByProps({ testID: 'private-home.button.customize-colors' }).props.onPress();
       });
 
-      // Editor opened -> both pickers rendered.
-      const pickerCalls = mockColorPalettePicker.mock.calls;
-      expect(pickerCalls.length).toBe(2);
+      // Editor opened -> two color pickers rendered.
+      expect(mockColorPalettePicker.mock.calls.length).toBeGreaterThanOrEqual(2);
 
+      const colorCalls = mockColorPalettePicker.mock.calls;
       await act(async () => {
-        pickerCalls[0][0].onValueChange('#111111'); // primary
-        pickerCalls[1][0].onValueChange('#EEEEEE'); // secondary
+        colorCalls[colorCalls.length - 2][0].onValueChange('#111111'); // primary
+        colorCalls[colorCalls.length - 1][0].onValueChange('#EEEEEE'); // secondary
       });
 
       const modalProps = mockCenteredModal.mock.calls[mockCenteredModal.mock.calls.length - 1][0];
@@ -260,6 +270,7 @@ describe('PrivateHomeScreen', () => {
       const lastModalProps = mockCenteredModal.mock.calls[mockCenteredModal.mock.calls.length - 1][0];
       expect(lastModalProps.isModalVisible).toBe(false);
     });
+
   });
 
   describe('non-owner member', () => {
@@ -285,12 +296,12 @@ describe('PrivateHomeScreen', () => {
       expect(() => headerRoot.root.findByProps({ testID: 'private-home.button.settings' })).toThrow();
     });
 
-    it('does not expose the hidden color editor (title has no onLongPress)', async () => {
-      const { renderer } = await renderScreen({ groupsData: memberData });
+    it('does not expose the customize colors button for non-owners', async () => {
+      const { navigation } = await renderScreen({ groupsData: memberData });
 
-      const title = renderer.root.findByProps({ testID: 'private-home.title' });
-      expect(title.props.onLongPress).toBeUndefined();
-      expect(title.props.accessibilityLabel).toBeUndefined();
+      const headerRoot = await renderHeader(navigation);
+
+      expect(() => headerRoot.root.findByProps({ testID: 'private-home.button.customize-colors' })).toThrow();
     });
   });
 

--- a/components/UI/ColorPalettePicker.js
+++ b/components/UI/ColorPalettePicker.js
@@ -1,11 +1,13 @@
+import { useMemo, useState } from 'react';
 import { Pressable, View, Text, StyleSheet } from 'react-native';
 
+import { generateShades } from '../../utils/colorShades';
+
 /**
- * Curated default swatches. Exported so callers/tests can reference the
- * exact hex values instead of hardcoding duplicates.
+ * Curated base colors. Exported so callers/tests reference exact hexes.
  *
- * Open/Closed: pass a custom `palette` prop to extend or replace without
- * editing this component.
+ * Open/Closed: pass a custom `palette` prop (list of {name, hex} bases) to
+ * extend or replace without editing this component.
  */
 export const DEFAULT_COLOR_PALETTE = [
   { name: 'Purple', hex: '#6528F7' },
@@ -22,17 +24,27 @@ export const DEFAULT_COLOR_PALETTE = [
   { name: 'Slate', hex: '#3D4358' },
 ];
 
+const SHADE_COUNT = 10;
+
+function noHash(hex) {
+  return hex.replace('#', '');
+}
+
 /**
- * Single Responsibility: render labelled swatches and report the picked hex.
- * Knows nothing about groups, persistence, or screens.
+ * Single Responsibility: render base swatches + their derivatives, report the
+ * picked hex. Knows nothing about groups, persistence, or screens.
+ *
+ * UX: tapping a BASE swatch expands that base's derivative row (10 shades,
+ * including the base itself). Tapping a SHADE calls onValueChange(hex).
  *
  * Props:
- * - label: optional heading text above the grid.
+ * - label: optional heading text.
  * - value: currently selected hex string (e.g. "#6528F7").
- * - onValueChange: called with the picked hex when a swatch is tapped.
- * - palette: swatches [{ name, hex }]; defaults to DEFAULT_COLOR_PALETTE.
- * - testIDPrefix: swatches get testID `${testIDPrefix}.swatch.${hexWithoutHash}`.
- * - accessibilityLabel: optional, applied to the grid container.
+ * - onValueChange: called with the picked hex when a shade is tapped.
+ * - palette: bases [{ name, hex }]; defaults to DEFAULT_COLOR_PALETTE.
+ * - testIDPrefix: bases -> `${prefix}.swatch.${hexNoHash}`;
+ *                 shades -> `${prefix}.shade.${baseHexNoHash}.${shadeHexNoHash}`.
+ * - accessibilityLabel: optional, applied to the base grid.
  */
 export default function ColorPalettePicker({
   label,
@@ -42,31 +54,83 @@ export default function ColorPalettePicker({
   testIDPrefix = 'color-palette-picker',
   accessibilityLabel,
 }) {
-  const normalizedValue = typeof value === 'string' ? value.toLowerCase() : value;
+  const normalizedValue = typeof value === 'string' ? value.toUpperCase() : value;
+
+  // base -> shades. Memoized so it stays stable across renders for a given palette.
+  const basesWithShades = useMemo(
+    () =>
+      palette.map((base) => ({
+        name: base.name,
+        hex: base.hex.toUpperCase(),
+        shades: generateShades(base.hex, SHADE_COUNT),
+      })),
+    [palette],
+  );
+
+  // Auto-expand the base whose family contains the current value, so the user
+  // sees their selection's shades on first render.
+  const initialBaseHex = useMemo(() => {
+    if (!normalizedValue) return null;
+    const match = basesWithShades.find(
+      (b) => b.hex === normalizedValue || b.shades.includes(normalizedValue),
+    );
+    return match ? match.hex : null;
+  }, [basesWithShades, normalizedValue]);
+
+  const [expandedBaseHex, setExpandedBaseHex] = useState(initialBaseHex);
+  const expanded = basesWithShades.find((b) => b.hex === expandedBaseHex) || null;
 
   return (
     <View style={styles.container}>
       {label ? <Text style={styles.label}>{label}</Text> : null}
       <View style={styles.grid} accessibilityLabel={accessibilityLabel}>
-        {palette.map((swatch) => {
-          const selected = normalizedValue === swatch.hex.toLowerCase();
+        {basesWithShades.map((base) => {
+          const selected = base.shades.includes(normalizedValue);
+          const isExpanded = base.hex === expandedBaseHex;
           return (
             <Pressable
-              key={swatch.hex}
-              testID={`${testIDPrefix}.swatch.${swatch.hex.replace('#', '')}`}
-              accessibilityLabel={swatch.name}
+              key={base.hex}
+              testID={`${testIDPrefix}.swatch.${noHash(base.hex)}`}
+              accessibilityLabel={base.name}
               accessibilityRole="button"
-              accessibilityState={selected ? { selected: true } : undefined}
-              onPress={() => onValueChange?.(swatch.hex)}
+              accessibilityState={{ selected, expanded: isExpanded }}
+              onPress={() => setExpandedBaseHex(base.hex)}
               style={[
                 styles.swatch,
-                { backgroundColor: swatch.hex },
+                { backgroundColor: base.hex },
                 selected && styles.selected,
+                isExpanded && styles.expandedBase,
               ]}
             />
           );
         })}
       </View>
+
+      {expanded && (
+        <View
+          style={styles.shadeGrid}
+          testID={`${testIDPrefix}.shades.${noHash(expanded.hex)}`}
+        >
+          {expanded.shades.map((shadeHex) => {
+            const selected = shadeHex === normalizedValue;
+            return (
+              <Pressable
+                key={shadeHex}
+                testID={`${testIDPrefix}.shade.${noHash(expanded.hex)}.${noHash(shadeHex)}`}
+                accessibilityLabel={`${expanded.name} shade`}
+                accessibilityRole="button"
+                accessibilityState={selected ? { selected: true } : undefined}
+                onPress={() => onValueChange?.(shadeHex)}
+                style={[
+                  styles.shade,
+                  { backgroundColor: shadeHex },
+                  selected && styles.selected,
+                ]}
+              />
+            );
+          })}
+        </View>
+      )}
     </View>
   );
 }
@@ -76,5 +140,16 @@ const styles = StyleSheet.create({
   label: { color: '#fff', fontSize: 16, marginBottom: 4 },
   grid: { flexDirection: 'row', flexWrap: 'wrap', gap: 12 },
   swatch: { width: 40, height: 40, borderRadius: 8 },
+  expandedBase: { borderWidth: 2, borderColor: 'rgba(255,255,255,0.5)' },
+  shadeGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 10,
+    padding: 8,
+    borderRadius: 8,
+    backgroundColor: 'rgba(0,0,0,0.25)',
+  },
+  shade: { width: 32, height: 32, borderRadius: 6 },
   selected: { borderWidth: 3, borderColor: '#fff' },
 });

--- a/screens/Groups/PrivateHomeScreen.js
+++ b/screens/Groups/PrivateHomeScreen.js
@@ -95,6 +95,8 @@ export default function PrivateHomeScreen({ navigation, route }) {
   useEffect(() => {
     navigation.setOptions({
       title: group?.name ?? '',
+      headerStyle: { backgroundColor: group?.primary_color || GlobalStyle.color.primaryColor900 },
+      headerTintColor: '#fff',
       headerRight: () => (
         <View style={{ flexDirection: 'row' }}>
           <IconButton
@@ -109,6 +111,17 @@ export default function PrivateHomeScreen({ navigation, route }) {
             accessibilityLabel="Switch to public"
             style={{ marginRight: 12 }}
           />
+          {isOwner && (
+            <IconButton
+              icon="color-palette-outline"
+              color="#fff"
+              size={26}
+              onPress={openColorEditor}
+              testID="private-home.button.customize-colors"
+              accessibilityLabel="Customize group colors"
+              style={{ marginRight: 12 }}
+            />
+          )}
           {isOwner && (
             <IconButton
               icon="person-add-outline"
@@ -133,7 +146,7 @@ export default function PrivateHomeScreen({ navigation, route }) {
         </View>
       ),
     });
-  }, [navigation, group?.name, group?.joining_code, isOwner, clear, shareCode]);
+  }, [navigation, group?.name, group?.primary_color, group?.joining_code, isOwner, clear, shareCode, openColorEditor]);
 
   useFocusEffect(
     useCallback(() => {
@@ -180,8 +193,6 @@ export default function PrivateHomeScreen({ navigation, route }) {
       <Text
         style={styles.title}
         testID="private-home.title"
-        accessibilityLabel={isOwner ? `${group?.name ?? ''}. Long press to edit group colors.` : undefined}
-        onLongPress={isOwner ? openColorEditor : undefined}
       >
         {group?.name ?? ''}
       </Text>

--- a/utils/colorShades.js
+++ b/utils/colorShades.js
@@ -1,0 +1,106 @@
+// Pure color math. No React, no side effects.
+// Single Responsibility: convert/derive hex shades. Reusable & unit-testable.
+
+function clamp(n, min, max) {
+  return Math.min(max, Math.max(min, n));
+}
+
+// Normalizes any reasonable hex input (#abc, abc, #aabbcc) to #RRGGBB uppercase.
+// Returns #000000 for anything unparseable so downstream math never sees NaN.
+export function normalizeHex(hex) {
+  if (typeof hex !== 'string') return '#000000';
+  let h = hex.trim();
+  if (!h.startsWith('#')) h = `#${h}`;
+  if (h.length === 4) {
+    h = `#${h[1]}${h[1]}${h[2]}${h[2]}${h[3]}${h[3]}`;
+  }
+  if (!/^#[0-9a-fA-F]{6}$/.test(h)) return '#000000';
+  return h.toUpperCase();
+}
+
+export function hexToRgb(hex) {
+  const h = normalizeHex(hex);
+  return {
+    r: parseInt(h.slice(1, 3), 16),
+    g: parseInt(h.slice(3, 5), 16),
+    b: parseInt(h.slice(5, 7), 16),
+  };
+}
+
+export function rgbToHex(r, g, b) {
+  const to = (n) => clamp(Math.round(n), 0, 255).toString(16).padStart(2, '0');
+  return `#${to(r)}${to(g)}${to(b)}`.toUpperCase();
+}
+
+// Returns [h (0-360), s (0-1), l (0-1)].
+export function hexToHsl(hex) {
+  const { r, g, b } = hexToRgb(hex);
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  const d = max - min;
+  if (d !== 0) {
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    if (max === rn) {
+      h = ((gn - bn) / d) % 6;
+    } else if (max === gn) {
+      h = (bn - rn) / d + 2;
+    } else {
+      h = (rn - gn) / d + 4;
+    }
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+  return [h, s, l];
+}
+
+export function hslToHex(h, s, l) {
+  const safeS = clamp(s, 0, 1);
+  const safeL = clamp(l, 0, 1);
+  const c = (1 - Math.abs(2 * safeL - 1)) * safeS;
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r1 = 0;
+  let g1 = 0;
+  let b1 = 0;
+  if (hp < 1) [r1, g1, b1] = [c, x, 0];
+  else if (hp < 2) [r1, g1, b1] = [x, c, 0];
+  else if (hp < 3) [r1, g1, b1] = [0, c, x];
+  else if (hp < 4) [r1, g1, b1] = [0, x, c];
+  else if (hp < 5) [r1, g1, b1] = [x, 0, c];
+  else [r1, g1, b1] = [c, 0, x];
+  const m = safeL - c / 2;
+  return rgbToHex((r1 + m) * 255, (g1 + m) * 255, (b1 + m) * 255);
+}
+
+const SHADE_L_MIN = 0.12;
+const SHADE_L_MAX = 0.92;
+
+// Returns `count` hex shades, lightness stepping dark -> light.
+// The exact input hex is always included (snapped onto its nearest step)
+// so the original color stays directly selectable in a derivative row.
+export function generateShades(hex, count = 10) {
+  const safeCount = Math.max(2, Math.floor(count));
+  const [h, s, baseL] = hexToHsl(hex);
+  const steps = [];
+  for (let i = 0; i < safeCount; i++) {
+    const l = SHADE_L_MIN + ((SHADE_L_MAX - SHADE_L_MIN) * i) / (safeCount - 1);
+    steps.push({ l, hex: hslToHex(h, s, l) });
+  }
+  let nearest = 0;
+  let nearestDelta = Infinity;
+  for (let i = 0; i < safeCount; i++) {
+    const delta = Math.abs(steps[i].l - baseL);
+    if (delta < nearestDelta) {
+      nearestDelta = delta;
+      nearest = i;
+    }
+  }
+  steps[nearest].hex = normalizeHex(hex);
+  return steps.map((step) => step.hex);
+}


### PR DESCRIPTION
This pull request introduces a new, reusable color shade generation utility and a redesigned `ColorPalettePicker` component that now supports selecting from a palette of base colors and their derived shades. It also updates the group color customization flow in the private group home screen, making color customization more discoverable and robust, and adds comprehensive unit tests for the color math utilities.

**Color customization and UI improvements:**

* The group header background color now reflects the group's `primary_color`, and owners see a new "customize colors" button in the header for easier access to color customization. The old long-press gesture is removed. (`screens/Groups/PrivateHomeScreen.js`, [[1]](diffhunk://#diff-43ae43fe490d9f6ed1ab36c7a3a530314c51fbb41d6eed38fe0ad496daa3202cR98-R99) [[2]](diffhunk://#diff-43ae43fe490d9f6ed1ab36c7a3a530314c51fbb41d6eed38fe0ad496daa3202cR114-R124) [[3]](diffhunk://#diff-43ae43fe490d9f6ed1ab36c7a3a530314c51fbb41d6eed38fe0ad496daa3202cL136-R149) [[4]](diffhunk://#diff-43ae43fe490d9f6ed1ab36c7a3a530314c51fbb41d6eed38fe0ad496daa3202cL183-L184)
* The color customization button is only visible to group owners, and non-owners cannot access the color editor. (`screens/Groups/PrivateHomeScreen.js`, [__tests__/screens/PrivateHomeScreen.test.jsL288-R304](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645L288-R304))

**Color palette and shade selection:**

* The `ColorPalettePicker` component is refactored to display a grid of base colors. Tapping a base color expands a row of 10 derived shades (from dark to light), allowing users to pick any shade. The component uses the new `generateShades` utility and is more accessible and testable. (`components/UI/ColorPalettePicker.js`, [[1]](diffhunk://#diff-d8ba0808d3e6ad928a95c6a1f2d7596d7e6bac62e5f230bffea341844345ad39R1-R10) [[2]](diffhunk://#diff-d8ba0808d3e6ad928a95c6a1f2d7596d7e6bac62e5f230bffea341844345ad39R27-R47) [[3]](diffhunk://#diff-d8ba0808d3e6ad928a95c6a1f2d7596d7e6bac62e5f230bffea341844345ad39L45-R133) [[4]](diffhunk://#diff-d8ba0808d3e6ad928a95c6a1f2d7596d7e6bac62e5f230bffea341844345ad39R143-R153)

**Color math utilities:**

* Adds a new `utils/colorShades.js` module containing pure functions for hex/RGB/HSL conversion, normalization, and shade generation. These utilities are robust, handle invalid input gracefully, and are covered by comprehensive unit tests. (`utils/colorShades.js`, [[1]](diffhunk://#diff-929d0b7089db7e6428cb5942a627c1b58030ed0fb8c1ee626f9d6a6d509fae74R1-R106); `__tests__/colorShades.test.js`, [[2]](diffhunk://#diff-5601e3a4abb79c67c24cff0e14f99a0e25239850410915548dfc99081711064bR1-R90)

**Test updates:**

* Updates and expands tests for private group home screen behaviors, including header color logic and color customization UI, and adds tests for the new color math utilities. (`__tests__/screens/PrivateHomeScreen.test.js`, [[1]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645L162-R162) [[2]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645L225-R253) [[3]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645R273) [[4]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645L288-R304); `__tests__/colorShades.test.js`, [[5]](diffhunk://#diff-5601e3a4abb79c67c24cff0e14f99a0e25239850410915548dfc99081711064bR1-R90)

These changes make color customization more intuitive for group owners, improve accessibility, and provide a solid foundation for future color-related features.