### PR TITLE
feat: implement next card resolution and navigation logic

### DIFF
--- a/.maestro/.handoff.md
+++ b/.maestro/.handoff.md
@@ -1,0 +1,88 @@
+---
+last_updated: 2026-06-25 (session 5)
+---
+# Parallel Orchestrator Handoff — Maestro E2E Flow Update
+
+## Verification status (real device FP3 A209TSS60201)
+
+| Flow | Status |
+|------|--------|
+| `hide-login-save-picture.yml` | ✅ PASS (end-to-end, device-verified) |
+| `guess-login-saved-picture-success.yml` | ✅ PASS (end-to-end, device-verified) |
+| `guess-login-saved-picture-failure.yml` | ✅ PASS (end-to-end, device-verified) |
+| `hide-to-guess-to-result.yml` | ✅ PASS (core hide→guess→result→home; ranking tail omitted — see open app bug #4) |
+
+All 4 maestro flows were verified green on device during this session. Bundle must be reloaded after any app-code change.
+
+## Current device + host state
+
+- **FP3 (`A209TSS60201`) is currently DISCONNECTED** (USB dropped — physical-device flakiness, happened once earlier this session too). Reconnect the USB cable before resuming.
+- **Metro was restarted**: now listening on `:8081` under pid `368782` (earlier was 337942). Host LAN IPs: `192.168.0.105` / `192.168.0.161`.
+- Last known app state (before disconnection): app had been force-stopped + relaunched and cold-started into the Expo Dev Client launcher (`DevLauncherActivity`) — i.e. it had lost the Metro connection. So after USB reconnect: reconnect the dev client to Metro (deep link `exp://192.168.0.105:8081` or rescan), then log in once via the no-relaunch path (`/tmp/opencode/login_only.yaml` or `auth-boot-login.yml` cold-start), land on HomeScreen. After that, run the 4 feature flows in order without re-launching.
+
+## Run model (no-relaunch)
+
+Expo Dev Client: re-launching breaks the Metro JS bundle connection. Two-phase:
+1. **Phase 1 (once):** connect app to Metro + log in + reach HomeScreen. `auth-boot-login.yml` is the cold-start flow (the only flow with `launchApp`). Use `-e LOGIN_EMAIL=a@a.com -e LOGIN_PASSWORD=aaaaaa`.
+2. **Phase 2 (run in order, no re-launch):**
+   ```
+   maestro test .maestro/hide-login-save-picture.yml
+   maestro test .maestro/guess-login-saved-picture-success.yml
+   maestro test .maestro/guess-login-saved-picture-failure.yml
+   maestro test .maestro/hide-to-guess-to-result.yml
+   ```
+   Each asserts HomeScreen at start, returns to HomeScreen at end. Hide must run before the guess-only flows (they assert `guess-path.card.saved` from the saved payload).
+
+**Maestro 2.3.0 has NO `--env-file`.** Use `-e KEY=VALUE`. Feature flows take no env.
+
+## Maestro flow changes (all reviewer PASS, all device-verified)
+
+### `hide-login-save-picture.yml`
+- No-relaunch: removed `runFlow: auth-boot-login.yml` + `setPermissions`; added fail-fast home assertions.
+- 3-step wizard: added Next → Next → confirm (describe → language → category steps in `SetInstructionScreen`/`ShowHideDescription`).
+- **Race fix:** explicit English selection at the language step (`setInstructions.language.button` → `setInstructions.language.option.en`) instead of relying on the async `getPreferredLanguage()` default. `handleNext`'s `languageMissing` guard blocked the 2nd Next while the AsyncStorage read hadn't resolved.
+
+### `guess-login-saved-picture-success.yml` + `guess-login-saved-picture-failure.yml`
+- No-relaunch: removed auth runFlow; added fail-fast home assertions.
+- **Swipe instead of tap:** replaced `tapOn guess-path.card.open.1` with `swipe guess-path.card.1 direction: RIGHT`. The card's parent `Animated.View` has a `PanResponder` that captures touch-move; maestro's tap on the E2E open-button Pressable does not reliably fire `onPress`, but a rightward swipe goes through the PanResponder as intended and fires `onSwipe` → `startGuessing` → GuessScreen.
+- Failure flow keeps `longPressOn game.picture.guess.surface` (E2E wrong-point trigger).
+
+### `hide-to-guess-to-result.yml`
+- Chains hide sub-flow (no-relaunch) → guess (swipe) → result.success → return_home.
+- **Ranking tail removed:** navigating to RankingScreen triggers a pre-existing unrelated app crash (open bug #4). Flow now ends at result.success + return_home. Comment in-file explains why.
+
+### `README.md`
+- Two-phase no-relaunch run model; purged broken `--env-file` references (use `-e`).
+- Updated Files-section bullets; kept Runtime Requirement + 3-step wizard note.
+
+## App bugs fixed this session (user-authorized; all jest green)
+
+1. **`utils/e2eMode.js` `buildE2ECategories`** — category `thumbnailUrl` was a raw `require()` (numeric asset id under Metro) → `CategoryChips.js:37` `<Image source={{uri: numeric}}>` crashed (`Value for uri cannot be cast from Double to String`). Fixed via `resolveLocalAsset(category.thumbnailUrl)?.uri ?? null`. 14/14 jest pass.
+2. **`components/UI/SwipeableCard.js` `e2eOpenButton`** — moved from top-right to bottom-right to stop colliding with the Expo Dev Client native "Tools" button (confirmed overlapping bounds `[949,219][1011,281]` vs `[895,239][1042,333]`). (Moot for the flows now that they swipe, but kept as a robustness fix.)
+3. **`utils/e2eMode.js` `buildE2EGuessCards` + `buildE2EGuessCardFromPayload`** — attached `hiddenLocation` as an own enumerable property on E2E cards. Was a field-name mismatch: `ImageModel` arg7 is `touchLocation`, but `GuessScreen` reads `route.params.hiddenLocation`; `{...item}` spread `touchLocation`, never `hiddenLocation`, so `isOnTarget` → `targetAbsoluteLocation(undefined)` crashed ("Cannot read property 'x' of undefined"). E2E-only; production computes server-side. 11/11 jest pass.
+
+## Open app bugs (NOT fixed — out of session scope / need user decision)
+
+4. **RankingScreen crash** (`hide-to-guess-to-result` ranking tail): `expo-file-system` `File.exists` called with a non-file URI → `java.lang.IllegalArgumentException: URI scheme is not "file"`. Origin: `utils/imagesRequests.js` (`File`/`Paths` from expo-file-system). Pre-existing, unrelated to hide/guess. Worked around by removing the ranking tail from the flow. Re-add the ranking tail once this app bug is fixed.
+
+5. **`RatingSubmissionBlock` validate button does not fire under Maestro** (rating+tag coverage blocked): on the success result screen, `result.rating.validate` (a Pressable, `enabled:true`, not inside a PanResponder) does not fire `onPress` under maestro's tap, so the rating is never submitted and `result.rating.success` never appears. The structurally-identical `result.rating.tags.add` Pressable DOES fire (tag chip appears). Setting the global rating works (the `StarRatingLine` PanResponder picks up the tap). Root cause unconfirmed — possibly a Pressable/accessibility quirk or a focus/keyboard interaction with the tag input. The rating+tag block was therefore reverted from both success flows. To re-add: investigate why validate's onPress doesn't fire under maestro while tag-add's does (compare the two Pressables — they look identical), or change the app to blur the tag input on add / make validate more robust to programmatic taps.
+
+## Open user requirement (explicitly requested, not yet met)
+
+- **"At the end of a successful, rate the enigma and add a tag."** — blocked by open app bug #5 above. The rating+tag steps were written and verified to work up to the tag-add (global rating set, tag chip appears) but cannot complete because validate doesn't fire. TestIDs mapped and ready to re-insert once #5 is resolved:
+  - `result.rating.block`, `result.rating.global.star.{1-5}` (PanResponder-driven), `result.rating.tags.input`, `result.rating.tags.add`, `result.rating.tags.chip.{name}`, `result.rating.validate`, `result.rating.success`.
+  - E2E stubs exist (`submitRating`, `addImageTag` in `utils/ratingRequests.js`).
+
+## E2E affordances (reference)
+
+- `guess-path.card.1` / `.card.saved` — saved-payload card (listId=1). Reach it via swipe, not the open button.
+- `guess-path.category.card.all` → `guess-path.button.start` (on SwipeInstructions, GuessFeedScreen) → swipe card.
+- `set-instructions.button.next` (×2, describe→lang→cat) with explicit `setInstructions.language.option.en` select, then `set-instructions.button.confirm-description`.
+- Language filter optional; flows skip it.
+
+## Next up
+
+1. Reconnect FP3 USB; reconnect dev client to Metro + log in to HomeScreen (Phase 1).
+2. Re-run the 4 flows in order to re-confirm all green (they were green before the disconnect).
+3. **Open user requirement — rating+tag:** investigate why `result.rating.validate` Pressable doesn't fire `onPress` under maestro's tap while the structurally-identical `result.rating.tags.add` does (open bug #5). Re-insert the rating+tag block into both success flows once resolved. TestIDs + verified-working-prefix already mapped (`result.rating.global.star.5` sets rating via the StarRatingLine PanResponder; `result.rating.tags.input`/`.add`/`.chip.e2e-tag` all work; only `.validate` + `.success` are blocked).
+4. Optionally fix open bug #4 (ranking `expo-file-system` File.exists crash in `utils/imagesRequests.js`) and re-add the ranking tail to `hide-to-guess-to-result.yml`.

--- a/.maestro/guess-next-card-from-category.yml
+++ b/.maestro/guess-next-card-from-category.yml
@@ -1,0 +1,135 @@
+appId: com.alegarn.WoIstWaldoProject
+---
+# DEVICE-LEVEL WIRING SMOKE for `result.button.next` ("Next Card") when the guess
+# session was entered via a SPECIFIC category (here: nature), instead of the
+# synthetic "all" category that the sibling guess-login-saved-picture-{success,
+# failure}.yml flows use.
+#
+# HONESTY NOTE — what this flow does NOT test (and why):
+# The category->"All" FALLBACK BOUNDARY inside resolveNextCard (the branch that,
+# once a specific category deck is exhausted, advances into the separate "All"
+# listId space) cannot be reached in Maestro/e2e mode. Concretely:
+#   1. AsyncStorage decks are never written in e2e mode (no real image fetch
+#      occurs; the deterministic stubs do not persist cursor/list state).
+#   2. The silent prefetch that would populate those decks is guarded by
+#      `!isE2EMode()` (SwipeImage prefetch gate), so both the specific-category
+#      list and the All list stay empty on device under EXPO_PUBLIC_E2E_MODE=true.
+#   3. Therefore resolveNextCard (utils/nextCardResolver.js) returns null for a
+#      specific category, and navigateToNextGuess (utils/guessNavigation.js)
+#      resets onto the 3-route feed stack ending on GuessFeedScreen — i.e. it
+#      lands on the re-seeded feed (guess-path.card.1), NOT on an All-fallback
+#      card. The boundary semantics are simply never exercised here.
+# That boundary logic IS covered, by Jest — not Maestro:
+#   - __tests__/nextCardResolver.test.js  (All-fallback branch + null return)
+#   - __tests__/guessNavigation.test.js   (reset stack shape per outcome)
+#
+# WHAT THIS FLOW DOES TEST:
+# That `result.button.next` is tappable on the FAILURE result screen when the
+# guess was entered via a real (non-"all") category, and that tapping it
+# navigates FORWARD off ResultScreen onto the next screen. That is a device-
+# level wiring smoke (category entry -> guess -> failure -> Next Card ->
+# forward navigation), NOT a test of the All-fallback semantics.
+#
+# Run assumptions:
+# - App already launched, connected to Metro, logged in, on HomeScreen.
+# - Run auth-boot-login.yml ONCE first. This flow does NOT re-launch (re-launch
+#   breaks the Metro JS bundle connection).
+# - Uses the deterministic FAILURE path (long-press on the guess surface) so
+#   result.button.next is reachable without the success rating gate
+#   (result.rating.global.star.* -> auto-submit).
+# - Uses the seeded fallback card (guess-path.card.1), so it does NOT depend on
+#   hide-login-save-picture.yml having run first; running it first is harmless
+#   and matches the documented phase-2 order.
+# Example: maestro test .maestro/guess-next-card-from-category.yml
+- extendedWaitUntil:
+    visible:
+      id: home.button.guess
+    timeout: 10000
+- assertVisible:
+    id: home.button.guess
+- assertVisible:
+    id: home.button.hide
+- tapOn:
+    id: home.button.guess
+# Enter via a SPECIFIC category (nature), NOT the synthetic .all card.
+- extendedWaitUntil:
+    visible:
+      id: guess-path.category.card.nature
+    timeout: 10000
+- tapOn:
+    id: guess-path.category.card.nature
+- extendedWaitUntil:
+    visible:
+      id: guess-path.button.start
+    timeout: 10000
+- tapOn:
+    id: guess-path.button.start
+- extendedWaitUntil:
+    visible:
+      id: guess-path.card.1
+    timeout: 10000
+- swipe:
+    elementIds:
+      - guess-path.card.1
+    direction: RIGHT
+- extendedWaitUntil:
+    visible:
+      id: game.instructions.guess.overlay
+    timeout: 10000
+- tapOn:
+    id: game.instructions.guess.overlay
+- extendedWaitUntil:
+    visible:
+      id: game.picture.guess-surface
+    timeout: 10000
+# Long press -> deterministic WRONG point (e2e-only) -> FAILURE result,
+# avoiding the success rating gate that would otherwise hide result.button.next.
+- longPressOn:
+    id: game.picture.guess-surface
+- extendedWaitUntil:
+    visible:
+      id: game.picture.clear-guess
+    timeout: 5000
+- tapOn:
+    id: game.picture.clear-guess
+- extendedWaitUntil:
+    visible:
+      id: game.picture.guess-modal.confirm
+    timeout: 5000
+- tapOn:
+    id: game.picture.guess-modal.confirm
+- extendedWaitUntil:
+    visible:
+      id: result.screen.failure
+    timeout: 10000
+- assertVisible:
+    id: result.screen.failure
+- assertVisible:
+    id: result.button.next
+- tapOn:
+    id: result.button.next
+# Landing assertion is an OR: in e2e the specific-category deck is empty (see
+# HONESTY NOTE), so resolveNextCard returns null and navigateToNextGuess resets
+# onto GuessFeedScreen -> guess-path.card.1 reappears (the expected branch).
+# game.instructions.guess.overlay is the wired-next-card branch (resolveNextCard
+# returned a card -> reset onto GuessScreen); it is NOT reachable in e2e today
+# but is kept as a robustness fallback. runFlow.when blocks skip silently when
+# their condition is unmet, so exactly one branch asserts; if both skip, the
+# button did nothing and return_home.yaml will still clean up (smoke trade-off).
+- runFlow:
+    when:
+      visible:
+        id: guess-path.card.1
+        timeout: 10000
+    commands:
+      - assertVisible:
+          id: guess-path.card.1
+- runFlow:
+    when:
+      visible:
+        id: game.instructions.guess.overlay
+        timeout: 5000
+    commands:
+      - assertVisible:
+          id: game.instructions.guess.overlay
+- runFlow: "_shared/return_home.yaml"

--- a/__tests__/SwipeImage.test.js
+++ b/__tests__/SwipeImage.test.js
@@ -327,6 +327,121 @@ describe('SwipeImage', () => {
     ], 'all', 'any');
   });
 
+  it('silently prefetches the all deck when the stack drops below four', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, imageFile: 'file:///1.jpg' },
+      { listId: 2, imageFile: 'file:///2.jpg' },
+      { listId: 3, imageFile: 'file:///3.jpg' },
+      { listId: 4, imageFile: 'file:///4.jpg' },
+    ]);
+    getLastImageId.mockResolvedValue(4);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const removableCard = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+    mockSwipeableCard.mockClear();
+
+    await act(async () => {
+      await removableCard.removeCard(1);
+      await flushEffects();
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      contextValue,
+      expect.objectContaining({ category_key: 'nature', category_id: 'cat-nature' }),
+    );
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      contextValue,
+      expect.objectContaining({ category_key: 'all', category_id: undefined }),
+    );
+  });
+
+  it('deduplicates the all-deck prefetch via allDeckWarmedRef on a second removal', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, imageFile: 'file:///1.jpg' },
+      { listId: 2, imageFile: 'file:///2.jpg' },
+      { listId: 3, imageFile: 'file:///3.jpg' },
+      { listId: 4, imageFile: 'file:///4.jpg' },
+    ]);
+    getLastImageId.mockResolvedValue(4);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const cardOne = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+    const cardTwo = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 2)[0];
+    mockSwipeableCard.mockClear();
+
+    await act(async () => {
+      await cardOne.removeCard(1);
+      await flushEffects();
+    });
+    await act(async () => {
+      await cardTwo.removeCard(2);
+      await flushEffects();
+    });
+
+    const allPrefetchCalls = getImages.mock.calls.filter(
+      ([, , params]) => params?.category_key === 'all' && params?.category_id === undefined,
+    );
+    expect(allPrefetchCalls).toHaveLength(1);
+  });
+
+  it('swallows all-deck prefetch errors without surfacing an Alert', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, imageFile: 'file:///1.jpg' },
+      { listId: 2, imageFile: 'file:///2.jpg' },
+      { listId: 3, imageFile: 'file:///3.jpg' },
+      { listId: 4, imageFile: 'file:///4.jpg' },
+    ]);
+    getLastImageId.mockResolvedValue(4);
+    getImages.mockImplementation((pictureId, authContext, params) => {
+      if (params?.category_key === 'all') {
+        return Promise.reject(new Error('all-deck warmup failed'));
+      }
+      return Promise.resolve({ isError: false, images: [] });
+    });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const removableCard = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+    mockSwipeableCard.mockClear();
+
+    await act(async () => {
+      await removableCard.removeCard(1);
+      await flushEffects();
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      contextValue,
+      expect.objectContaining({ category_key: 'all', category_id: undefined }),
+    );
+    expect(Alert.alert).not.toHaveBeenCalled();
+  });
+
+  it('skips the all-deck prefetch entirely in e2e mode', async () => {
+    isE2EMode.mockReturnValue(true);
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const removableCard = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+    mockSwipeableCard.mockClear();
+
+    await act(async () => {
+      await removableCard.removeCard(1);
+      await flushEffects();
+    });
+
+    const allPrefetchCalls = getImages.mock.calls.filter(
+      ([, , params]) => params?.category_key === 'all' && params?.category_id === undefined,
+    );
+    expect(allPrefetchCalls).toHaveLength(0);
+  });
+
   it('uses the seeded guess cards in e2e mode instead of cache or network state', async () => {
     isE2EMode.mockReturnValue(true);
 

--- a/__tests__/guessNavigation.test.js
+++ b/__tests__/guessNavigation.test.js
@@ -1,24 +1,25 @@
-jest.mock('../utils/storageDatum', () => ({
-  getNextImage: jest.fn(),
+jest.mock('../utils/nextCardResolver', () => ({
+  resolveNextCard: jest.fn(),
 }));
 
-import { getNextImage } from '../utils/storageDatum';
+import { resolveNextCard } from '../utils/nextCardResolver';
 import { navigateToNextGuess } from '../utils/guessNavigation';
+import { RECENT_ALL_CATEGORY } from '../constants/categories';
 
 describe('navigateToNextGuess', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('resets once to a clean stack with GuessScreen receiving the next item', async () => {
+  it('resets once to a clean stack with GuessScreen receiving the resolved card and original category', async () => {
     const navigation = { reset: jest.fn() };
     const category = { key: 'city' };
-    const item = {
+    const card = {
       listId: 7,
       imageFile: 'file:///cache/7.jpg',
       touchLocation: { x: 0.4, y: 0.6 },
     };
-    getNextImage.mockResolvedValueOnce(item);
+    resolveNextCard.mockResolvedValueOnce({ card, category });
 
     await navigateToNextGuess(navigation, {
       category,
@@ -27,7 +28,7 @@ describe('navigateToNextGuess', () => {
       isTutorial: true,
     });
 
-    expect(getNextImage).toHaveBeenCalledWith('city', 'fr', 5);
+    expect(resolveNextCard).toHaveBeenCalledWith({ category, language: 'fr', currentListId: 5, scope: undefined });
     expect(navigation.reset).toHaveBeenCalledTimes(1);
     expect(navigation.reset).toHaveBeenCalledWith({
       index: 3,
@@ -52,19 +53,56 @@ describe('navigateToNextGuess', () => {
     });
   });
 
-  it('falls back to the "all" category key when category is missing', async () => {
+  it('carries the resolved All category into both GuessScreen and the back-stack GuessFeedScreen on category exhaustion', async () => {
     const navigation = { reset: jest.fn() };
-    getNextImage.mockResolvedValueOnce({ listId: 1, hiddenLocation: { x: 0.1, y: 0.2 } });
+    const originalCategory = { key: 'city', id: 7 };
+    const allCard = {
+      listId: 1,
+      imageFile: 'file:///cache/all1.jpg',
+      hiddenLocation: { x: 0.2, y: 0.8 },
+    };
+    resolveNextCard.mockResolvedValueOnce({ card: allCard, category: RECENT_ALL_CATEGORY });
 
-    await navigateToNextGuess(navigation, { category: null, language: 'en' });
+    await navigateToNextGuess(navigation, {
+      category: originalCategory,
+      language: 'en',
+      currentListId: 9,
+      isTutorial: false,
+    });
 
-    expect(getNextImage).toHaveBeenCalledWith('all', 'en', undefined);
+    expect(resolveNextCard).toHaveBeenCalledWith({
+      category: originalCategory,
+      language: 'en',
+      currentListId: 9,
+      scope: undefined,
+    });
+    expect(navigation.reset).toHaveBeenCalledTimes(1);
+    expect(navigation.reset).toHaveBeenCalledWith({
+      index: 3,
+      routes: [
+        { name: 'HomeScreen' },
+        { name: 'GuessPathScreen', params: { isTutorial: false } },
+        { name: 'GuessFeedScreen', params: { category: RECENT_ALL_CATEGORY, language: 'en' } },
+        {
+          name: 'GuessScreen',
+          params: {
+            listId: 1,
+            imageFile: 'file:///cache/all1.jpg',
+            hiddenLocation: { x: 0.2, y: 0.8 },
+            category: RECENT_ALL_CATEGORY,
+            language: 'en',
+            isTutorial: false,
+            skipInstructions: true,
+          },
+        },
+      ],
+    });
   });
 
-  it('resets once to the 3-route feed stack when the deck is exhausted', async () => {
+  it('resets once to the 3-route feed stack rooted at the original category when both decks are exhausted', async () => {
     const navigation = { reset: jest.fn() };
     const category = { key: 'nature' };
-    getNextImage.mockResolvedValueOnce(null);
+    resolveNextCard.mockResolvedValueOnce(null);
 
     await navigateToNextGuess(navigation, {
       category,
@@ -73,7 +111,7 @@ describe('navigateToNextGuess', () => {
       isTutorial: false,
     });
 
-    expect(getNextImage).toHaveBeenCalledWith('nature', 'de', 9);
+    expect(resolveNextCard).toHaveBeenCalledWith({ category, language: 'de', currentListId: 9, scope: undefined });
     expect(navigation.reset).toHaveBeenCalledTimes(1);
     expect(navigation.reset).toHaveBeenCalledWith({
       index: 2,
@@ -89,11 +127,12 @@ describe('navigateToNextGuess', () => {
     const navigation = { reset: jest.fn() };
     const scope = { kind: 'private', groupId: 'g-1' };
     const category = { key: 'city' };
-    getNextImage.mockResolvedValueOnce({
+    const card = {
       listId: 7,
       imageFile: 'file:///cache/7.jpg',
       touchLocation: { x: 0.4, y: 0.6 },
-    });
+    };
+    resolveNextCard.mockResolvedValueOnce({ card, category });
 
     await navigateToNextGuess(navigation, {
       category,
@@ -127,11 +166,11 @@ describe('navigateToNextGuess', () => {
     });
   });
 
-  it('resets to a 4-route feed stack rooted at HomeScreen when private scope deck is exhausted', async () => {
+  it('resets to a 4-route feed stack rooted at HomeScreen when private scope decks are exhausted', async () => {
     const navigation = { reset: jest.fn() };
     const scope = { kind: 'private', groupId: 'g-1' };
     const category = { key: 'nature' };
-    getNextImage.mockResolvedValueOnce(null);
+    resolveNextCard.mockResolvedValueOnce(null);
 
     await navigateToNextGuess(navigation, {
       category,

--- a/__tests__/nextCardResolver.test.js
+++ b/__tests__/nextCardResolver.test.js
@@ -1,0 +1,106 @@
+jest.mock('../utils/storageDatum', () => ({
+  getNextImageForScope: jest.fn(),
+}));
+
+import { getNextImageForScope } from '../utils/storageDatum';
+import { resolveNextCard } from '../utils/nextCardResolver';
+import { RECENT_ALL_CATEGORY } from '../constants/categories';
+
+describe('resolveNextCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the in-category card with the original category and skips the All fallback', async () => {
+    const category = { key: 'city', id: 7 };
+    const card = { listId: 4, imageFile: 'file:///cache/4.jpg' };
+    getNextImageForScope.mockResolvedValueOnce(card);
+
+    const result = await resolveNextCard({ category, language: 'fr', currentListId: 3, scope: { kind: 'public' } });
+
+    expect(result).toEqual({ card, category });
+    expect(getNextImageForScope).toHaveBeenCalledTimes(1);
+    expect(getNextImageForScope).toHaveBeenCalledWith({
+      category,
+      language: 'fr',
+      currentListId: 3,
+      scope: { kind: 'public' },
+    });
+  });
+
+  it('falls back to the All deck with RECENT_ALL_CATEGORY when the category deck is exhausted', async () => {
+    const category = { key: 'city', id: 7 };
+    const allCard = { listId: 1, imageFile: 'file:///cache/all1.jpg' };
+    getNextImageForScope
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(allCard);
+
+    const result = await resolveNextCard({ category, language: 'fr', currentListId: 9, scope: { kind: 'public' } });
+
+    expect(result).toEqual({ card: allCard, category: RECENT_ALL_CATEGORY });
+    expect(getNextImageForScope).toHaveBeenCalledTimes(2);
+    expect(getNextImageForScope).toHaveBeenNthCalledWith(1, {
+      category,
+      language: 'fr',
+      currentListId: 9,
+      scope: { kind: 'public' },
+    });
+    expect(getNextImageForScope).toHaveBeenNthCalledWith(2, {
+      category: RECENT_ALL_CATEGORY,
+      language: 'fr',
+      currentListId: undefined,
+      scope: { kind: 'public' },
+    });
+  });
+
+  it('advances within All using the real currentListId (regression: must NOT always return images[0])', async () => {
+    const card = { listId: 12, imageFile: 'file:///cache/12.jpg' };
+    getNextImageForScope.mockResolvedValueOnce(card);
+
+    const result = await resolveNextCard({
+      category: RECENT_ALL_CATEGORY,
+      language: 'en',
+      currentListId: 11,
+      scope: { kind: 'public' },
+    });
+
+    expect(result).toEqual({ card, category: RECENT_ALL_CATEGORY });
+    expect(getNextImageForScope).toHaveBeenCalledTimes(1);
+    expect(getNextImageForScope).toHaveBeenCalledWith({
+      category: RECENT_ALL_CATEGORY,
+      language: 'en',
+      currentListId: 11,
+      scope: { kind: 'public' },
+    });
+  });
+
+  it('returns null when both the category deck and the All deck are empty', async () => {
+    getNextImageForScope
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    const result = await resolveNextCard({
+      category: { key: 'city', id: 7 },
+      language: 'en',
+      currentListId: 9,
+      scope: { kind: 'public' },
+    });
+
+    expect(result).toBeNull();
+    expect(getNextImageForScope).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null when already in All and the All deck is exhausted', async () => {
+    getNextImageForScope.mockResolvedValueOnce(null);
+
+    const result = await resolveNextCard({
+      category: RECENT_ALL_CATEGORY,
+      language: 'en',
+      currentListId: 99,
+      scope: { kind: 'public' },
+    });
+
+    expect(result).toBeNull();
+    expect(getNextImageForScope).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/storageDatum.test.js
+++ b/__tests__/storageDatum.test.js
@@ -4,6 +4,10 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   removeItem: jest.fn(),
 }));
 
+jest.mock('../services/groups/groupFeedCache', () => ({
+  readGroupFeedCache: jest.fn(),
+}));
+
 const mockDelete = jest.fn();
 let mockFileExists = true;
 
@@ -28,6 +32,7 @@ jest.mock('expo-file-system', () => {
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { File } from 'expo-file-system';
+import { readGroupFeedCache } from '../services/groups/groupFeedCache';
 
 import {
   clearE2EHiddenGuessCard,
@@ -38,6 +43,7 @@ import {
   getLastImageUuid,
   getLocalImages,
   getNextImage,
+  getNextImageForScope,
   getOnboardingCompleted,
   getPreferredLanguage,
   getSessionLanguageFilter,
@@ -60,6 +66,7 @@ describe('storageDatum utilities', () => {
     mockFileExists = true;
     AsyncStorage.setItem.mockResolvedValue(undefined);
     AsyncStorage.removeItem.mockResolvedValue(undefined);
+    readGroupFeedCache.mockReset();
   });
 
   it('reads the local image list and returns null when none is stored', async () => {
@@ -271,5 +278,104 @@ describe('storageDatum utilities', () => {
 
     AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([]));
     expect(await getNextImage('all', 'any')).toBeNull();
+  });
+
+  describe('getNextImageForScope', () => {
+    it('delegates to getNextImage on the public path and returns the next card', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([
+        { listId: 1, imageFile: 'file:///cache/1.jpg' },
+        { listId: 2, imageFile: 'file:///cache/2.jpg' },
+      ]));
+
+      const card = await getNextImageForScope({ category: { key: 'all' }, language: 'any', currentListId: 1, scope: { kind: 'public' } });
+
+      expect(card).toEqual({ listId: 2, imageFile: 'file:///cache/2.jpg' });
+      expect(readGroupFeedCache).not.toHaveBeenCalled();
+    });
+
+    it('returns null on the public path when the deck is exhausted', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([
+        { listId: 1, imageFile: 'file:///cache/1.jpg' },
+      ]));
+
+      const card = await getNextImageForScope({ category: { key: 'all' }, language: 'any', currentListId: 5, scope: { kind: 'public' } });
+
+      expect(card).toBeNull();
+    });
+
+    it('reads the private group feed cache and returns the next card for a private scope', async () => {
+      readGroupFeedCache.mockResolvedValueOnce({
+        images: [
+          { listId: 1, imageFile: 'file:///cache/p1.jpg' },
+          { listId: 2, imageFile: 'file:///cache/p2.jpg' },
+        ],
+        nextCursor: null,
+      });
+
+      const card = await getNextImageForScope({
+        category: { key: 'city', id: 7 },
+        language: 'fr',
+        currentListId: 1,
+        scope: { kind: 'private', groupId: 'g-3' },
+      });
+
+      expect(card).toEqual({ listId: 2, imageFile: 'file:///cache/p2.jpg' });
+      expect(readGroupFeedCache).toHaveBeenCalledWith('g-3', { categoryId: 7, language: 'fr' });
+    });
+
+    it('returns null for a private scope when no card has a greater listId', async () => {
+      readGroupFeedCache.mockResolvedValueOnce({
+        images: [{ listId: 1, imageFile: 'file:///cache/p1.jpg' }],
+        nextCursor: null,
+      });
+
+      const card = await getNextImageForScope({
+        category: { key: 'city', id: 7 },
+        language: 'fr',
+        currentListId: 9,
+        scope: { kind: 'private', groupId: 'g-3' },
+      });
+
+      expect(card).toBeNull();
+    });
+
+    it('returns null for a private scope when the cache is empty or missing', async () => {
+      readGroupFeedCache.mockResolvedValueOnce({ images: [], nextCursor: null });
+      const cardEmpty = await getNextImageForScope({
+        category: { key: 'all' },
+        language: 'fr',
+        currentListId: 1,
+        scope: { kind: 'private', groupId: 'g-3' },
+      });
+      expect(cardEmpty).toBeNull();
+
+      readGroupFeedCache.mockResolvedValueOnce(null);
+      const cardMissing = await getNextImageForScope({
+        category: { key: 'all' },
+        language: 'fr',
+        currentListId: 1,
+        scope: { kind: 'private', groupId: 'g-3' },
+      });
+      expect(cardMissing).toBeNull();
+    });
+
+    it('returns the first image for a private scope when currentListId is not finite', async () => {
+      readGroupFeedCache.mockResolvedValueOnce({
+        images: [
+          { listId: 7, imageFile: 'file:///cache/p7.jpg' },
+          { listId: 8, imageFile: 'file:///cache/p8.jpg' },
+        ],
+        nextCursor: null,
+      });
+
+      const card = await getNextImageForScope({
+        category: { key: 'all' },
+        language: 'fr',
+        currentListId: undefined,
+        scope: { kind: 'private', groupId: 'g-3' },
+      });
+
+      expect(card).toEqual({ listId: 7, imageFile: 'file:///cache/p7.jpg' });
+    });
   });
 });

--- a/components/UI/SwipeImage.js
+++ b/components/UI/SwipeImage.js
@@ -7,12 +7,12 @@ import SwipeableCard from './SwipeableCard';
 import LoadingOverlay from './LoadingOverlay';
 import useBadgeDetail from './useBadgeDetail';
 
-import { getImages } from '../../utils/imagesRequests';
-import { getE2EHiddenGuessCard, getLocalImages, storeImageList, getLastImageId, emptyImageList, removeImageFromList, updateImageList, getLastImageUuid, saveLastImageUuid, deleteImageFromStorage } from '../../utils/storageDatum';
+import { getE2EHiddenGuessCard, getLocalImages, getLastImageId, emptyImageList, removeImageFromList, updateImageList, saveLastImageUuid, deleteImageFromStorage } from '../../utils/storageDatum';
 import { AuthContext } from '../../store/auth-context';
 import { buildE2EGuessCardFromPayload, buildE2EGuessCards, isE2EMode } from '../../utils/e2eMode';
 import { GlobalStyle } from '../../constants/theme';
 import { readGroupFeedCache, writeGroupFeedCache } from '../../services/groups/groupFeedCache';
+import { fetchCardBatch, persistCardBatch } from '../../services/cardDeck';
 /* https://snack.expo.dev/embedded/@aboutreact/tinder-like-swipeable-card-example?preview=true&platform=ios&iframeId=0kofaqg0vl&theme=dark */
 
 export default function SwipeImage({ screenWidth, screenHeight, startGuessing, category, language, onOpenFilter, scope }) {
@@ -34,6 +34,8 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
 
   const asyncImagesAreLoadingRef = useRef(false);
   asyncImagesAreLoadingRef.current = asyncImagesAreLoading;
+
+  const allDeckWarmedRef = useRef(false);
 
   // Functions __________________________________________________________________
 
@@ -58,15 +60,13 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
 
     if (currentImageList === null) {
       console.log("updatedImageList handleData imageList null");
-      if (isPrivateScope) {
-        await writeGroupFeedCache(
-          privateGroupId,
-          { categoryId: category?.id === 'all' ? undefined : category?.id, language: lang },
-          { images: updatedImageList, nextCursor: null },
-        );
-      } else {
-        await storeImageList(updatedImageList, categoryKey, lang);
-      }
+      await persistCardBatch({
+        cards: updatedImageList,
+        categoryKey,
+        categoryId: category?.id,
+        language: lang,
+        scope,
+      });
       setImageList(updatedImageList);
 
       if (updatedImageList?.length > 0) {
@@ -82,15 +82,18 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       console.log("updatedImageList handleData imageList !== null");
 
       if (updatedImageList?.length > 0) {
-        const newImageList = isPrivateScope
-          ? [...currentImageList, ...updatedImageList]
-          : await updateImageList(updatedImageList, categoryKey, lang);
+        let newImageList;
         if (isPrivateScope) {
-          await writeGroupFeedCache(
-            privateGroupId,
-            { categoryId: category?.id === 'all' ? undefined : category?.id, language: lang },
-            { images: newImageList, nextCursor: null },
-          );
+          newImageList = [...currentImageList, ...updatedImageList];
+          await persistCardBatch({
+            cards: newImageList,
+            categoryKey,
+            categoryId: category?.id,
+            language: lang,
+            scope,
+          });
+        } else {
+          newImageList = await updateImageList(updatedImageList, categoryKey, lang);
         }
         setImageList(newImageList);
         return true
@@ -98,17 +101,17 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
 
       return false
     };
-  }, [category?.id, categoryKey, isPrivateScope, lang, privateGroupId]);
+  }, [category?.id, categoryKey, isPrivateScope, lang, scope]);
 
   const loadNewImages = useCallback(async (pictureIdOverride) => {
     console.log("loadNewImages");
-    const lastImageUuid = await getLastImageUuid(categoryKey, lang);
-    const pictureId = pictureIdOverride !== undefined ? pictureIdOverride : lastImageUuid;
-    const response = await getImages(pictureId, context, {
-      category_id: category?.id === 'all' ? undefined : category?.id,
-      category_key: category?.key || 'all',
+    const response = await fetchCardBatch({
+      categoryKey,
+      categoryId: category?.id,
       language,
       scope,
+      authContext: context,
+      pictureIdOverride,
     });
 
     if (response.isError === true) {
@@ -120,7 +123,7 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       const isCardLeft = await handleData(response.images);
       return isCardLeft;
     };
-  }, [context, handleData, category, language, categoryKey, lang]);
+  }, [context, handleData, category, language, categoryKey]);
 
   /* centralized function for loading images / set when imgs are loading */
   const handleImagesLoading = useCallback(async (pictureIdOverride) => {
@@ -211,9 +214,21 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       if (updatedImageList?.length < 4 && !asyncImagesAreLoadingRef.current) {
         await handleImagesLoading();
       }
+
+      if (updatedImageList?.length < 4
+        && !asyncImagesAreLoadingRef.current
+        && !isE2EMode()
+        && !allDeckWarmedRef.current) {
+        allDeckWarmedRef.current = true;
+        fetchCardBatch({ categoryKey: 'all', language, scope, authContext: context })
+          .then((r) => (r && !r.isError && r.images?.length
+            ? persistCardBatch({ cards: r.images, categoryKey: 'all', language, scope })
+            : null))
+          .catch(() => {});
+      }
       return null;
     },
-    [category?.id, deleteImage, handleImagesLoading, isPrivateScope, lang, privateGroupId]
+    [category?.id, context, deleteImage, handleImagesLoading, isPrivateScope, lang, language, privateGroupId, scope]
   );
 
   // Effects __________________________________________________________________

--- a/constants/categories.js
+++ b/constants/categories.js
@@ -1,0 +1,1 @@
+export const RECENT_ALL_CATEGORY = { id: 'all', key: 'all', name: 'Recent/All', count: undefined };

--- a/screens/GuessScreens/GuessPathScreen.js
+++ b/screens/GuessScreens/GuessPathScreen.js
@@ -31,12 +31,8 @@ import {
   listGroupCategories,
 } from '../../services/groups/groupCategoriesApi';
 
-const RECENT_ALL_CATEGORY = {
-  id: 'all',
-  key: 'all',
-  name: 'Recent/All',
-  count: undefined,
-};
+import { RECENT_ALL_CATEGORY } from '../../constants/categories';
+export { RECENT_ALL_CATEGORY };
 
 const DEFAULT_LANGUAGE = 'en';
 const NAVIGATION_ANY_LANGUAGE = 'any';

--- a/services/cardDeck.js
+++ b/services/cardDeck.js
@@ -1,0 +1,44 @@
+import { getImages } from '../utils/imagesRequests';
+import { getLastImageUuid, storeImageList } from '../utils/storageDatum';
+import { writeGroupFeedCache } from './groups/groupFeedCache';
+
+function normalizeLanguage(language) {
+  return language || 'any';
+}
+
+function resolveCategoryId(categoryId) {
+  return categoryId === 'all' ? undefined : categoryId;
+}
+
+function isPrivateScope(scope) {
+  return !!scope && scope.kind === 'private' && !!scope.groupId;
+}
+
+export async function fetchCardBatch({ categoryKey, categoryId, language, scope, authContext, pictureIdOverride } = {}) {
+  const lang = normalizeLanguage(language);
+  const lastImageUuid = await getLastImageUuid(categoryKey, lang);
+  const pictureId = pictureIdOverride !== undefined ? pictureIdOverride : lastImageUuid;
+
+  return getImages(pictureId, authContext, {
+    category_id: resolveCategoryId(categoryId),
+    category_key: categoryKey || 'all',
+    language,
+    scope,
+  });
+}
+
+export async function persistCardBatch({ cards, categoryKey, categoryId, language, scope } = {}) {
+  const lang = normalizeLanguage(language);
+
+  if (isPrivateScope(scope)) {
+    await writeGroupFeedCache(
+      scope.groupId,
+      { categoryId: resolveCategoryId(categoryId), language: lang },
+      { images: cards, nextCursor: null },
+    );
+    return null;
+  }
+
+  await storeImageList(cards, categoryKey, lang);
+  return null;
+}

--- a/utils/guessNavigation.js
+++ b/utils/guessNavigation.js
@@ -1,21 +1,22 @@
-import { getNextImage } from './storageDatum';
+import { resolveNextCard } from './nextCardResolver';
 
 /**
- * Resolve the next playable card from the persisted deck and reset to a clean
- * navigation stack so Back from GuessScreen lands on the feed (decision D3).
- * Mirrors the GuessScreen param contract of GuessFeedScreen.startGuessing
- * (spread item, hiddenLocation alias, category, language) so it lives in one place.
- * Always navigates: when a next card is resolved it resets to a 4-route stack
- * ending on GuessScreen; when the deck is exhausted it resets to a 3-route
- * feed stack ending on GuessFeedScreen. Both stacks end on a Back-to-feed target.
+ * Resolve the next playable card (read-only resolver: AsyncStorage + private
+ * cache only, no network) and reset to a clean navigation stack so Back from
+ * GuessScreen lands on the feed (decision D3). Mirrors the GuessScreen param
+ * contract of GuessFeedScreen.startGuessing (spread item, hiddenLocation alias,
+ * category, language) so it lives in one place. Always navigates: when a next
+ * card is resolved it resets to a 4-route stack ending on GuessScreen; when the
+ * deck is exhausted it resets to a 3-route feed stack ending on GuessFeedScreen.
+ * The resolved category is carried in BOTH GuessScreen and the back-stack
+ * GuessFeedScreen so Back from an "All" card lands on an "All" feed.
  */
 export async function navigateToNextGuess(navigation, { category, language, currentListId, isTutorial, scope }) {
-  const categoryKey = category?.key || 'all';
   const isPrivateScope = scope?.kind === 'private';
 
-  const item = await getNextImage(categoryKey, language, currentListId);
+  const result = await resolveNextCard({ category, language, currentListId, scope });
 
-  if (!item) {
+  if (!result) {
     const homeRoute = isPrivateScope
       ? { name: 'PrivateHomeScreen', params: { scope } }
       : { name: 'HomeScreen' };
@@ -35,6 +36,7 @@ export async function navigateToNextGuess(navigation, { category, language, curr
     return;
   }
 
+  const feedCategory = result.category;
   const homeRoute = isPrivateScope
     ? { name: 'PrivateHomeScreen', params: { scope } }
     : { name: 'HomeScreen' };
@@ -42,12 +44,12 @@ export async function navigateToNextGuess(navigation, { category, language, curr
     ? { name: 'GuessPathScreen', params: { isTutorial, scope } }
     : { name: 'GuessPathScreen', params: { isTutorial } };
   const feedRoute = isPrivateScope
-    ? { name: 'GuessFeedScreen', params: { category, language, scope } }
-    : { name: 'GuessFeedScreen', params: { category, language } };
+    ? { name: 'GuessFeedScreen', params: { category: feedCategory, language, scope } }
+    : { name: 'GuessFeedScreen', params: { category: feedCategory, language } };
   const guessParams = {
-    ...item,
-    hiddenLocation: item?.hiddenLocation ?? item?.touchLocation,
-    category,
+    ...result.card,
+    hiddenLocation: result.card?.hiddenLocation ?? result.card?.touchLocation,
+    category: result.category,
     language,
     isTutorial,
     skipInstructions: true,

--- a/utils/nextCardResolver.js
+++ b/utils/nextCardResolver.js
@@ -1,0 +1,28 @@
+import { RECENT_ALL_CATEGORY } from '../constants/categories';
+import { getNextImageForScope } from './storageDatum';
+
+/**
+ * Read-only orchestrator: pick the deck to advance in.
+ * - In "All" → advance WITHIN All using the real cursor (else first-card loop).
+ * - In a real category → try it; on the category/All boundary pass undefined so
+ *   the separate All listId space starts at its first card.
+ * Returns { card, category } | null. Never mutates, never fetches.
+ */
+export async function resolveNextCard({ category, language, currentListId, scope }) {
+  const inAll = category?.key === 'all';
+  if (inAll) {
+    const card = await getNextImageForScope({ category, language, currentListId, scope });
+    return card ? { card, category } : null;
+  }
+
+  const cat = await getNextImageForScope({ category, language, currentListId, scope });
+  if (cat) return { card: cat, category };
+
+  const allCard = await getNextImageForScope({
+    category: RECENT_ALL_CATEGORY,
+    language,
+    currentListId: undefined,
+    scope,
+  });
+  return allCard ? { card: allCard, category: RECENT_ALL_CATEGORY } : null;
+}

--- a/utils/storageDatum.js
+++ b/utils/storageDatum.js
@@ -1,5 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { File, Paths } from "expo-file-system";
+import { readGroupFeedCache } from "../services/groups/groupFeedCache";
 
 const E2E_HIDDEN_GUESS_CARD_KEY = 'e2eHiddenGuessCard';
 const SESSION_LANGUAGE_FILTER_KEY = 'sessionLanguageFilter';
@@ -55,6 +56,32 @@ export async function getLocalImages(categoryKey, language) {
  */
 export async function getNextImage(categoryKey, language, currentListId) {
   const images = await getLocalImages(categoryKey, language);
+  if (!Array.isArray(images) || images.length === 0) {
+    return null;
+  }
+
+  if (Number.isFinite(currentListId)) {
+    return images.find((image) => image?.listId > currentListId) ?? null;
+  }
+
+  return images[0];
+};
+
+/**
+ * Scope-aware next-card reader. Public scope delegates to getNextImage; private
+ * scope reads the group feed cache instead (mirrors SwipeImage's derivation:
+ * categoryId is undefined for "all", otherwise the numeric category id).
+ * Read-only.
+ */
+export async function getNextImageForScope({ category, language, currentListId, scope }) {
+  const isPrivate = scope?.kind === 'private' && scope?.groupId;
+  if (!isPrivate) {
+    return getNextImage(category?.key || 'all', language, currentListId);
+  }
+
+  const categoryId = category?.key === 'all' ? undefined : category?.id;
+  const cache = await readGroupFeedCache(scope.groupId, { categoryId, language });
+  const images = cache?.images;
   if (!Array.isArray(images) || images.length === 0) {
     return null;
   }


### PR DESCRIPTION
- Add `guess-next-card-from-category.yml` for testing navigation from a specific category to the next card.
- Enhance `SwipeImage` component to prefetch the "all" deck when the card stack is low and handle image loading accordingly.
- Refactor `navigateToNextGuess` to utilize `resolveNextCard` for determining the next card based on category and scope.
- Introduce `nextCardResolver.js` to manage logic for resolving the next card from either a specific category or the "all" category.
- Update `storageDatum.js` to include `getNextImageForScope` for scope-aware image retrieval.
- Create `cardDeck.js` service for fetching and persisting card batches based on category and scope.
- Add `RECENT_ALL_CATEGORY` constant for consistent handling of the "all" category across the application.
- Update tests to cover new functionality and ensure proper behavior in both public and private scopes.