### PR TITLE
Fix/private groups bugs

### DIFF
--- a/App.js
+++ b/App.js
@@ -62,9 +62,9 @@ import { getUserConsent } from './utils/adHandling';
 import {
   bootstrapStoredAuthSession,
   getStoredAuthState,
-  getUserName,
   hasCompleteAuthState,
   isPersistedBearerToken,
+  validateStoredSession,
 } from './utils/auth';
 import { ensureE2EOnboardingBypass, isE2EMode } from './utils/e2eMode';
 import { getOnboardingCompleted } from './utils/storageDatum';
@@ -551,7 +551,7 @@ export function Root() {
         return;
       }
 
-      if (typeof getUserName !== 'function') {
+      if (typeof validateStoredSession !== 'function') {
         return;
       }
 
@@ -559,7 +559,7 @@ export function Root() {
         // Cheap authed call: confirms the stored token is still server-valid.
         // Only auth rejection should clear the session here. Network/server
         // failures should not force-log the user out on app launch.
-        const result = await getUserName({ context: authContext });
+        const result = await validateStoredSession({ context: authContext });
 
         if (cancelled) {
           return;

--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -92,7 +92,7 @@ jest.mock('../store/auth-context', () => {
 
 jest.mock('../utils/auth', () => ({
   bootstrapStoredAuthSession: jest.fn(),
-  getUserName: jest.fn(),
+  validateStoredSession: jest.fn(),
 }));
 
 jest.mock('../utils/e2eMode', () => ({
@@ -109,7 +109,7 @@ import { act, create } from 'react-test-renderer';
 
 import { Root } from '../App';
 import { AuthContext } from '../store/auth-context';
-import { bootstrapStoredAuthSession, getUserName } from '../utils/auth';
+import { bootstrapStoredAuthSession, validateStoredSession } from '../utils/auth';
 import { ensureE2EOnboardingBypass, isE2EMode } from '../utils/e2eMode';
 import { getOnboardingCompleted } from '../utils/storageDatum';
 
@@ -121,7 +121,7 @@ describe('App Root', () => {
     getOnboardingCompleted.mockResolvedValue(true);
     isE2EMode.mockReturnValue(false);
     bootstrapStoredAuthSession.mockResolvedValue(false);
-    getUserName.mockResolvedValue({ status: 200, data: { username: 'waldo' } });
+    validateStoredSession.mockResolvedValue({ status: 200, data: { is_tutorial_finished: true } });
   });
 
   async function flushEffects() {
@@ -331,14 +331,14 @@ describe('App Root', () => {
 
     await renderRoot(contextValue);
 
-    expect(getUserName).toHaveBeenCalledTimes(1);
-    expect(getUserName).toHaveBeenCalledWith({ context: contextValue });
+    expect(validateStoredSession).toHaveBeenCalledTimes(1);
+    expect(validateStoredSession).toHaveBeenCalledWith({ context: contextValue });
     expect(contextValue.logout).not.toHaveBeenCalled();
   });
 
   it('logs out when the restored token is rejected by the backend with 401', async () => {
     bootstrapStoredAuthSession.mockResolvedValue(true);
-    getUserName.mockResolvedValue({ status: 401, data: { errors: ['Unauthorized'] } });
+    validateStoredSession.mockResolvedValue({ status: 401, data: { errors: ['Unauthorized'] } });
 
     const contextValue = {
       IsAuthenticated: true,
@@ -349,13 +349,13 @@ describe('App Root', () => {
 
     await renderRoot(contextValue);
 
-    expect(getUserName).toHaveBeenCalledTimes(1);
+    expect(validateStoredSession).toHaveBeenCalledTimes(1);
     expect(contextValue.logout).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the session when the restored token validation call fails without an auth rejection', async () => {
     bootstrapStoredAuthSession.mockResolvedValue(true);
-    getUserName.mockRejectedValue(new Error('network down'));
+    validateStoredSession.mockRejectedValue(new Error('network down'));
 
     const contextValue = {
       IsAuthenticated: true,
@@ -366,7 +366,7 @@ describe('App Root', () => {
 
     await renderRoot(contextValue);
 
-    expect(getUserName).toHaveBeenCalledTimes(1);
+    expect(validateStoredSession).toHaveBeenCalledTimes(1);
     expect(contextValue.logout).not.toHaveBeenCalled();
   });
 
@@ -383,7 +383,7 @@ describe('App Root', () => {
 
     await renderRoot(contextValue);
 
-    expect(getUserName).not.toHaveBeenCalled();
+    expect(validateStoredSession).not.toHaveBeenCalled();
     expect(contextValue.logout).not.toHaveBeenCalled();
   });
 
@@ -399,7 +399,7 @@ describe('App Root', () => {
 
     await renderRoot(contextValue);
 
-    expect(getUserName).not.toHaveBeenCalled();
+    expect(validateStoredSession).not.toHaveBeenCalled();
     expect(contextValue.logout).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/guessNavigation.test.js
+++ b/__tests__/guessNavigation.test.js
@@ -45,6 +45,7 @@ describe('navigateToNextGuess', () => {
             category,
             language: 'fr',
             isTutorial: true,
+            skipInstructions: true,
           },
         },
       ],
@@ -79,7 +80,7 @@ describe('navigateToNextGuess', () => {
       routes: [
         { name: 'HomeScreen' },
         { name: 'GuessPathScreen', params: { isTutorial: false } },
-        { name: 'GuessFeedScreen', params: { category, language: 'de' } },
+        { name: 'GuessFeedScreen', params: { category, language: 'de', skipInstructions: true } },
       ],
     });
   });
@@ -147,7 +148,7 @@ describe('navigateToNextGuess', () => {
         { name: 'HomeScreen' },
         { name: 'PrivateHomeScreen', params: { scope } },
         { name: 'GuessPathScreen', params: { isTutorial: false, scope } },
-        { name: 'GuessFeedScreen', params: { category, language: 'de', scope } },
+        { name: 'GuessFeedScreen', params: { category, language: 'de', scope, skipInstructions: true } },
       ],
     });
   });

--- a/components/Picture/GuessPicture.js
+++ b/components/Picture/GuessPicture.js
@@ -14,9 +14,9 @@ import {
 } from '../../utils/e2eMode';
 
 
-export default function GuessPicture({ imageFile, description, imageIsPortrait, imageHeight, imageWidth, hiddenLocation, screenDimensions, toAdScreen }) {
+export default function GuessPicture({ imageFile, description, imageIsPortrait, imageHeight, imageWidth, hiddenLocation, screenDimensions, toAdScreen, skipInstructions }) {
 
-  const [showFilter, setShowFilter] = useState(true); 
+  const [showFilter, setShowFilter] = useState(!skipInstructions); 
   const [touchLocation, setTouchLocation] = useState(null);
   const [target, setTarget] = useState(null);
   const [showModal, setShowModal] = useState(false);

--- a/screens/GuessScreens/GuessFeedScreen.js
+++ b/screens/GuessScreens/GuessFeedScreen.js
@@ -18,12 +18,12 @@ const DEFAULT_LANGUAGE = 'en';
 // GuessFeedScreen is currently the only caller in the authenticated stack, but we
 // still pass them explicitly so the cache namespace + filter plumbing stays explicit.
 export default function GuessFeedScreen({ navigation, route }) {
-  const { category, language: routeLanguage } = route.params || {};
+  const { category, language: routeLanguage, skipInstructions } = route.params || {};
   const routeScope = route?.params?.scope;
   const { scope: activeScope } = useActiveGroup();
   const scope = routeScope ?? activeScope;
   const [language, setLanguage] = useState(routeLanguage || null);
-  const [showOverlay, setShowOverlay] = useState(true);
+  const [showOverlay, setShowOverlay] = useState(!skipInstructions);
   const [isFilterModalVisible, setIsFilterModalVisible] = useState(false);
 
   const screenWidth = Dimensions.get('window').width;

--- a/screens/GuessScreens/GuessScreen.js
+++ b/screens/GuessScreens/GuessScreen.js
@@ -7,7 +7,7 @@ import TutorialOverlay from '../../components/UI/TutorialOverlay';
 
 export default function GuessScreen({ navigation, route }) {
 
-  const { imageFile, pictureId, description, imageHeight, imageWidth, isPortrait, hiddenLocation, listId, isTutorial, category, language, scope } = route.params;
+  const { imageFile, pictureId, description, imageHeight, imageWidth, isPortrait, hiddenLocation, listId, isTutorial, category, language, scope, skipInstructions } = route.params;
   const isPrivate = scope?.kind === 'private';
 
   const screenWidth = Dimensions.get('window').width;
@@ -63,6 +63,7 @@ export default function GuessScreen({ navigation, route }) {
       hiddenLocation={hiddenLocation}
       screenDimensions={screenDimensions}
       toAdScreen={toAdScreen}
+      skipInstructions={skipInstructions}
     />
     {
       isTutorial && 

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -216,9 +216,13 @@ export async function checkSecureStoreItem({ secureStoreValue, context }) {
   return context?.[secureStoreValue] ?? null;
 };
 
-export async function getUserName({ context }) {
+// Lightweight authed probe used at app launch to confirm the restored JWT
+// is still server-valid. Hits an existing cheap authed route and inspects
+// only the HTTP status (401/403 ⇒ logout; anything else ⇒ keep session).
+// Response body is intentionally unused by the caller.
+export async function validateStoredSession({ context }) {
   const { token, userId } = await getBackendHeaders(context);
-  const url = `${process.env.EXPO_PUBLIC_APP_BACKEND_URL}api/v1/users/${userId}/get_user_name`;
+  const url = `${process.env.EXPO_PUBLIC_APP_BACKEND_URL}api/v1/users/${userId}/get_is_tutorial_finished`;
   const headers = setHeaders({ token });
   const config = {
     headers: headers,
@@ -228,7 +232,7 @@ export async function getUserName({ context }) {
     return { status: response.status, data: response.data };
   }).catch((error) => {
     const mappedError = mapRequestError(error);
-    return { status: mappedError.status, data: mappedError.data};
+    return { status: mappedError.status, data: mappedError.data };
   });
 
   return response;

--- a/utils/guessNavigation.js
+++ b/utils/guessNavigation.js
@@ -23,8 +23,8 @@ export async function navigateToNextGuess(navigation, { category, language, curr
       ? { name: 'GuessPathScreen', params: { isTutorial, scope } }
       : { name: 'GuessPathScreen', params: { isTutorial } };
     const feedRoute = isPrivateScope
-      ? { name: 'GuessFeedScreen', params: { category, language, scope } }
-      : { name: 'GuessFeedScreen', params: { category, language } };
+      ? { name: 'GuessFeedScreen', params: { category, language, scope, skipInstructions: true } }
+      : { name: 'GuessFeedScreen', params: { category, language, skipInstructions: true } };
 
     navigation.reset({
       index: isPrivateScope ? 3 : 2,
@@ -50,6 +50,7 @@ export async function navigateToNextGuess(navigation, { category, language, curr
     category,
     language,
     isTutorial,
+    skipInstructions: true,
   };
 
   if (isPrivateScope) {


### PR DESCRIPTION
This pull request primarily updates the authentication session validation logic and enhances the guess navigation flow to allow skipping instructional overlays. The most significant changes are the replacement of the `getUserName` function with a more appropriately named and purposed `validateStoredSession` function for session validation, and the introduction of a `skipInstructions` parameter to streamline the user experience by allowing certain screens to bypass instructional overlays. Test files and navigation utilities are updated accordingly to support and verify these changes.

**Authentication/session validation updates:**

* Replaced `getUserName` with `validateStoredSession` in `utils/auth.js`, updating the implementation to use the `/get_is_tutorial_finished` endpoint for lightweight session validation. All usages in `App.js` and related test files have been updated to reflect this change. [[1]](diffhunk://#diff-9b5b5955d0e684e7904f3fc143e07aaa11b7e7c3b36d10985c4aff2554940cbfL65-R67) [[2]](diffhunk://#diff-9b5b5955d0e684e7904f3fc143e07aaa11b7e7c3b36d10985c4aff2554940cbfL554-R562) [[3]](diffhunk://#diff-ab4c5274f7c148ce3d5bb2087250258da609f195f0100dff58b79532a5fc58b1L95-R95) [[4]](diffhunk://#diff-ab4c5274f7c148ce3d5bb2087250258da609f195f0100dff58b79532a5fc58b1L112-R112) [[5]](diffhunk://#diff-ab4c5274f7c148ce3d5bb2087250258da609f195f0100dff58b79532a5fc58b1L124-R124) [[6]](diffhunk://#diff-ab4c5274f7c148ce3d5bb2087250258da609f195f0100dff58b79532a5fc58b1L334-R341) [[7]](diffhunk://#diff-ab4c5274f7c148ce3d5bb2087250258da609f195f0100dff58b79532a5fc58b1L352-R358) [[8]](diffhunk://#diff-ab4c5274f7c148ce3d5bb2087250258da609f195f0100dff58b79532a5fc58b1L369-R369) [[9]](diffhunk://#diff-ab4c5274f7c148ce3d5bb2087250258da609f195f0100dff58b79532a5fc58b1L386-R386) [[10]](diffhunk://#diff-ab4c5274f7c148ce3d5bb2087250258da609f195f0100dff58b79532a5fc58b1L402-R402) [[11]](diffhunk://#diff-8757d61b21af5b38b5adb709a03845a2fbc99ddadce574843abfb21ce60d87d7L219-R225)

**Guess navigation and instructional overlay improvements:**

* Added a `skipInstructions` parameter to the navigation flow in `utils/guessNavigation.js` so that when navigating to `GuessFeedScreen`, the instructional overlay can be skipped. The navigation logic and related tests have been updated to pass and assert this parameter. [[1]](diffhunk://#diff-38eb751e7cd33a833be7b563ea01ebd32ad8701f5d69ce3f145d071bc2d87c65L26-R27) [[2]](diffhunk://#diff-38eb751e7cd33a833be7b563ea01ebd32ad8701f5d69ce3f145d071bc2d87c65R53) [[3]](diffhunk://#diff-5650baa1f5a997eedb1d731d852935e8edd4ee8d2fdbe8dc1ebfe5383ffdcd86R48) [[4]](diffhunk://#diff-5650baa1f5a997eedb1d731d852935e8edd4ee8d2fdbe8dc1ebfe5383ffdcd86L82-R83) [[5]](diffhunk://#diff-5650baa1f5a997eedb1d731d852935e8edd4ee8d2fdbe8dc1ebfe5383ffdcd86L150-R151)
* Updated `GuessFeedScreen` and `GuessPicture` components to respect the `skipInstructions` parameter, initializing their instructional overlays as hidden when `skipInstructions` is true. [[1]](diffhunk://#diff-bac7f4929e6eb71d47f96dbbfc1cc3e26bfa02373a1046d9699508ad5b7fc13dL21-R26) [[2]](diffhunk://#diff-b06fe0100ce5a5f80305afc7c0ba5f86c18a67868d3c04b024e4d3663167ead8L17-R19)
* Modified `GuessScreen` to accept and forward the `skipInstructions` parameter to `GuessPicture`. [[1]](diffhunk://#diff-058b29f298a581ef344d249db590d83be3e2e56ac72bead507cae205add9b305L10-R10) [[2]](diffhunk://#diff-058b29f298a581ef344d249db590d83be3e2e56ac72bead507cae205add9b305R66)