### PR TITLE
Fix/private categories

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -10,6 +10,8 @@ This directory contains login-first Maestro flows for the deterministic app runt
 - `guess-login-saved-picture-failure.yml`: assumes an already-connected, logged-in session on HomeScreen; opens the guess path, reuses the saved hide payload, long-presses the guess surface to select the E2E wrong point, verifies the failure result actions, then uses `Next Card` to confirm direct continuation into the next guess.
 - `hide-to-guess-to-result.yml`: assumes an already-connected, logged-in session on HomeScreen; runs the deterministic hide -> guess -> ranking journey using the saved hide payload bridge.
 - `auth-boot-signup.yml`: signup smoke flow that generates unique credentials at runtime so it can be rerun without email or username collisions.
+- `private-manage-mode-smoke.yml`: NON-destructive smoke of the owner-only private category manage UI. Switches to a private group, opens the GuessPathScreen "manage" modal, asserts the Update-images / Delete-categories options, and that the per-card pencil / trash icons appear only in the chosen mode. Never taps a pencil/trash. See "Private group flows" below for preconditions.
+- `private-category-delete.yml`: DESTRUCTIVE smoke of the owner-only Delete-categories path. Manage → delete mode → tap the first card's trash → confirm the system Alert → assert the grid reloaded with the category removed. Issues a real backend DELETE (category CRUD is not stubbed). See "Private group flows" below for preconditions.
 - `e2e.env.example.yaml`: sample Maestro flow variables only.
 
 ## Runtime Requirement
@@ -82,6 +84,25 @@ maestro test .maestro/hide-to-guess-to-result.yml
 ```
 
 These flows take no env vars.
+
+### Private group flows
+
+The two `private-*.yml` flows exercise the owner-only category manage UI on a **private** group's GuessPathScreen. Unlike the public flows above, the private surface is NOT reachable from the default seeded state — these preconditions must hold on the device before running them (after the Phase 1 login):
+
+- The logged-in account **owns** at least one private group.
+- `private-category-delete.yml` requires that group to have **≥ 2 owner-created categories** (it deletes one and asserts a trash icon remains for the reload).
+- The app is on HomeScreen at flow start.
+
+Notes:
+- These flows inline their own private→public cleanup (switch-to-public) because `_shared/return_home.yaml` is tuned for the public stack (it asserts `home.button.ranking` directly).
+- `private-category-delete.yml` is **destructive**: category CRUD is not stubbed by e2e mode, so it issues a real backend `DELETE` and the test account loses one category per run. Reseed as needed.
+- Per-card pencil/trash testIDs embed the category UUID, so the flows target the first match via regex (`guess-path.category.edit.*` / `guess-path.category.delete.*`); they do not assert a named category. Precise handler assertions live in `__tests__/GuessPathScreen.test.js`.
+- The category-thumbnail picker has no e2e bypass, so the update-image path is covered only up to "pencil icon appears in update mode"; a full thumbnail-swap device test needs an e2e hook in `categoryThumbnailUpload.js`.
+
+```bash
+maestro test .maestro/private-manage-mode-smoke.yml
+maestro test .maestro/private-category-delete.yml
+```
 
 The Android app id is `com.alegarn.WoIstWaldoProject`.
 

--- a/.maestro/private-category-delete.yml
+++ b/.maestro/private-category-delete.yml
@@ -1,0 +1,135 @@
+appId: com.alegarn.WoIstWaldoProject
+---
+# PRIVATE CATEGORY DELETE (destructive device smoke).
+# Assesses the owner-only Delete-categories path end-to-end: manage → delete mode →
+# tap a card's trash → confirm the system Alert → the category is removed and the
+# grid reloads (manage mode stays active).
+#
+# DESTRUCTIVE — BACKEND MUTATION: category CRUD is NOT stubbed by e2e mode (only
+# image upload / ranking / score / guess-card are). Tapping confirm issues a real
+# DELETE /private_groups/:id/categories/:id against the configured backend and
+# permanently removes one category (plus its thumbnail image row + storage object).
+# The test account loses one category each run — ensure the owned group has enough
+# categories to absorb repeated runs, or reseed between runs.
+#
+# PRECONDITIONS (NOT seeded by the public e2e suite — must hold on device):
+#  - Account is logged in and OWNS the active private group.
+#  - That group has AT LEAST 2 owner-created categories (so after deleting one, at
+#    least one trash icon remains to assert the reload against, and the grid is not
+#    emptied).
+#  - App is on HomeScreen at flow start (run auth-boot-login.yml once first).
+#  - EXPO_PUBLIC_E2E_MODE=true in the bundle.
+#
+# HONESTY NOTE:
+#  - Per-card trash testID embeds the category UUID (guess-path.category.delete.{uuid}).
+#    This flow taps the FIRST match via regex (.*) — i.e. deletes the first deletable
+#    category in sort order, not a named one. A precise "this specific category was
+#    deleted" assertion is not feasible in Maestro with dynamic UUIDs; the handler
+#    unit tests (__tests__/GuessPathScreen.test.js) cover that precisely.
+#  - The confirm dialog is a React Native Alert.alert (SYSTEM dialog). Maestro taps
+#    its button by visible text (^Delete$), not by testID.
+#  - Private-stack cleanup is inlined (see smoke flow for the same rationale).
+#
+# Example: maestro test .maestro/private-category-delete.yml
+
+# --- fail fast: must be on public HomeScreen ---
+- extendedWaitUntil:
+    visible:
+      id: home.button.guess
+    timeout: 10000
+- assertVisible:
+    id: home.button.guess
+
+# --- switch to private scope (open first group if no active group) ---
+- tapOn:
+    id: home.header.other-options
+- extendedWaitUntil:
+    visible:
+      id: home.menu.scope-toggle
+    timeout: 5000
+- tapOn:
+    id: home.menu.scope-toggle
+- runFlow:
+    when:
+      visible:
+        id: groups-list.container
+        timeout: 5000
+    commands:
+      - tapOn:
+          id: groups-list.button.open.*
+      - extendedWaitUntil:
+          visible:
+            id: private-home.title
+          timeout: 10000
+- extendedWaitUntil:
+    visible:
+      id: private-home.title
+    timeout: 10000
+
+# --- enter private GuessPathScreen ---
+- tapOn:
+    id: private-home.button.find
+- extendedWaitUntil:
+    visible:
+      id: guess-path.category.grid
+    timeout: 10000
+
+# --- manage → delete mode ---
+- tapOn:
+    id: guess-path.button.manage
+- extendedWaitUntil:
+    visible:
+      id: guess-path.manage.option.delete
+    timeout: 5000
+- tapOn:
+    id: guess-path.manage.option.delete
+- extendedWaitUntil:
+    visible:
+      id: guess-path.category.delete.*
+    timeout: 5000
+
+# --- tap the first trash, then confirm the system Alert (^Delete$ exact) ---
+- tapOn:
+    id: guess-path.category.delete.*
+- extendedWaitUntil:
+    visible:
+      text: ^Delete$
+    timeout: 5000
+- tapOn:
+    text: ^Delete$
+
+# --- assert the grid reloaded and manage mode stayed active (a trash icon is still
+#     visible for the remaining categories). Proves DELETE succeeded + reloadCategories
+#     ran. Requires the >=2 categories precondition so one trash remains. ---
+- extendedWaitUntil:
+    visible:
+      id: guess-path.category.delete.*
+    timeout: 10000
+- assertVisible:
+    id: guess-path.category.delete.*
+
+# --- exit manage mode ---
+- tapOn:
+    id: guess-path.button.manage-done
+
+# --- cleanup: private stack → public HomeScreen ---
+- runFlow:
+    when:
+      visible:
+        id: guess-path.button.home
+        timeout: 5000
+    commands:
+      - tapOn:
+          id: guess-path.button.home
+- runFlow:
+    when:
+      visible:
+        id: private-home.button.switch-to-public
+        timeout: 5000
+    commands:
+      - tapOn:
+          id: private-home.button.switch-to-public
+- extendedWaitUntil:
+    visible:
+      id: home.button.ranking
+    timeout: 10000

--- a/.maestro/private-manage-mode-smoke.yml
+++ b/.maestro/private-manage-mode-smoke.yml
@@ -1,0 +1,143 @@
+appId: com.alegarn.WoIstWaldoProject
+---
+# PRIVATE CATEGORY MANAGE-MODE SMOKE (non-destructive).
+# Assesses the owner-only "manage" UI added to the private GuessPathScreen: the
+# manage button, its Update-images / Delete-categories options, and that the
+# per-card pencil / trash icons appear only in the chosen mode.
+#
+# NON-DESTRUCTIVE: only enters modes and asserts icons appear; never taps a
+# pencil/trash, so no category or thumbnail is changed. Pair with
+# private-category-delete.yml for the destructive delete path.
+#
+# PRECONDITIONS (NOT seeded by the public e2e suite — must hold on device):
+#  - Account is logged in and OWNS at least one private group.
+#  - That group has at least one owner-created category (so a per-card icon renders).
+#  - App is on HomeScreen at flow start (run auth-boot-login.yml once first).
+#  - EXPO_PUBLIC_E2E_MODE=true in the bundle.
+#
+# HONESTY NOTE — what this flow does NOT cover:
+#  - Actual thumbnail upload: the category-thumbnail picker (categoryThumbnailUpload.js)
+#    has NO e2e bypass (unlike the hide flow's LogicalImagePicker), so an Update-images
+#    tap cannot complete a real upload under EXPO_PUBLIC_E2E_MODE=true. This flow stops
+#    at "pencil icon is shown in update mode". Add an e2e hook to categoryThumbnailUpload
+#    to test the full swap on device.
+#  - Per-card testIDs embed the category UUID (guess-path.category.edit.{uuid} /
+#    delete.{uuid}); this flow targets the FIRST match via regex (.*) and does not
+#    assert a specific category.
+#  - Private-stack cleanup is inlined (the shared return_home.yaml is tuned for the
+#    public stack and asserts home.button.ranking directly).
+#
+# Example: maestro test .maestro/private-manage-mode-smoke.yml
+
+# --- fail fast: must be on public HomeScreen ---
+- extendedWaitUntil:
+    visible:
+      id: home.button.guess
+    timeout: 10000
+- assertVisible:
+    id: home.button.guess
+
+# --- open the header menu and switch to private scope ---
+- tapOn:
+    id: home.header.other-options
+- extendedWaitUntil:
+    visible:
+      id: home.menu.scope-toggle
+    timeout: 5000
+- tapOn:
+    id: home.menu.scope-toggle
+
+# If no active group is set, scope-toggle lands on GroupsListScreen — open the first.
+- runFlow:
+    when:
+      visible:
+        id: groups-list.container
+        timeout: 5000
+    commands:
+      - tapOn:
+          id: groups-list.button.open.*        # first owned/joined group (Open button)
+      - extendedWaitUntil:
+          visible:
+            id: private-home.title
+          timeout: 10000
+
+# Went straight to PrivateHomeScreen (active group already set) — wait for it.
+- extendedWaitUntil:
+    visible:
+      id: private-home.title
+    timeout: 10000
+
+# --- enter the private GuessPathScreen (Find) ---
+- tapOn:
+    id: private-home.button.find
+- extendedWaitUntil:
+    visible:
+      id: guess-path.category.grid
+    timeout: 10000
+
+# --- open the owner manage modal ---
+- tapOn:
+    id: guess-path.button.manage
+- extendedWaitUntil:
+    visible:
+      id: guess-path.manage.option.delete
+    timeout: 5000
+- assertVisible:
+    id: guess-path.manage.option.update
+- assertVisible:
+    id: guess-path.manage.option.delete
+
+# --- pick DELETE mode: a trash icon must appear on a deletable card ---
+- tapOn:
+    id: guess-path.manage.option.delete
+- extendedWaitUntil:
+    visible:
+      id: guess-path.category.delete.*
+    timeout: 5000
+- assertVisible:
+    id: guess-path.category.delete.*
+
+# --- reopen manage, pick UPDATE mode: a pencil must appear instead ---
+- tapOn:
+    id: guess-path.button.manage
+- extendedWaitUntil:
+    visible:
+      id: guess-path.manage.option.update
+    timeout: 5000
+- tapOn:
+    id: guess-path.manage.option.update
+- extendedWaitUntil:
+    visible:
+      id: guess-path.category.edit.*
+    timeout: 5000
+- assertVisible:
+    id: guess-path.category.edit.*
+
+# --- exit manage mode via Done ---
+- tapOn:
+    id: guess-path.button.manage-done
+
+# --- cleanup: unwind private stack back to public HomeScreen ---
+# E2E home button pops the private stack to its root (PrivateHomeScreen).
+- runFlow:
+    when:
+      visible:
+        id: guess-path.button.home
+        timeout: 5000
+    commands:
+      - tapOn:
+          id: guess-path.button.home
+# PrivateHomeScreen → switch back to public.
+- runFlow:
+    when:
+      visible:
+        id: private-home.button.switch-to-public
+        timeout: 5000
+    commands:
+      - tapOn:
+          id: private-home.button.switch-to-public
+# Back on public HomeScreen.
+- extendedWaitUntil:
+    visible:
+      id: home.button.ranking
+    timeout: 10000

--- a/__tests__/GuessCategoryCard.test.js
+++ b/__tests__/GuessCategoryCard.test.js
@@ -22,7 +22,7 @@ describe('GuessCategoryCard', () => {
     name: 'Nature',
   };
 
-  const thumbnailUrl = { uri: 'file:///nature.jpg' };
+  const thumbnailUrl = 'file:///nature.jpg';
 
   async function renderCard(overrides = {}) {
     let renderer;
@@ -89,7 +89,7 @@ describe('GuessCategoryCard', () => {
 
     const image = renderer.root.findByType('ImageBackground');
 
-    expect(image.props.source).toBe('https://example/x.png');
+    expect(image.props.source).toEqual({ uri: 'https://example/x.png' });
   });
 
   it('renders the fallback view when the key is unknown and thumbnailUrl is missing', async () => {

--- a/__tests__/GuessPathScreen.test.js
+++ b/__tests__/GuessPathScreen.test.js
@@ -64,6 +64,7 @@ jest.mock('../services/groups/groupCategoriesApi', () => ({
   listGroupCategories: jest.fn(),
   createGroupCategory: jest.fn(),
   updateGroupCategory: jest.fn(),
+  deleteGroupCategory: jest.fn(),
 }));
 
 jest.mock('../services/groups/groupCategoryThumbnails', () => ({
@@ -84,7 +85,7 @@ jest.mock('../store/auth-context', () => {
 });
 
 import React from 'react';
-import { Dimensions } from 'react-native';
+import { Alert, Dimensions } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
 import GuessPathScreen from '../screens/GuessScreens/GuessPathScreen';
@@ -97,6 +98,7 @@ import {
 import { isE2EMode } from '../utils/e2eMode';
 import {
   createGroupCategory,
+  deleteGroupCategory,
   listGroupCategories,
   updateGroupCategory,
 } from '../services/groups/groupCategoriesApi';
@@ -140,6 +142,7 @@ describe('GuessPathScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFocusEffects.clear();
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
     jest.spyOn(Dimensions, 'get').mockReturnValue({
       width: 320,
       height: 640,
@@ -151,6 +154,7 @@ describe('GuessPathScreen', () => {
     listGroupCategories.mockResolvedValue({ status: 200, data: [] });
     createGroupCategory.mockResolvedValue({ status: 201, data: {} });
     updateGroupCategory.mockResolvedValue({ status: 200, data: {} });
+    deleteGroupCategory.mockResolvedValue({ status: 204, data: {} });
     resolveCategoryThumbnail.mockResolvedValue(null);
     deleteCategoryThumbnailFile.mockReturnValue(undefined);
     uploadCategoryThumbnail.mockResolvedValue(null);
@@ -165,6 +169,7 @@ describe('GuessPathScreen', () => {
       mountedRenderers.splice(0).forEach((renderer) => renderer.unmount());
     });
 
+    Alert.alert.mockRestore();
     Dimensions.get.mockRestore();
   });
 
@@ -225,6 +230,27 @@ describe('GuessPathScreen', () => {
       ([props]) => props.testID === `guess-path.category.edit.${categoryId}`
     );
     return call?.[0];
+  }
+
+  function getManageButtonProps() {
+    const call = mockIconButton.mock.calls.find(
+      ([props]) => props.testID === 'guess-path.button.manage'
+    );
+    return call?.[0];
+  }
+
+  function getDeleteButtonProps(categoryId) {
+    const call = mockIconButton.mock.calls.find(
+      ([props]) => props.testID === `guess-path.category.delete.${categoryId}`
+    );
+    return call?.[0];
+  }
+
+  function invokeAlertDelete() {
+    expect(Alert.alert).toHaveBeenCalled();
+    const buttons = Alert.alert.mock.calls[Alert.alert.mock.calls.length - 1][2];
+    const deleteButton = buttons.find((b) => b.text === 'Delete');
+    return deleteButton.onPress;
   }
 
   it('fetches categories on mount with the auth context', async () => {
@@ -608,6 +634,16 @@ describe('GuessPathScreen', () => {
 
     const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
+    await act(async () => {
+      getManageButtonProps().onPress();
+      await flushEffects();
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'guess-path.manage.option.update' }).props.onPress();
+      await flushEffects();
+    });
+
     const pencilProps = renderer.root.findByProps({
       testID: 'guess-path.category.edit.c-1',
     }).props;
@@ -648,5 +684,333 @@ describe('GuessPathScreen', () => {
     expect(() =>
       renderer.root.findByProps({ testID: 'guess-path.category.edit.c-1' })
     ).toThrow();
+  });
+
+  it('owner default mode: manage button present, no per-card edit or delete icons', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-1', role: 'owner' }] },
+      refresh: jest.fn(),
+    });
+    const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+
+    const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    expect(getManageButtonProps()).toBeDefined();
+    expect(getPencilEditButtonProps('c-1')).toBeUndefined();
+    expect(getDeleteButtonProps('c-1')).toBeUndefined();
+    expect(() =>
+      renderer.root.findByProps({ testID: 'guess-path.category.edit.c-1' })
+    ).toThrow();
+    expect(() =>
+      renderer.root.findByProps({ testID: 'guess-path.category.delete.c-1' })
+    ).toThrow();
+  });
+
+  it('owner taps manage then Update images: modal opens then closes, pencil appears on non-all card only', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-1', role: 'owner' }] },
+      refresh: jest.fn(),
+    });
+    const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+
+    const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    expect(() =>
+      renderer.root.findByProps({ testID: 'guess-path.manage' })
+    ).toThrow();
+
+    await act(async () => {
+      getManageButtonProps().onPress();
+      await flushEffects();
+    });
+
+    expect(
+      renderer.root.findByProps({ testID: 'guess-path.manage.option.update' })
+    ).toBeTruthy();
+    expect(
+      renderer.root.findByProps({ testID: 'guess-path.manage.option.delete' })
+    ).toBeTruthy();
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'guess-path.manage.option.update' }).props.onPress();
+      await flushEffects();
+    });
+
+    expect(getPencilEditButtonProps('c-1')).toBeDefined();
+    expect(getPencilEditButtonProps('all')).toBeUndefined();
+    expect(
+      renderer.root.findByProps({ testID: 'guess-path.category.edit.c-1' })
+    ).toBeTruthy();
+  });
+
+  it('owner taps Delete categories: trash appears on non-all card only', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-1', role: 'owner' }] },
+      refresh: jest.fn(),
+    });
+    const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+
+    const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    await act(async () => {
+      getManageButtonProps().onPress();
+      await flushEffects();
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'guess-path.manage.option.delete' }).props.onPress();
+      await flushEffects();
+    });
+
+    expect(getDeleteButtonProps('c-1')).toBeDefined();
+    expect(getDeleteButtonProps('all')).toBeUndefined();
+  });
+
+  it('trash press confirms via Alert, deletes category, purges thumbnail file and reloads', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-1', role: 'owner' }] },
+      refresh: jest.fn(),
+    });
+    const category = {
+      id: 'c-1',
+      key: 'c-1',
+      name: 'Cats',
+      thumbnail_image_id: 'thumb-1',
+    };
+    listGroupCategories
+      .mockResolvedValueOnce({ status: 200, data: [category] })
+      .mockResolvedValue({ status: 200, data: [] });
+    deleteGroupCategory.mockResolvedValue({ status: 204, data: {} });
+
+    const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    await act(async () => {
+      getManageButtonProps().onPress();
+      await flushEffects();
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'guess-path.manage.option.delete' }).props.onPress();
+      await flushEffects();
+    });
+
+    const trashProps = getDeleteButtonProps('c-1');
+
+    await act(async () => {
+      trashProps.onPress();
+      await flushEffects();
+    });
+
+    const deleteOnPress = invokeAlertDelete();
+
+    await act(async () => {
+      await deleteOnPress();
+      await flushEffects();
+    });
+
+    expect(deleteGroupCategory).toHaveBeenCalledWith(contextValue, 'g-1', 'c-1');
+    expect(deleteCategoryThumbnailFile).toHaveBeenCalledWith('g-1', 'thumb-1');
+    expect(listGroupCategories).toHaveBeenCalledTimes(2);
+  });
+
+  it('delete error branch: reload NOT called and Alert error path triggered', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-1', role: 'owner' }] },
+      refresh: jest.fn(),
+    });
+    const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    deleteGroupCategory.mockResolvedValue({ status: 500, data: {} });
+
+    const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    const initialCalls = listGroupCategories.mock.calls.length;
+
+    await act(async () => {
+      getManageButtonProps().onPress();
+      await flushEffects();
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'guess-path.manage.option.delete' }).props.onPress();
+      await flushEffects();
+    });
+
+    const trashProps = getDeleteButtonProps('c-1');
+
+    await act(async () => {
+      trashProps.onPress();
+      await flushEffects();
+    });
+
+    const deleteOnPress = invokeAlertDelete();
+
+    await act(async () => {
+      await deleteOnPress();
+      await flushEffects();
+    });
+
+    expect(deleteGroupCategory).toHaveBeenCalledWith(contextValue, 'g-1', 'c-1');
+    expect(listGroupCategories).toHaveBeenCalledTimes(initialCalls);
+    expect(Alert.alert).toHaveBeenLastCalledWith(
+      'Error 500',
+      'Could not delete category.'
+    );
+  });
+
+  it('non-owner: manage button absent and no per-card icons', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: {
+        owned: [],
+        joined: [{ id: 'g-1', role: 'member' }],
+      },
+      refresh: jest.fn(),
+    });
+    const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+
+    await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    expect(getManageButtonProps()).toBeUndefined();
+    expect(getPencilEditButtonProps('c-1')).toBeUndefined();
+    expect(getDeleteButtonProps('c-1')).toBeUndefined();
+  });
+
+  it('manage banner hidden by default, visible after picking a mode, hidden again after Done', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-1', role: 'owner' }] },
+      refresh: jest.fn(),
+    });
+    const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+
+    const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    expect(() =>
+      renderer.root.findByProps({ testID: 'guess-path.button.manage-done' })
+    ).toThrow();
+
+    await act(async () => {
+      getManageButtonProps().onPress();
+      await flushEffects();
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'guess-path.manage.option.delete' }).props.onPress();
+      await flushEffects();
+    });
+
+    expect(
+      renderer.root.findByProps({ testID: 'guess-path.button.manage-done' })
+    ).toBeTruthy();
+    expect(getDeleteButtonProps('c-1')).toBeDefined();
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'guess-path.button.manage-done' }).props.onPress();
+      await flushEffects();
+    });
+
+    expect(() =>
+      renderer.root.findByProps({ testID: 'guess-path.button.manage-done' })
+    ).toThrow();
+    expect(() =>
+      renderer.root.findByProps({ testID: 'guess-path.category.delete.c-1' })
+    ).toThrow();
+  });
+
+  it('useFocusEffect re-focus resets manageMode so the trash icon disappears', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-1', role: 'owner' }] },
+      refresh: jest.fn(),
+    });
+    const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+
+    const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    await act(async () => {
+      getManageButtonProps().onPress();
+      await flushEffects();
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'guess-path.manage.option.delete' }).props.onPress();
+      await flushEffects();
+    });
+
+    expect(getDeleteButtonProps('c-1')).toBeDefined();
+
+    await triggerFocusEffects();
+
+    expect(() =>
+      renderer.root.findByProps({ testID: 'guess-path.category.delete.c-1' })
+    ).toThrow();
+  });
+
+  it('does not fire a second delete when the trash icon is tapped while a delete is in flight', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-1', role: 'owner' }] },
+      refresh: jest.fn(),
+    });
+    const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+
+    let resolveFirstDelete;
+    deleteGroupCategory.mockImplementation(
+      () => new Promise((resolve) => { resolveFirstDelete = resolve; })
+    );
+
+    const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    await act(async () => {
+      getManageButtonProps().onPress();
+      await flushEffects();
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'guess-path.manage.option.delete' }).props.onPress();
+      await flushEffects();
+    });
+
+    await act(async () => {
+      getDeleteButtonProps('c-1').onPress();
+      await flushEffects();
+    });
+    const firstDeleteOnPress = invokeAlertDelete();
+
+    await act(async () => {
+      firstDeleteOnPress();
+      await flushEffects();
+    });
+
+    expect(deleteGroupCategory).toHaveBeenCalledTimes(1);
+
+    const trashCalls = mockIconButton.mock.calls.filter(
+      ([props]) => props.testID === 'guess-path.category.delete.c-1'
+    );
+    const latestTrashProps = trashCalls[trashCalls.length - 1][0];
+
+    await act(async () => {
+      latestTrashProps.onPress();
+      await flushEffects();
+    });
+    const secondDeleteOnPress = invokeAlertDelete();
+
+    await act(async () => {
+      secondDeleteOnPress();
+      await flushEffects();
+    });
+
+    expect(deleteGroupCategory).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirstDelete({ status: 204, data: {} });
+      await flushEffects();
+    });
+
+    expect(deleteGroupCategory).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/GuessPathScreen.test.js
+++ b/__tests__/GuessPathScreen.test.js
@@ -63,10 +63,16 @@ jest.mock('../utils/e2eMode', () => ({
 jest.mock('../services/groups/groupCategoriesApi', () => ({
   listGroupCategories: jest.fn(),
   createGroupCategory: jest.fn(),
+  updateGroupCategory: jest.fn(),
 }));
 
 jest.mock('../services/groups/groupCategoryThumbnails', () => ({
   resolveCategoryThumbnail: jest.fn(),
+  deleteCategoryThumbnailFile: jest.fn(),
+}));
+
+jest.mock('../services/groups/categoryThumbnailUpload', () => ({
+  uploadCategoryThumbnail: jest.fn(),
 }));
 
 jest.mock('../store/auth-context', () => {
@@ -92,8 +98,13 @@ import { isE2EMode } from '../utils/e2eMode';
 import {
   createGroupCategory,
   listGroupCategories,
+  updateGroupCategory,
 } from '../services/groups/groupCategoriesApi';
-import { resolveCategoryThumbnail } from '../services/groups/groupCategoryThumbnails';
+import {
+  resolveCategoryThumbnail,
+  deleteCategoryThumbnailFile,
+} from '../services/groups/groupCategoryThumbnails';
+import { uploadCategoryThumbnail } from '../services/groups/categoryThumbnailUpload';
 
 const CATEGORIES = [
   { id: '1', key: 'nature', name: 'Nature', thumbnailUrl: 'x', count: 5 },
@@ -139,7 +150,10 @@ describe('GuessPathScreen', () => {
     getCategories.mockResolvedValue({ data: CATEGORIES });
     listGroupCategories.mockResolvedValue({ status: 200, data: [] });
     createGroupCategory.mockResolvedValue({ status: 201, data: {} });
+    updateGroupCategory.mockResolvedValue({ status: 200, data: {} });
     resolveCategoryThumbnail.mockResolvedValue(null);
+    deleteCategoryThumbnailFile.mockReturnValue(undefined);
+    uploadCategoryThumbnail.mockResolvedValue(null);
     getSessionLanguageFilter.mockResolvedValue(null);
     saveSessionLanguageFilter.mockResolvedValue(undefined);
     mockUseGroupsHub.mockReturnValue({ data: null, refresh: jest.fn() });
@@ -202,6 +216,13 @@ describe('GuessPathScreen', () => {
   function getAddCategoryButtonProps() {
     const call = mockIconButton.mock.calls.find(
       ([props]) => props.testID === 'guess-path.button.add-category'
+    );
+    return call?.[0];
+  }
+
+  function getPencilEditButtonProps(categoryId) {
+    const call = mockIconButton.mock.calls.find(
+      ([props]) => props.testID === `guess-path.category.edit.${categoryId}`
     );
     return call?.[0];
   }
@@ -521,6 +542,111 @@ describe('GuessPathScreen', () => {
     expect(createGroupCategory).not.toHaveBeenCalled();
     expect(() =>
       renderer.root.findByProps({ testID: 'guess-path.add-category.input.name' })
+    ).toThrow();
+  });
+
+  it('creates a category with thumbnailImageId when a thumbnail is picked in the modal', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-1', role: 'owner' }] },
+      refresh: jest.fn(),
+    });
+    uploadCategoryThumbnail.mockResolvedValue({ imageId: 'img-7' });
+    listGroupCategories
+      .mockResolvedValueOnce({ status: 200, data: [] })
+      .mockResolvedValue({ status: 200, data: PRIVATE_CREATED_CATEGORIES });
+
+    const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    await act(async () => {
+      getAddCategoryButtonProps().onPress();
+      await flushEffects();
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({
+        testID: 'guess-path.add-category.button.pick-thumbnail',
+      }).props.onPress();
+      await flushEffects();
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({
+        testID: 'guess-path.add-category.input.name',
+      }).props.onChangeText('NewCat');
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({
+        testID: 'guess-path.add-category.button.create',
+      }).props.onPress();
+      await flushEffects();
+    });
+
+    expect(uploadCategoryThumbnail).toHaveBeenCalledWith({ context: contextValue, groupId: 'g-1' });
+    expect(createGroupCategory).toHaveBeenCalledWith(contextValue, 'g-1', {
+      name: 'NewCat',
+      thumbnailImageId: 'img-7',
+    });
+  });
+
+  it('renders a pencil edit affordance on owned category cards and swaps the thumbnail on press', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: { owned: [{ id: 'g-1', role: 'owner' }] },
+      refresh: jest.fn(),
+    });
+    const category = {
+      id: 'c-1',
+      key: 'c-1',
+      name: 'Cats',
+      thumbnail_image_id: 'old-thumb',
+      thumbnail_url: 'https://example.com/old.webp',
+    };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    resolveCategoryThumbnail.mockResolvedValue('file:///cache/old.webp');
+    uploadCategoryThumbnail.mockResolvedValue({ imageId: 'img-new' });
+    updateGroupCategory.mockResolvedValue({ status: 200, data: {} });
+
+    const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    const pencilProps = renderer.root.findByProps({
+      testID: 'guess-path.category.edit.c-1',
+    }).props;
+    expect(pencilProps).toBeTruthy();
+    expect(pencilProps.accessibilityLabel).toBe('Edit Cats thumbnail');
+
+    await act(async () => {
+      pencilProps.onPress();
+      await flushEffects();
+    });
+
+    expect(uploadCategoryThumbnail).toHaveBeenCalledWith({ context: contextValue, groupId: 'g-1' });
+    expect(deleteCategoryThumbnailFile).toHaveBeenCalledWith('g-1', 'old-thumb');
+    expect(deleteCategoryThumbnailFile.mock.invocationCallOrder[0]).toBeLessThan(
+      updateGroupCategory.mock.invocationCallOrder[0],
+    );
+    expect(updateGroupCategory).toHaveBeenCalledWith(contextValue, 'g-1', 'c-1', {
+      thumbnailImageId: 'img-new',
+    });
+    // reloadCategories fired after successful swap.
+    expect(listGroupCategories).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not render the pencil edit affordance for non-owner members', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: {
+        owned: [],
+        joined: [{ id: 'g-1', role: 'member' }],
+      },
+      refresh: jest.fn(),
+    });
+    const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+
+    const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    expect(getPencilEditButtonProps('c-1')).toBeUndefined();
+    expect(() =>
+      renderer.root.findByProps({ testID: 'guess-path.category.edit.c-1' })
     ).toThrow();
   });
 });

--- a/__tests__/GuessPathScreen.test.js
+++ b/__tests__/GuessPathScreen.test.js
@@ -2,6 +2,25 @@ const mockGuessCategoryCard = jest.fn(() => null);
 const mockTutorialOverlay = jest.fn(() => null);
 const mockIconButton = jest.fn(() => null);
 const mockUseGroupsHub = jest.fn();
+const mockFocusEffects = new Set();
+
+jest.mock('@react-navigation/native', () => {
+  const React = require('react');
+
+  return {
+    useFocusEffect: (callback) => {
+      React.useEffect(() => {
+        mockFocusEffects.add(callback);
+        const cleanup = callback();
+
+        return () => {
+          mockFocusEffects.delete(callback);
+          cleanup?.();
+        };
+      }, [callback]);
+    },
+  };
+});
 
 jest.mock('../components/UI/GuessCategoryCard', () => {
   return function MockGuessCategoryCard(props) {
@@ -46,6 +65,10 @@ jest.mock('../services/groups/groupCategoriesApi', () => ({
   createGroupCategory: jest.fn(),
 }));
 
+jest.mock('../services/groups/groupCategoryThumbnails', () => ({
+  resolveCategoryThumbnail: jest.fn(),
+}));
+
 jest.mock('../store/auth-context', () => {
   const React = require('react');
 
@@ -70,10 +93,28 @@ import {
   createGroupCategory,
   listGroupCategories,
 } from '../services/groups/groupCategoriesApi';
+import { resolveCategoryThumbnail } from '../services/groups/groupCategoryThumbnails';
 
 const CATEGORIES = [
   { id: '1', key: 'nature', name: 'Nature', thumbnailUrl: 'x', count: 5 },
   { id: '2', key: 'city', name: 'City', thumbnailUrl: 'y', count: 3 },
+];
+
+const PRIVATE_THUMBNAIL_CATEGORIES = [
+  {
+    id: 'c-1',
+    key: 'c-1',
+    name: 'Cats',
+    thumbnail_image_id: 'thumb-1',
+    thumbnail_url: 'https://example.com/thumb-1.webp',
+  },
+  {
+    id: 'c-2',
+    key: 'c-2',
+    name: 'Dogs',
+    thumbnail_image_id: 'thumb-2',
+    thumbnail_url: 'https://example.com/thumb-2.webp',
+  },
 ];
 
 const PRIVATE_CREATED_CATEGORIES = [
@@ -87,6 +128,7 @@ describe('GuessPathScreen', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFocusEffects.clear();
     jest.spyOn(Dimensions, 'get').mockReturnValue({
       width: 320,
       height: 640,
@@ -97,6 +139,7 @@ describe('GuessPathScreen', () => {
     getCategories.mockResolvedValue({ data: CATEGORIES });
     listGroupCategories.mockResolvedValue({ status: 200, data: [] });
     createGroupCategory.mockResolvedValue({ status: 201, data: {} });
+    resolveCategoryThumbnail.mockResolvedValue(null);
     getSessionLanguageFilter.mockResolvedValue(null);
     saveSessionLanguageFilter.mockResolvedValue(undefined);
     mockUseGroupsHub.mockReturnValue({ data: null, refresh: jest.fn() });
@@ -115,6 +158,13 @@ describe('GuessPathScreen', () => {
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
+  }
+
+  async function triggerFocusEffects() {
+    await act(async () => {
+      [...mockFocusEffects].forEach((callback) => callback());
+      await flushEffects();
+    });
   }
 
   async function renderScreen(route = { params: {} }) {
@@ -370,6 +420,82 @@ describe('GuessPathScreen', () => {
       ([props]) => props.category.id
     );
     expect(renderedKeys).toContain('c-new');
+  });
+
+  it('prefers resolved local private thumbnail uris and falls back to presigned urls', async () => {
+    listGroupCategories.mockResolvedValue({
+      status: 200,
+      data: PRIVATE_THUMBNAIL_CATEGORIES,
+    });
+    resolveCategoryThumbnail
+      .mockResolvedValueOnce('file:///cache/private-thumb-g-1-thumb-1.webp')
+      .mockResolvedValueOnce(null);
+
+    await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    expect(resolveCategoryThumbnail).toHaveBeenCalledTimes(2);
+    expect(resolveCategoryThumbnail).toHaveBeenNthCalledWith(1, contextValue, {
+      groupId: 'g-1',
+      category: PRIVATE_THUMBNAIL_CATEGORIES[0],
+    });
+    expect(resolveCategoryThumbnail).toHaveBeenNthCalledWith(2, contextValue, {
+      groupId: 'g-1',
+      category: PRIVATE_THUMBNAIL_CATEGORIES[1],
+    });
+    expect(getCardPropsByKey('c-1')).toEqual(
+      expect.objectContaining({
+        thumbnailUrl: 'file:///cache/private-thumb-g-1-thumb-1.webp',
+      })
+    );
+    expect(getCardPropsByKey('c-2')).toEqual(
+      expect.objectContaining({
+        thumbnailUrl: 'https://example.com/thumb-2.webp',
+      })
+    );
+  });
+
+  it('refetches private categories on focus and resolves thumbnails for categories added on the server', async () => {
+    const initialCategory = {
+      id: 'c-1',
+      key: 'c-1',
+      name: 'Cats',
+      thumbnail_image_id: 'thumb-1',
+      thumbnail_url: 'https://example.com/thumb-1.webp',
+    };
+    const newServerCategory = {
+      id: 'c-2',
+      key: 'c-2',
+      name: 'Dogs',
+      thumbnail_image_id: 'thumb-2',
+      thumbnail_url: 'https://example.com/thumb-2.webp',
+    };
+    let serverCategories = [initialCategory];
+
+    listGroupCategories.mockImplementation(async () => ({
+      status: 200,
+      data: serverCategories,
+    }));
+
+    await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    expect(listGroupCategories).toHaveBeenCalledTimes(1);
+    expect(getCardPropsByKey('c-2')).toBeUndefined();
+
+    serverCategories = [initialCategory, newServerCategory];
+
+    await triggerFocusEffects();
+
+    expect(listGroupCategories).toHaveBeenCalledTimes(2);
+    expect(listGroupCategories).toHaveBeenLastCalledWith(contextValue, 'g-1');
+    expect(getCardPropsByKey('c-2')).toEqual(
+      expect.objectContaining({
+        category: expect.objectContaining({ id: 'c-2', name: 'Dogs' }),
+      })
+    );
+    expect(resolveCategoryThumbnail).toHaveBeenCalledWith(contextValue, {
+      groupId: 'g-1',
+      category: newServerCategory,
+    });
   });
 
   it('closes the create-category modal without creating when cancel is tapped', async () => {

--- a/__tests__/apiClient.test.js
+++ b/__tests__/apiClient.test.js
@@ -15,6 +15,7 @@ import axios from 'axios';
 import {
   installAxiosUnauthorizedHandler,
   isAuthEndpoint,
+  isImageStorageEndpoint,
   setUnauthorizedHandler,
 } from '../utils/apiClient';
 
@@ -47,6 +48,33 @@ describe('utils/apiClient', () => {
       expect(isAuthEndpoint(null)).toBe(false);
       expect(isAuthEndpoint(undefined)).toBe(false);
       expect(isAuthEndpoint(42)).toBe(false);
+    });
+  });
+
+  describe('isImageStorageEndpoint', () => {
+    it('flags local_image_storage download URLs', () => {
+      expect(
+        isImageStorageEndpoint(
+          'https://api.example/api/v1/local_image_storage/42'
+        )
+      ).toBe(true);
+    });
+
+    it('does not flag regular api endpoints or auth endpoints', () => {
+      expect(
+        isImageStorageEndpoint('https://api.example/api/v1/categories')
+      ).toBe(false);
+      expect(isImageStorageEndpoint('https://api.example/auth/sign_in')).toBe(
+        false
+      );
+      expect(isImageStorageEndpoint('https://api.example/auth')).toBe(false);
+    });
+
+    it('treats empty values and non-strings as non-image-storage', () => {
+      expect(isImageStorageEndpoint('')).toBe(false);
+      expect(isImageStorageEndpoint(null)).toBe(false);
+      expect(isImageStorageEndpoint(undefined)).toBe(false);
+      expect(isImageStorageEndpoint(42)).toBe(false);
     });
   });
 
@@ -94,6 +122,24 @@ describe('utils/apiClient', () => {
 
       await expect(onRejected(signInError)).rejects.toEqual(signInError);
       await expect(onRejected(signUpError)).rejects.toEqual(signUpError);
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('never invokes the handler for image-storage 401s but still rejects', async () => {
+      const handler = jest.fn();
+      setUnauthorizedHandler(handler);
+
+      const onRejected = getInstalledRejectionHandler();
+
+      const error = {
+        response: { status: 401 },
+        config: {
+          url: 'https://api.example/api/v1/local_image_storage/42',
+        },
+      };
+
+      await expect(onRejected(error)).rejects.toEqual(error);
 
       expect(handler).not.toHaveBeenCalled();
     });

--- a/__tests__/screens/GroupSettingsScreen.test.js
+++ b/__tests__/screens/GroupSettingsScreen.test.js
@@ -59,6 +59,10 @@ jest.mock('../../services/groups/groupUploadApi', () => ({
   preparePrivateUpload: jest.fn(),
 }));
 
+jest.mock('../../services/groups/groupCategoryThumbnails', () => ({
+  deleteCategoryThumbnailFile: jest.fn(),
+}));
+
 jest.mock('../../utils/imagesRequests', () => ({
   performImageUpload: jest.fn(),
 }));
@@ -73,10 +77,22 @@ jest.mock('../../store/auth-context', () => {
 import React from 'react';
 import { act, create } from 'react-test-renderer';
 import { Alert } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
 
 import GroupSettingsScreen from '../../screens/Groups/GroupSettingsScreen';
-import { listGroupCategories } from '../../services/groups/groupCategoriesApi';
+import {
+  listGroupCategories,
+  updateGroupCategory,
+} from '../../services/groups/groupCategoriesApi';
 import { updateGroupSettings } from '../../services/groups/groupApi';
+import { preparePrivateUpload } from '../../services/groups/groupUploadApi';
+import { deleteCategoryThumbnailFile } from '../../services/groups/groupCategoryThumbnails';
+import { performImageUpload } from '../../utils/imagesRequests';
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe('GroupSettingsScreen', () => {
   beforeEach(() => {
@@ -98,8 +114,7 @@ describe('GroupSettingsScreen', () => {
       renderer = create(
         <GroupSettingsScreen navigation={navigation} />
       );
-      await Promise.resolve();
-      await Promise.resolve();
+      await flushEffects();
     });
     return { renderer, navigation };
   }
@@ -161,5 +176,106 @@ describe('GroupSettingsScreen', () => {
 
     const saveButtonProps = renderer.root.findByProps({ testID: 'group-settings.button.save-colors' }).props;
     expect(saveButtonProps.text).toBe('Save');
+  });
+
+  it('launches picker and prepares category thumbnail upload without categoryId payload', async () => {
+    const category = { id: 'cat-1', name: 'Cats' };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    ImagePicker.launchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file:///thumb.png', fileSize: 42 }],
+    });
+    preparePrivateUpload.mockResolvedValue({ status: 400, data: {} });
+
+    const { renderer } = await renderScreen({
+      groupsData: {
+        owned: [{ id: 'g-3', role: 'owner', name: 'Mine' }],
+        joined: [],
+      },
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'group-settings.uploader.category-thumbnail' }).props.onPress();
+      await flushEffects();
+    });
+
+    expect(ImagePicker.launchImageLibraryAsync).toHaveBeenCalledWith({
+      allowsEditing: false,
+      mediaTypes: ['images'],
+      quality: 0.5,
+    });
+
+    const uploadArgs = preparePrivateUpload.mock.calls[0][0];
+    expect(uploadArgs).toMatchObject({
+      context: {},
+      groupId: 'g-3',
+      kind: 'category-thumbnail',
+      fileExtension: 'png',
+      contentType: 'image/png',
+      contentLength: 42,
+      isCategoryThumbnail: true,
+    });
+    expect(uploadArgs).not.toHaveProperty('categoryId');
+  });
+
+  it('updates category thumbnail with thumbnailImageId and reloads categories after successful upload', async () => {
+    const category = { id: 'cat-1', name: 'Cats' };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    ImagePicker.launchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file:///thumb.webp', fileSize: 42 }],
+    });
+    preparePrivateUpload.mockResolvedValue({ status: 201, data: { imageId: 'img-9' } });
+    performImageUpload.mockResolvedValue({ status: 200 });
+    updateGroupCategory.mockResolvedValue({ status: 200, data: {} });
+
+    const { renderer } = await renderScreen({
+      groupsData: {
+        owned: [{ id: 'g-3', role: 'owner', name: 'Mine' }],
+        joined: [],
+      },
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'group-settings.uploader.category-thumbnail' }).props.onPress();
+      await flushEffects();
+    });
+
+    expect(updateGroupCategory).toHaveBeenCalledWith({}, 'g-3', 'cat-1', {
+      thumbnailImageId: 'img-9',
+    });
+    expect(listGroupCategories).toHaveBeenCalledTimes(2);
+  });
+
+  it('deletes previous local thumbnail before updating category on re-upload', async () => {
+    const category = { id: 'cat-1', name: 'Cats', thumbnail_image_id: 'old-thumb' };
+    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    ImagePicker.launchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file:///thumb.jpg', fileSize: 42 }],
+    });
+    preparePrivateUpload.mockResolvedValue({ status: 201, data: { imageId: 'img-new' } });
+    performImageUpload.mockResolvedValue({ status: 200 });
+    updateGroupCategory.mockResolvedValue({ status: 200, data: {} });
+
+    const { renderer } = await renderScreen({
+      groupsData: {
+        owned: [{ id: 'g-3', role: 'owner', name: 'Mine' }],
+        joined: [],
+      },
+    });
+
+    await act(async () => {
+      renderer.root.findByProps({ testID: 'group-settings.uploader.category-thumbnail' }).props.onPress();
+      await flushEffects();
+    });
+
+    expect(deleteCategoryThumbnailFile).toHaveBeenCalledWith('g-3', 'old-thumb');
+    expect(deleteCategoryThumbnailFile.mock.invocationCallOrder[0]).toBeLessThan(
+      updateGroupCategory.mock.invocationCallOrder[0],
+    );
+    expect(updateGroupCategory).toHaveBeenCalledWith({}, 'g-3', 'cat-1', {
+      thumbnailImageId: 'img-new',
+    });
   });
 });

--- a/__tests__/screens/MemberManagementScreen.test.js
+++ b/__tests__/screens/MemberManagementScreen.test.js
@@ -146,6 +146,7 @@ describe('MemberManagementScreen', () => {
     expect(removeMember).toHaveBeenCalledWith(expect.objectContaining({
       groupId: 'g-3',
       membershipId: 'm-2',
+      removedUserId: 'u-2',
     }));
   });
 

--- a/__tests__/services/categoryThumbnailUpload.test.js
+++ b/__tests__/services/categoryThumbnailUpload.test.js
@@ -1,0 +1,96 @@
+jest.mock('expo-image-picker', () => ({
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+jest.mock('../../services/groups/groupUploadApi', () => ({
+  preparePrivateUpload: jest.fn(),
+}));
+
+jest.mock('../../utils/imagesRequests', () => ({
+  performImageUpload: jest.fn(),
+}));
+
+import * as ImagePicker from 'expo-image-picker';
+import { preparePrivateUpload } from '../../services/groups/groupUploadApi';
+import { performImageUpload } from '../../utils/imagesRequests';
+import { uploadCategoryThumbnail } from '../../services/groups/categoryThumbnailUpload';
+
+describe('uploadCategoryThumbnail', () => {
+  const context = { token: 'Bearer x' };
+  const groupId = 'g-1';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when the user cancels the picker without firing presign', async () => {
+    ImagePicker.launchImageLibraryAsync.mockResolvedValue({ canceled: true, assets: [] });
+
+    const result = await uploadCategoryThumbnail({ context, groupId });
+
+    expect(result).toBeNull();
+    expect(preparePrivateUpload).not.toHaveBeenCalled();
+    expect(performImageUpload).not.toHaveBeenCalled();
+  });
+
+  it('presigns without categoryId, uploads, and returns the new imageId', async () => {
+    ImagePicker.launchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file:///thumb.webp', fileSize: 42 }],
+    });
+    preparePrivateUpload.mockResolvedValue({ status: 201, data: { imageId: 'img-9' } });
+    performImageUpload.mockResolvedValue({ status: 200 });
+
+    const result = await uploadCategoryThumbnail({ context, groupId });
+
+    expect(result).toEqual({ imageId: 'img-9' });
+
+    const presignArgs = preparePrivateUpload.mock.calls[0][0];
+    expect(presignArgs).toMatchObject({
+      context,
+      groupId,
+      kind: 'category-thumbnail',
+      fileExtension: 'webp',
+      contentType: 'image/webp',
+      contentLength: 42,
+      isCategoryThumbnail: true,
+    });
+    expect(presignArgs).not.toHaveProperty('categoryId');
+
+    expect(performImageUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plan: { imageId: 'img-9' },
+        fileUrl: 'file:///thumb.webp',
+        fileExtension: 'webp',
+        contentLength: 42,
+        context,
+      }),
+    );
+  });
+
+  it('throws when presign returns a non-success status', async () => {
+    ImagePicker.launchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file:///thumb.png', fileSize: 1 }],
+    });
+    preparePrivateUpload.mockResolvedValue({ status: 422, data: {} });
+
+    await expect(
+      uploadCategoryThumbnail({ context, groupId }),
+    ).rejects.toThrow('Could not prepare upload.');
+    expect(performImageUpload).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PUT upload step fails', async () => {
+    ImagePicker.launchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file:///thumb.png', fileSize: 1 }],
+    });
+    preparePrivateUpload.mockResolvedValue({ status: 201, data: { imageId: 'img-x' } });
+    performImageUpload.mockResolvedValue({ status: 500 });
+
+    await expect(
+      uploadCategoryThumbnail({ context, groupId }),
+    ).rejects.toThrow('Upload failed.');
+  });
+});

--- a/__tests__/services/groupApi.test.js
+++ b/__tests__/services/groupApi.test.js
@@ -15,8 +15,19 @@ jest.mock('../../utils/auth', () => ({
   })),
 }));
 
+jest.mock('../../services/groups/groupFeedCache', () => ({
+  clearGroupFeedCache: jest.fn(),
+  purgeAllPrivateCaches: jest.fn(),
+}));
+
+jest.mock('../../services/groups/groupCategoryThumbnails', () => ({
+  clearGroupThumbnails: jest.fn(),
+}));
+
 import axios from 'axios';
 import { getBackendHeaders, setHeaders } from '../../utils/auth';
+import { clearGroupFeedCache, purgeAllPrivateCaches } from '../../services/groups/groupFeedCache';
+import { clearGroupThumbnails } from '../../services/groups/groupCategoryThumbnails';
 
 import {
   fetchGroups,
@@ -35,7 +46,6 @@ import { joinByCode } from '../../services/groups/groupJoinApi';
 import {
   listGroupCategories,
   createGroupCategory,
-  updateGroupCategory,
   deleteGroupCategory,
 } from '../../services/groups/groupCategoriesApi';
 import {
@@ -116,7 +126,7 @@ describe('services/groups', () => {
       );
     });
 
-    it('deleteGroup DELETEs the group endpoint', async () => {
+    it('deleteGroup DELETEs the group endpoint and clears private caches on success', async () => {
       axios.delete.mockResolvedValue({ status: 204, data: null });
 
       const response = await deleteGroup(CONTEXT, 'g-1');
@@ -125,6 +135,9 @@ describe('services/groups', () => {
         'https://backend.example/api/v1/private_groups/g-1/',
         { headers: AUTH_HEADERS }
       );
+      expect(clearGroupFeedCache).toHaveBeenCalledWith('g-1');
+      expect(clearGroupThumbnails).toHaveBeenCalledWith('g-1');
+      expect(purgeAllPrivateCaches).toHaveBeenCalledTimes(1);
       expect(response.status).toBe(204);
     });
 
@@ -158,18 +171,39 @@ describe('services/groups', () => {
       expect(response.data).toEqual([{ id: 'm-1' }]);
     });
 
-    it('removeMember DELETEs the targeted membership', async () => {
+    it('removeMember DELETEs the targeted membership without purging caches for another member', async () => {
       axios.delete.mockResolvedValue({ status: 204, data: null });
 
-      await removeMember({ context: CONTEXT, groupId: 'g-3', membershipId: 'm-9' });
+      await removeMember({
+        context: CONTEXT,
+        groupId: 'g-3',
+        membershipId: 'm-9',
+        removedUserId: 'user-9',
+      });
 
       expect(axios.delete).toHaveBeenCalledWith(
         'https://backend.example/api/v1/private_groups/g-3/memberships/m-9',
         { headers: AUTH_HEADERS }
       );
+      expect(clearGroupFeedCache).not.toHaveBeenCalled();
+      expect(clearGroupThumbnails).not.toHaveBeenCalled();
     });
 
-    it('leaveGroup POSTs the leave action', async () => {
+    it('removeMember clears group-private caches when current user is removed', async () => {
+      axios.delete.mockResolvedValue({ status: 204, data: null });
+
+      await removeMember({
+        context: CONTEXT,
+        groupId: 'g-3',
+        membershipId: 'm-9',
+        removedUserId: 'user-1',
+      });
+
+      expect(clearGroupFeedCache).toHaveBeenCalledWith('g-3');
+      expect(clearGroupThumbnails).toHaveBeenCalledWith('g-3');
+    });
+
+    it('leaveGroup POSTs the leave action and clears group-private caches on success', async () => {
       axios.post.mockResolvedValue({ status: 204, data: null });
 
       await leaveGroup({ context: CONTEXT, groupId: 'g-3' });
@@ -179,6 +213,8 @@ describe('services/groups', () => {
         {},
         { headers: AUTH_HEADERS }
       );
+      expect(clearGroupFeedCache).toHaveBeenCalledWith('g-3');
+      expect(clearGroupThumbnails).toHaveBeenCalledWith('g-3');
     });
 
     it('transferOwnership POSTs the serialized target_user_id payload', async () => {
@@ -230,18 +266,6 @@ describe('services/groups', () => {
       expect(axios.post).toHaveBeenCalledWith(
         'https://backend.example/api/v1/private_groups/g-3/categories/',
         { private_category: { name: 'Cities', sort_order: 4 } },
-        { headers: AUTH_HEADERS }
-      );
-    });
-
-    it('updateGroupCategory PATCHes only supplied category fields', async () => {
-      axios.patch.mockResolvedValue({ status: 200, data: { data: { id: 'c-2' } } });
-
-      await updateGroupCategory(CONTEXT, 'g-3', 'c-2', { thumbnailUrl: 'private-images/g-3/groupUi/c-2.png' });
-
-      expect(axios.patch).toHaveBeenCalledWith(
-        'https://backend.example/api/v1/private_groups/g-3/categories/c-2/',
-        { private_category: { thumbnail_url: 'private-images/g-3/groupUi/c-2.png' } },
         { headers: AUTH_HEADERS }
       );
     });

--- a/__tests__/services/groupCategoriesApi.test.js
+++ b/__tests__/services/groupCategoriesApi.test.js
@@ -1,0 +1,80 @@
+jest.mock('axios', () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+}));
+
+jest.mock('../../utils/auth', () => ({
+  getBackendHeaders: jest.fn(),
+  setHeaders: jest.fn(),
+  mapRequestError: jest.fn((error) => ({
+    status: error?.response?.status ?? error?.request?.status,
+    data: error?.response?.data ?? error,
+  })),
+}));
+
+import axios from 'axios';
+import { getBackendHeaders, setHeaders } from '../../utils/auth';
+import {
+  createGroupCategory,
+  updateGroupCategory,
+} from '../../services/groups/groupCategoriesApi';
+
+const TOKEN = 'Bearer token-1';
+const AUTH_HEADERS = { Authorization: TOKEN, HTTP_AUTHORIZATION: TOKEN };
+const CONTEXT = { token: TOKEN, userId: 'user-1', scoreId: 'score-1' };
+
+describe('services/groups/groupCategoriesApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.EXPO_PUBLIC_APP_BACKEND_URL = 'https://backend.example/';
+    getBackendHeaders.mockResolvedValue({ token: TOKEN, userId: 'user-1', scoreId: 'score-1' });
+    setHeaders.mockReturnValue(AUTH_HEADERS);
+  });
+
+  it('createGroupCategory POSTs thumbnail_image_id when thumbnailImageId is supplied', async () => {
+    axios.post.mockResolvedValue({ status: 201, data: { data: { id: 'c-1' } } });
+
+    await createGroupCategory(CONTEXT, 'g-1', { name: 'Cats', thumbnailImageId: 't-1' });
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://backend.example/api/v1/private_groups/g-1/categories/',
+      { private_category: { name: 'Cats', sort_order: undefined, thumbnail_image_id: 't-1' } },
+      { headers: AUTH_HEADERS }
+    );
+  });
+
+  it('createGroupCategory omits thumbnail_image_id when thumbnailImageId is not supplied', async () => {
+    axios.post.mockResolvedValue({ status: 201, data: { data: { id: 'c-2' } } });
+
+    await createGroupCategory(CONTEXT, 'g-1', { name: 'Dogs' });
+
+    const [, body] = axios.post.mock.calls[0];
+    expect(body).toEqual({ private_category: { name: 'Dogs', sort_order: undefined } });
+    expect(body.private_category).not.toHaveProperty('thumbnail_image_id');
+  });
+
+  it('updateGroupCategory PATCHes thumbnail_image_id when thumbnailImageId is supplied', async () => {
+    axios.patch.mockResolvedValue({ status: 200, data: { data: { id: 'c-1' } } });
+
+    await updateGroupCategory(CONTEXT, 'g-1', 'c-1', { thumbnailImageId: 't-2' });
+
+    expect(axios.patch).toHaveBeenCalledWith(
+      'https://backend.example/api/v1/private_groups/g-1/categories/c-1/',
+      { private_category: { thumbnail_image_id: 't-2' } },
+      { headers: AUTH_HEADERS }
+    );
+  });
+
+  it('updateGroupCategory omits thumbnail_image_id when thumbnailImageId is not supplied', async () => {
+    axios.patch.mockResolvedValue({ status: 200, data: { data: { id: 'c-1' } } });
+
+    await updateGroupCategory(CONTEXT, 'g-1', 'c-1', { name: 'New' });
+
+    const [, body] = axios.patch.mock.calls[0];
+    expect(body).toEqual({ private_category: { name: 'New' } });
+    expect(body.private_category).not.toHaveProperty('thumbnail_image_id');
+  });
+});

--- a/__tests__/services/groupCategoryThumbnails.test.js
+++ b/__tests__/services/groupCategoryThumbnails.test.js
@@ -235,4 +235,73 @@ describe('services/groups/groupCategoryThumbnails', () => {
 
     expect(() => clearGroupThumbnails('g-1')).not.toThrow();
   });
+
+  it('sends Authorization and HTTP_AUTHORIZATION headers when the thumbnail URL points at backend storage', async () => {
+    const originalBackendUrl = process.env.EXPO_PUBLIC_APP_BACKEND_URL;
+    process.env.EXPO_PUBLIC_APP_BACKEND_URL = 'https://backend.example.com/';
+    File.__state.existsOverride = false;
+    axios.get.mockResolvedValue({
+      data: 'data:image/png;base64,AAEC',
+      headers: { 'content-type': 'text/plain' },
+    });
+
+    try {
+      const uri = await resolveCategoryThumbnail(
+        { ...CONTEXT, scoreId: 's-1' },
+        {
+          groupId: 'g-backend',
+          category: {
+            thumbnail_image_id: 't-backend',
+            thumbnail_url:
+              'https://backend.example.com/api/v1/local_image_storage/thumbs/t-backend.png',
+          },
+        }
+      );
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'https://backend.example.com/api/v1/local_image_storage/thumbs/t-backend.png',
+        {
+          headers: { Authorization: 'Bearer t', HTTP_AUTHORIZATION: 'Bearer t' },
+          timeout: 15000,
+        }
+      );
+      expect(uri).toEqual(expect.stringContaining('private-thumb-g-backend-t-backend.png'));
+      expect(File.__state.writtenUris).toHaveLength(1);
+      expect(File.__state.writtenUris[0]).toEqual({
+        uri: expect.stringContaining('private-thumb-g-backend-t-backend.png'),
+        data: 'AAEC',
+        options: { encoding: 'base64' },
+      });
+    } finally {
+      process.env.EXPO_PUBLIC_APP_BACKEND_URL = originalBackendUrl;
+    }
+  });
+
+  it('returns the presigned URL without writing when backend response is not a valid data URL', async () => {
+    const originalBackendUrl = process.env.EXPO_PUBLIC_APP_BACKEND_URL;
+    process.env.EXPO_PUBLIC_APP_BACKEND_URL = 'https://backend.example.com/';
+    File.__state.existsOverride = false;
+    axios.get.mockResolvedValue({
+      data: new Uint8Array([0, 1, 2]),
+      headers: { 'content-type': 'text/plain' },
+    });
+
+    try {
+      const uri = await resolveCategoryThumbnail(CONTEXT, {
+        groupId: 'g-backend',
+        category: {
+          thumbnail_image_id: 't-bad',
+          thumbnail_url:
+            'https://backend.example.com/api/v1/local_image_storage/thumbs/t-bad.png',
+        },
+      });
+
+      expect(uri).toBe(
+        'https://backend.example.com/api/v1/local_image_storage/thumbs/t-bad.png'
+      );
+      expect(File.__state.writtenUris).toHaveLength(0);
+    } finally {
+      process.env.EXPO_PUBLIC_APP_BACKEND_URL = originalBackendUrl;
+    }
+  });
 });

--- a/__tests__/services/groupCategoryThumbnails.test.js
+++ b/__tests__/services/groupCategoryThumbnails.test.js
@@ -1,0 +1,238 @@
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+jest.mock('base64-js', () => ({
+  fromByteArray: jest.fn((bytes) => `b64:${bytes.length}`),
+}));
+
+jest.mock('expo-file-system', () => {
+  const state = {
+    existsOverride: null,
+    deletedUris: [],
+    writtenUris: [],
+    writeError: null,
+  };
+
+  const File = jest.fn().mockImplementation(function MockFile(firstArg, secondArg) {
+    const base = typeof firstArg === 'string' ? firstArg : firstArg?.uri;
+    this.uri = secondArg ? `${base}${secondArg}` : base;
+    const override = state.existsOverride;
+    this.exists = typeof override === 'function'
+      ? override(this.uri)
+      : (override === null ? true : override);
+    this.write = jest.fn((data, options) => {
+      if (state.writeError) {
+        throw state.writeError;
+      }
+      state.writtenUris.push({ uri: this.uri, data, options });
+    });
+    this.delete = jest.fn(() => {
+      state.deletedUris.push(this.uri);
+    });
+  });
+
+  const cacheStore = {
+    uri: 'file:///cache/',
+    list: () => [],
+    create: jest.fn(),
+  };
+
+  function resetMockState() {
+    state.existsOverride = null;
+    state.deletedUris.length = 0;
+    state.writtenUris.length = 0;
+    state.writeError = null;
+    cacheStore.list = () => [];
+    cacheStore.create = jest.fn();
+    File.mockClear();
+  }
+
+  File.__state = state;
+  File.__cacheStore = cacheStore;
+  File.__reset = resetMockState;
+
+  const Paths = class MockPaths {
+    static get cache() {
+      return cacheStore;
+    }
+  };
+
+  return { File, Paths };
+});
+
+import axios from 'axios';
+import { fromByteArray } from 'base64-js';
+import { File } from 'expo-file-system';
+import {
+  resolveCategoryThumbnail,
+  deleteCategoryThumbnailFile,
+  clearGroupThumbnails,
+} from '../../services/groups/groupCategoryThumbnails';
+
+const CONTEXT = { token: 'Bearer t', userId: 'u-1' };
+
+describe('services/groups/groupCategoryThumbnails', () => {
+  beforeEach(() => {
+    axios.get.mockReset();
+    fromByteArray.mockClear();
+    File.__reset();
+  });
+
+  it('downloads the presigned thumbnail as arraybuffer and writes a private-thumb file when the local file is absent', async () => {
+    File.__state.existsOverride = false;
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    axios.get.mockResolvedValue({
+      data: bytes,
+      headers: { 'content-type': 'image/png' },
+    });
+
+    const uri = await resolveCategoryThumbnail(CONTEXT, {
+      groupId: 'g-1',
+      category: {
+        thumbnail_image_id: 't-1',
+        thumbnail_url: 'https://presigned.example.com/thumbs/t-1.png',
+      },
+    });
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://presigned.example.com/thumbs/t-1.png',
+      { responseType: 'arraybuffer', timeout: 15000 }
+    );
+    expect(uri).toEqual(expect.stringContaining('private-thumb-g-1-t-1.png'));
+    expect(fromByteArray).toHaveBeenCalledWith(bytes);
+    expect(File.__state.writtenUris).toHaveLength(1);
+    expect(File.__state.writtenUris[0]).toEqual({
+      uri: expect.stringContaining('private-thumb-g-1-t-1.png'),
+      data: 'b64:4',
+      options: { encoding: 'base64' },
+    });
+  });
+
+  it('returns the cached URI without calling axios when the local file already exists', async () => {
+    File.__state.existsOverride = true;
+
+    const uri = await resolveCategoryThumbnail(CONTEXT, {
+      groupId: 'g-1',
+      category: {
+        thumbnail_image_id: 't-1',
+        thumbnail_url: 'https://presigned.example.com/thumbs/t-1.png',
+      },
+    });
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(uri).toEqual(expect.stringContaining('private-thumb-g-1-t-1.png'));
+  });
+
+  it('falls back to content-type for the file extension when the presigned URL path has none', async () => {
+    File.__state.existsOverride = false;
+    const bytes = new Uint8Array([5, 6, 7]);
+    axios.get.mockResolvedValue({
+      data: bytes,
+      headers: { 'content-type': 'image/webp' },
+    });
+
+    const uri = await resolveCategoryThumbnail(CONTEXT, {
+      groupId: 'g-1',
+      category: {
+        thumbnail_image_id: 't-2',
+        thumbnail_url: 'https://presigned.example.com/thumbs/t-2?sig=abc',
+      },
+    });
+
+    expect(uri).toEqual(expect.stringContaining('private-thumb-g-1-t-2.webp'));
+    expect(File.__state.writtenUris[0].uri).toEqual(
+      expect.stringContaining('private-thumb-g-1-t-2.webp')
+    );
+  });
+
+  it('returns null and skips the network when thumbnail_image_id is null', async () => {
+    const uri = await resolveCategoryThumbnail(CONTEXT, {
+      groupId: 'g-1',
+      category: { thumbnail_image_id: null, thumbnail_url: 'https://x/y.png' },
+    });
+
+    expect(uri).toBeNull();
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the category has no thumbnail_image_id key at all', async () => {
+    const uri = await resolveCategoryThumbnail(CONTEXT, {
+      groupId: 'g-1',
+      category: {},
+    });
+
+    expect(uri).toBeNull();
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  it('returns the original presigned URL when the download fails', async () => {
+    File.__state.existsOverride = false;
+    axios.get.mockRejectedValue(new Error('network down'));
+
+    const uri = await resolveCategoryThumbnail(CONTEXT, {
+      groupId: 'g-1',
+      category: {
+        thumbnail_image_id: 't-3',
+        thumbnail_url: 'https://presigned.example.com/thumbs/t-3.png',
+      },
+    });
+
+    expect(uri).toBe('https://presigned.example.com/thumbs/t-3.png');
+    expect(File.__state.writtenUris).toHaveLength(0);
+  });
+
+  it('returns the original presigned URL when file write fails', async () => {
+    File.__state.existsOverride = false;
+    File.__state.writeError = new Error('disk full');
+    axios.get.mockResolvedValue({
+      data: new Uint8Array([8, 9]),
+      headers: { 'content-type': 'image/jpeg' },
+    });
+
+    const uri = await resolveCategoryThumbnail(CONTEXT, {
+      groupId: 'g-1',
+      category: {
+        thumbnail_image_id: 't-4',
+        thumbnail_url: 'https://presigned.example.com/thumbs/t-4.jpeg',
+      },
+    });
+
+    expect(uri).toBe('https://presigned.example.com/thumbs/t-4.jpeg');
+  });
+
+  it('deleteCategoryThumbnailFile best-effort deletes the local thumbnail file', () => {
+    deleteCategoryThumbnailFile('g-1', 't-1');
+
+    const deleted = File.__state.deletedUris.filter((u) =>
+      u.includes('private-thumb-g-1-t-1')
+    );
+    expect(deleted.length).toBeGreaterThan(0);
+  });
+
+  it('clearGroupThumbnails deletes only entries matching the group prefix', () => {
+    File.__cacheStore.list = () => [
+      'file:///cache/private-thumb-g-1-t-1.webp',
+      'file:///cache/private-thumb-g-2-t-1.png',
+      'file:///cache/other-private-foo.png',
+    ];
+
+    clearGroupThumbnails('g-1');
+
+    expect(File.__state.deletedUris).toEqual(
+      expect.arrayContaining(['file:///cache/private-thumb-g-1-t-1.webp'])
+    );
+    expect(File.__state.deletedUris).not.toContain(
+      'file:///cache/private-thumb-g-2-t-1.png'
+    );
+    expect(File.__state.deletedUris).not.toContain(
+      'file:///cache/other-private-foo.png'
+    );
+  });
+
+  it('clearGroupThumbnails does not throw when Paths.cache.list is undefined', () => {
+    File.__cacheStore.list = undefined;
+
+    expect(() => clearGroupThumbnails('g-1')).not.toThrow();
+  });
+});

--- a/__tests__/services/groupFeedCache.test.js
+++ b/__tests__/services/groupFeedCache.test.js
@@ -152,4 +152,36 @@ describe('services/groups/groupFeedCache — purge behavior', () => {
     ]));
     expect(deletedUris).not.toContain('file:///cache/public-img-2.png');
   });
+
+  it('purgeAllPrivateCaches also deletes private-thumb-{groupId}-{imageId} files via the existing private- prefix sweep', async () => {
+    const listedUris = [
+      'file:///cache/private-thumb-group-7-image-9.webp',
+      'file:///cache/public-thumb-group-7-image-9.webp',
+    ];
+
+    const cacheDir = Paths.cache;
+    const originalList = cacheDir.list;
+    const deletedUris = [];
+
+    File.mockImplementation(function MockFile(uri) {
+      this.uri = typeof uri === 'string' ? uri : uri?.uri;
+      this.exists = true;
+      this.delete = jest.fn(() => { deletedUris.push(this.uri); });
+    });
+    cacheDir.list = () => listedUris;
+
+    try {
+      await purgeAllPrivateCaches();
+    } finally {
+      cacheDir.list = originalList;
+      File.mockImplementation(function MockFile(uri) {
+        this.uri = typeof uri === 'string' ? uri : uri?.uri;
+        this.exists = true;
+        this.delete = jest.fn();
+      });
+    }
+
+    expect(deletedUris).toContain('file:///cache/private-thumb-group-7-image-9.webp');
+    expect(deletedUris).not.toContain('file:///cache/public-thumb-group-7-image-9.webp');
+  });
 });

--- a/components/UI/GuessCategoryCard.js
+++ b/components/UI/GuessCategoryCard.js
@@ -10,7 +10,7 @@ function isRemoteThumbnail(value) {
 export default function GuessCategoryCard({ category, thumbnailUrl, count, onPress, testIDPrefix }) {
   const cardTestID = `${testIDPrefix}.card.${category.id}`;
   const useRemote = isRemoteThumbnail(thumbnailUrl);
-  const source = useRemote ? thumbnailUrl : getCategoryAsset(category?.key);
+  const source = useRemote ? { uri: thumbnailUrl } : getCategoryAsset(category?.key);
 
   return (
     <Pressable onPress={onPress} testID={cardTestID} style={styles.card}>

--- a/screens/Groups/GroupSettingsScreen.js
+++ b/screens/Groups/GroupSettingsScreen.js
@@ -23,6 +23,7 @@ import {
 import { deleteCategoryThumbnailFile } from '../../services/groups/groupCategoryThumbnails';
 import { preparePrivateUpload } from '../../services/groups/groupUploadApi';
 import { performImageUpload } from '../../utils/imagesRequests';
+import { uploadCategoryThumbnail } from '../../services/groups/categoryThumbnailUpload';
 
 const UI_KINDS = [
   { kind: 'home-background', flag: 'isHomeBackground', label: 'Home background' },
@@ -121,7 +122,7 @@ export default function GroupSettingsScreen({ navigation }) {
     }
   };
 
-  const pickAndUpload = async (uiKind, category) => {
+  const pickAndUpload = async (uiKind) => {
     setActiveUploadKind(uiKind.kind);
     try {
       const result = await ImagePicker.launchImageLibraryAsync({
@@ -156,27 +157,44 @@ export default function GroupSettingsScreen({ navigation }) {
         context: authContext,
       });
       if (uploadResponse?.status === 200 || uploadResponse?.status === 204) {
-        if (category?.id) {
-          if (category.thumbnail_image_id) {
-            deleteCategoryThumbnailFile(groupId, category.thumbnail_image_id);
-          }
-
-          const updateResponse = await updateGroupCategory(authContext, groupId, category.id, {
-            thumbnailImageId: uploadPlan.imageId,
-          });
-
-          if (updateResponse?.status === 200 || updateResponse?.status === 204) {
-            await loadCategories();
-          } else {
-            Alert.alert(`Error ${updateResponse?.status ?? ''}`, 'Could not update category.');
-            return;
-          }
-        }
         Alert.alert('Uploaded', `${uiKind.label} updated.`);
         refresh();
       } else {
         Alert.alert(`Error ${uploadResponse?.status ?? ''}`, 'Upload failed.');
       }
+    } finally {
+      setActiveUploadKind(null);
+    }
+  };
+
+  // Category thumbnails swap via the shared helper (same flow used by GuessPathScreen
+  // pencil + create-with-thumbnail). Old local cache file purged before the PATCH
+  // so a failed update does not leave stale bytes for the new imageId.
+  const swapCategoryThumbnail = async (category) => {
+    if (!category?.id) {
+      return;
+    }
+    setActiveUploadKind('category-thumbnail');
+    try {
+      const uploaded = await uploadCategoryThumbnail({ context: authContext, groupId });
+      if (!uploaded) {
+        return;
+      }
+      if (category.thumbnail_image_id) {
+        deleteCategoryThumbnailFile(groupId, category.thumbnail_image_id);
+      }
+      const updateResponse = await updateGroupCategory(authContext, groupId, category.id, {
+        thumbnailImageId: uploaded.imageId,
+      });
+      if (updateResponse?.status === 200 || updateResponse?.status === 204) {
+        await loadCategories();
+        Alert.alert('Uploaded', 'Category thumbnail updated.');
+        refresh();
+      } else {
+        Alert.alert(`Error ${updateResponse?.status ?? ''}`, 'Could not update category.');
+      }
+    } catch (err) {
+      Alert.alert('Error', err?.message ?? 'Could not update thumbnail.');
     } finally {
       setActiveUploadKind(null);
     }
@@ -319,7 +337,7 @@ export default function GroupSettingsScreen({ navigation }) {
                 Save
               </Button>
               <Button
-                onPress={() => pickAndUpload({ kind: 'category-thumbnail', flag: 'isCategoryThumbnail', label: 'Category thumbnail' }, item)}
+                onPress={() => swapCategoryThumbnail(item)}
                 testID="group-settings.uploader.category-thumbnail"
               >
                 Thumb

--- a/screens/Groups/GroupSettingsScreen.js
+++ b/screens/Groups/GroupSettingsScreen.js
@@ -20,6 +20,7 @@ import {
   updateGroupCategory,
   deleteGroupCategory,
 } from '../../services/groups/groupCategoriesApi';
+import { deleteCategoryThumbnailFile } from '../../services/groups/groupCategoryThumbnails';
 import { preparePrivateUpload } from '../../services/groups/groupUploadApi';
 import { performImageUpload } from '../../utils/imagesRequests';
 
@@ -141,7 +142,6 @@ export default function GroupSettingsScreen({ navigation }) {
         contentType: `image/${fileExtension}`,
         contentLength: asset.fileSize ?? 0,
         [uiKind.flag]: true,
-        categoryId: category?.id,
       });
       if (presignResponse?.status !== 200 && presignResponse?.status !== 201) {
         Alert.alert(`Error ${presignResponse?.status ?? ''}`, 'Could not prepare upload.');
@@ -157,10 +157,20 @@ export default function GroupSettingsScreen({ navigation }) {
       });
       if (uploadResponse?.status === 200 || uploadResponse?.status === 204) {
         if (category?.id) {
-          await updateGroupCategory(authContext, groupId, category.id, {
-            thumbnailUrl: `private-images/${groupId}/groupUi/${uploadPlan.imageId}.${fileExtension}`,
+          if (category.thumbnail_image_id) {
+            deleteCategoryThumbnailFile(groupId, category.thumbnail_image_id);
+          }
+
+          const updateResponse = await updateGroupCategory(authContext, groupId, category.id, {
+            thumbnailImageId: uploadPlan.imageId,
           });
-          await loadCategories();
+
+          if (updateResponse?.status === 200 || updateResponse?.status === 204) {
+            await loadCategories();
+          } else {
+            Alert.alert(`Error ${updateResponse?.status ?? ''}`, 'Could not update category.');
+            return;
+          }
         }
         Alert.alert('Uploaded', `${uiKind.label} updated.`);
         refresh();

--- a/screens/Groups/MemberManagementScreen.js
+++ b/screens/Groups/MemberManagementScreen.js
@@ -65,6 +65,7 @@ export default function MemberManagementScreen() {
       context: authContext,
       groupId,
       membershipId: removeTarget.id,
+      removedUserId: removeTarget.user_id ?? removeTarget.userId,
     });
     setIsWorking(false);
     setRemoveTarget(null);

--- a/screens/GuessScreens/GuessPathScreen.js
+++ b/screens/GuessScreens/GuessPathScreen.js
@@ -30,6 +30,7 @@ import { useGroupsHub } from '../../hooks/useGroupsHub';
 import { AuthContext } from '../../store/auth-context';
 import {
   createGroupCategory,
+  deleteGroupCategory,
   listGroupCategories,
   updateGroupCategory,
 } from '../../services/groups/groupCategoriesApi';
@@ -54,8 +55,11 @@ export default function GuessPathScreen({ navigation, route }) {
   const [isAddCategoryVisible, setIsAddCategoryVisible] = useState(false);
   const [newCategoryName, setNewCategoryName] = useState('');
   const [isCreatingCategory, setIsCreatingCategory] = useState(false);
+  const [isDeletingCategory, setIsDeletingCategory] = useState(false);
   const [newCategoryThumbnailImageId, setNewCategoryThumbnailImageId] = useState(null);
   const [isPickingCreateThumbnail, setIsPickingCreateThumbnail] = useState(false);
+  const [manageMode, setManageMode] = useState(null);
+  const [isManageModalVisible, setIsManageModalVisible] = useState(false);
 
   const isTutorial = route?.params?.isTutorial;
   const routeScope = route?.params?.scope;
@@ -108,6 +112,7 @@ export default function GuessPathScreen({ navigation, route }) {
 
   useFocusEffect(
     useCallback(() => {
+      setManageMode(null);
       reloadCategories();
     }, [reloadCategories])
   );
@@ -228,6 +233,39 @@ export default function GuessPathScreen({ navigation, route }) {
     }
   };
 
+  const handleDeleteCategory = async (item) => {
+    Alert.alert(
+      'Delete category?',
+      `"${item.name}" will be removed.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            if (isDeletingCategory) {
+              return;
+            }
+            setIsDeletingCategory(true);
+            try {
+              const response = await deleteGroupCategory(context, scope.groupId, item.id);
+              if (response?.status === 200 || response?.status === 204) {
+                if (item.thumbnail_image_id) {
+                  deleteCategoryThumbnailFile(scope.groupId, item.thumbnail_image_id);
+                }
+                await reloadCategories();
+              } else {
+                Alert.alert(`Error ${response?.status ?? ''}`, 'Could not delete category.');
+              }
+            } finally {
+              setIsDeletingCategory(false);
+            }
+          },
+        },
+      ],
+    );
+  };
+
   const gridData = [RECENT_ALL_CATEGORY, ...categories];
 
   return (
@@ -261,6 +299,16 @@ export default function GuessPathScreen({ navigation, route }) {
                 accessibilityLabel="Add category"
               />
             )}
+            {isOwner && (
+              <IconButton
+                icon="options-outline"
+                color="GlobalStyle.color.tertiaryColor900"
+                size={24}
+                onPress={() => setIsManageModalVisible(true)}
+                testID="guess-path.button.manage"
+                accessibilityLabel="Manage categories"
+              />
+            )}
             <IconButton
               icon="ellipsis-horizontal"
               color="GlobalStyle.color.tertiaryColor900"
@@ -271,6 +319,21 @@ export default function GuessPathScreen({ navigation, route }) {
             />
           </View>
         </View>
+        {manageMode !== null && (
+          <View style={styles.manageBanner}>
+            <Text style={styles.manageBannerText}>
+              {manageMode === 'update' ? 'Updating images' : 'Deleting categories'}
+            </Text>
+            <Button
+              onPress={() => setManageMode(null)}
+              testID="guess-path.button.manage-done"
+              accessibilityLabel="Done managing"
+              thin={true}
+            >
+              Done
+            </Button>
+          </View>
+        )}
         <FlatList
           data={gridData}
           numColumns={2}
@@ -287,7 +350,7 @@ export default function GuessPathScreen({ navigation, route }) {
                 onPress={() => handleCategoryPress(item)}
                 testIDPrefix="guess-path.category"
               />
-              {isOwner && item.id !== 'all' && (
+              {isOwner && item.id !== 'all' && manageMode === 'update' && (
                 <IconButton
                   icon="create-outline"
                   color="#FFFFFF"
@@ -295,6 +358,18 @@ export default function GuessPathScreen({ navigation, route }) {
                   onPress={() => handleEditCategoryThumbnail(item)}
                   testID={`guess-path.category.edit.${item.id}`}
                   accessibilityLabel={`Edit ${item.name} thumbnail`}
+                  style={styles.cardEditButton}
+                />
+              )}
+              {isOwner && item.id !== 'all' && manageMode === 'delete' && (
+                <IconButton
+                  icon="trash-outline"
+                  color="#FF3B30"
+                  size={18}
+                  onPress={() => handleDeleteCategory(item)}
+                  disabled={isDeletingCategory}
+                  testID={`guess-path.category.delete.${item.id}`}
+                  accessibilityLabel={`Delete ${item.name}`}
                   style={styles.cardEditButton}
                 />
               )}
@@ -378,6 +453,54 @@ export default function GuessPathScreen({ navigation, route }) {
           </Button>
         </View>
       </CenteredModal>
+
+      <Modal
+        visible={isManageModalVisible}
+        onRequestClose={() => setIsManageModalVisible(false)}
+        animationType="slide"
+        transparent={false}
+      >
+        <View style={styles.modalContainer} testID="guess-path.manage">
+          <View style={styles.modalHeader}>
+            <Text style={styles.modalTitle}>Manage categories</Text>
+            <Pressable
+              onPress={() => setIsManageModalVisible(false)}
+              testID="guess-path.manage.close"
+              accessibilityRole="button"
+              accessibilityLabel="Close manage categories"
+              style={styles.modalCloseButton}
+            >
+              <Text style={styles.modalCloseText}>Close</Text>
+            </Pressable>
+          </View>
+          <ScrollView>
+            <Pressable
+              onPress={() => {
+                setManageMode('update');
+                setIsManageModalVisible(false);
+              }}
+              testID="guess-path.manage.option.update"
+              accessibilityRole="button"
+              accessibilityLabel="Update category images"
+              style={styles.option}
+            >
+              <Text style={styles.optionText}>Update images</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => {
+                setManageMode('delete');
+                setIsManageModalVisible(false);
+              }}
+              testID="guess-path.manage.option.delete"
+              accessibilityRole="button"
+              accessibilityLabel="Delete categories"
+              style={styles.option}
+            >
+              <Text style={styles.optionText}>Delete categories</Text>
+            </Pressable>
+          </ScrollView>
+        </View>
+      </Modal>
     </>
   );
 }
@@ -417,6 +540,18 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
+  },
+  manageBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    backgroundColor: 'rgba(29, 19, 61, 0.08)',
+  },
+  manageBannerText: {
+    fontSize: 14,
+    color: 'GlobalStyle.color.tertiaryColor900',
   },
   categoryInput: {
     borderWidth: 1,

--- a/screens/GuessScreens/GuessPathScreen.js
+++ b/screens/GuessScreens/GuessPathScreen.js
@@ -1,4 +1,5 @@
 import { useCallback, useContext, useEffect, useState } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 import {
   Alert,
   FlatList,
@@ -30,6 +31,7 @@ import {
   createGroupCategory,
   listGroupCategories,
 } from '../../services/groups/groupCategoriesApi';
+import { resolveCategoryThumbnail } from '../../services/groups/groupCategoryThumbnails';
 
 import { RECENT_ALL_CATEGORY } from '../../constants/categories';
 export { RECENT_ALL_CATEGORY };
@@ -56,11 +58,14 @@ export default function GuessPathScreen({ navigation, route }) {
     (g) => g.id === scope.groupId
   );
 
-  function normalizePrivateCategory(category) {
+  function normalizePrivateCategory(category, resolvedThumbnailUrl = null) {
     return {
       ...category,
       key: category?.key ?? category?.id,
-      thumbnailUrl: category?.thumbnailUrl ?? category?.thumbnail_url ?? null,
+      thumbnailUrl: resolvedThumbnailUrl
+        ?? category?.thumbnailUrl
+        ?? category?.thumbnail_url
+        ?? null,
     };
   }
 
@@ -70,15 +75,34 @@ export default function GuessPathScreen({ navigation, route }) {
       : await getCategories({ context });
 
     if (response?.data) {
-      setCategories((response.data ?? []).map((category) => (
-        isPrivateScope ? normalizePrivateCategory(category) : category
-      )));
+      if (isPrivateScope) {
+        const privateCategories = response.data ?? [];
+        const resolvedThumbnailUrls = await Promise.all(
+          privateCategories.map((category) => (
+            category?.thumbnail_image_id
+              ? resolveCategoryThumbnail(context, {
+                groupId: scope.groupId,
+                category,
+              })
+              : Promise.resolve(null)
+          ))
+        );
+
+        setCategories(privateCategories.map((category, index) => (
+          normalizePrivateCategory(category, resolvedThumbnailUrls[index])
+        )));
+        return;
+      }
+
+      setCategories(response.data ?? []);
     }
   }, [context, isPrivateScope, scope?.groupId]);
 
-  useEffect(() => {
-    reloadCategories();
-  }, [reloadCategories]);
+  useFocusEffect(
+    useCallback(() => {
+      reloadCategories();
+    }, [reloadCategories])
+  );
 
   useEffect(() => {
     let cancelled = false;

--- a/screens/GuessScreens/GuessPathScreen.js
+++ b/screens/GuessScreens/GuessPathScreen.js
@@ -16,6 +16,7 @@ import { GlobalStyle } from '../../constants/theme';
 import GuessCategoryCard from '../../components/UI/GuessCategoryCard';
 import TutorialOverlay from '../../components/UI/TutorialOverlay';
 import IconButton from '../../components/UI/IconButton';
+import Button from '../../components/UI/Button';
 import CenteredModal from '../../components/UI/CenteredModal';
 import { LANGUAGES } from '../../constants/languages';
 import { getCategories } from '../../utils/categoryRequests';
@@ -30,8 +31,13 @@ import { AuthContext } from '../../store/auth-context';
 import {
   createGroupCategory,
   listGroupCategories,
+  updateGroupCategory,
 } from '../../services/groups/groupCategoriesApi';
-import { resolveCategoryThumbnail } from '../../services/groups/groupCategoryThumbnails';
+import {
+  resolveCategoryThumbnail,
+  deleteCategoryThumbnailFile,
+} from '../../services/groups/groupCategoryThumbnails';
+import { uploadCategoryThumbnail } from '../../services/groups/categoryThumbnailUpload';
 
 import { RECENT_ALL_CATEGORY } from '../../constants/categories';
 export { RECENT_ALL_CATEGORY };
@@ -48,6 +54,8 @@ export default function GuessPathScreen({ navigation, route }) {
   const [isAddCategoryVisible, setIsAddCategoryVisible] = useState(false);
   const [newCategoryName, setNewCategoryName] = useState('');
   const [isCreatingCategory, setIsCreatingCategory] = useState(false);
+  const [newCategoryThumbnailImageId, setNewCategoryThumbnailImageId] = useState(null);
+  const [isPickingCreateThumbnail, setIsPickingCreateThumbnail] = useState(false);
 
   const isTutorial = route?.params?.isTutorial;
   const routeScope = route?.params?.scope;
@@ -145,12 +153,14 @@ export default function GuessPathScreen({ navigation, route }) {
 
   const handleOpenAddCategory = () => {
     setNewCategoryName('');
+    setNewCategoryThumbnailImageId(null);
     setIsAddCategoryVisible(true);
   };
 
   const handleCloseAddCategory = () => {
     setIsAddCategoryVisible(false);
     setNewCategoryName('');
+    setNewCategoryThumbnailImageId(null);
   };
 
   const handleCreateCategory = async () => {
@@ -162,14 +172,59 @@ export default function GuessPathScreen({ navigation, route }) {
       return;
     }
     setIsCreatingCategory(true);
-    const response = await createGroupCategory(context, scope.groupId, { name: trimmed });
+    const response = await createGroupCategory(context, scope.groupId, {
+      name: trimmed,
+      thumbnailImageId: newCategoryThumbnailImageId ?? undefined,
+    });
     setIsCreatingCategory(false);
     if (response?.status === 200 || response?.status === 201) {
       setIsAddCategoryVisible(false);
       setNewCategoryName('');
+      setNewCategoryThumbnailImageId(null);
       await reloadCategories();
     } else {
       Alert.alert('Error', 'Could not create category.');
+    }
+  };
+
+  const handlePickCreateThumbnail = async () => {
+    if (isPickingCreateThumbnail) {
+      return;
+    }
+    setIsPickingCreateThumbnail(true);
+    try {
+      const uploaded = await uploadCategoryThumbnail({ context, groupId: scope.groupId });
+      if (uploaded) {
+        setNewCategoryThumbnailImageId(uploaded.imageId);
+      }
+    } catch (err) {
+      Alert.alert('Error', err?.message ?? 'Could not pick thumbnail.');
+    } finally {
+      setIsPickingCreateThumbnail(false);
+    }
+  };
+
+  // Per-card thumbnail swap from the grid (owner only). Old local cache file purged
+  // before the PATCH so a failed update does not leave stale bytes for the new imageId.
+  const handleEditCategoryThumbnail = async (category) => {
+    try {
+      const uploaded = await uploadCategoryThumbnail({ context, groupId: scope.groupId });
+      if (!uploaded) {
+        return;
+      }
+      if (category.thumbnail_image_id) {
+        deleteCategoryThumbnailFile(scope.groupId, category.thumbnail_image_id);
+      }
+      const response = await updateGroupCategory(context, scope.groupId, category.id, {
+        thumbnailImageId: uploaded.imageId,
+      });
+      if (response?.status === 200 || response?.status === 204) {
+        await reloadCategories();
+      } else {
+        Alert.alert('Error', 'Could not update thumbnail.');
+      }
+    } catch (err) {
+      Alert.alert('Error', err?.message ?? 'Could not update thumbnail.');
     }
   };
 
@@ -232,6 +287,17 @@ export default function GuessPathScreen({ navigation, route }) {
                 onPress={() => handleCategoryPress(item)}
                 testIDPrefix="guess-path.category"
               />
+              {isOwner && item.id !== 'all' && (
+                <IconButton
+                  icon="create-outline"
+                  color="#FFFFFF"
+                  size={18}
+                  onPress={() => handleEditCategoryThumbnail(item)}
+                  testID={`guess-path.category.edit.${item.id}`}
+                  accessibilityLabel={`Edit ${item.name} thumbnail`}
+                  style={styles.cardEditButton}
+                />
+              )}
             </View>
           )}
         />
@@ -291,15 +357,26 @@ export default function GuessPathScreen({ navigation, route }) {
         confirmLabel={isCreatingCategory ? 'Creating...' : 'Create'}
         cancelLabel="Cancel"
       >
-        <TextInput
-          testID="guess-path.add-category.input.name"
-          accessibilityLabel="New category name"
-          placeholder="New category"
-          value={newCategoryName}
-          onChangeText={setNewCategoryName}
-          editable={!isCreatingCategory}
-          style={styles.categoryInput}
-        />
+        <View style={styles.addCategoryBody}>
+          <TextInput
+            testID="guess-path.add-category.input.name"
+            accessibilityLabel="New category name"
+            placeholder="New category"
+            value={newCategoryName}
+            onChangeText={setNewCategoryName}
+            editable={!isCreatingCategory}
+            style={styles.categoryInput}
+          />
+          <Button
+            onPress={handlePickCreateThumbnail}
+            testID="guess-path.add-category.button.pick-thumbnail"
+            accessibilityLabel="Pick category thumbnail"
+            disabled={isPickingCreateThumbnail || isCreatingCategory}
+            thin={true}
+          >
+            {newCategoryThumbnailImageId ? 'Thumbnail ready' : 'Add thumbnail (optional)'}
+          </Button>
+        </View>
       </CenteredModal>
     </>
   );
@@ -349,6 +426,10 @@ const styles = StyleSheet.create({
     minWidth: 200,
     color: '#000',
   },
+  addCategoryBody: {
+    gap: 10,
+    minWidth: 200,
+  },
   gridContent: {
     padding: 12,
     gap: 12,
@@ -358,6 +439,16 @@ const styles = StyleSheet.create({
   },
   gridItem: {
     flex: 1,
+    position: 'relative',
+  },
+  cardEditButton: {
+    position: 'absolute',
+    top: 6,
+    right: 6,
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+    borderRadius: 12,
+    paddingHorizontal: 4,
+    paddingVertical: 2,
   },
   modalContainer: {
     flex: 1,

--- a/services/groups/categoryThumbnailUpload.js
+++ b/services/groups/categoryThumbnailUpload.js
@@ -1,0 +1,51 @@
+import * as ImagePicker from 'expo-image-picker';
+
+import { preparePrivateUpload } from './groupUploadApi';
+import { performImageUpload } from '../../utils/imagesRequests';
+
+// Opens the image picker and uploads the chosen asset as a private category thumbnail.
+// Returns { imageId } on success, or null when the user cancels the picker.
+// Throws on prepare/upload failure so the caller can surface an Alert.
+//
+// Caller owns the post-upload lifecycle: swap (deleteCategoryThumbnailFile + updateGroupCategory)
+// or create-with-thumbnail (createGroupCategory with thumbnailImageId).
+export async function uploadCategoryThumbnail({ context, groupId }) {
+  const result = await ImagePicker.launchImageLibraryAsync({
+    allowsEditing: false,
+    mediaTypes: ['images'],
+    quality: 0.5,
+  });
+  if (result?.canceled || !result?.assets?.length) {
+    return null;
+  }
+
+  const asset = result.assets[0];
+  const fileExtension = (asset.uri.split('.').pop() || 'jpg').toLowerCase();
+
+  const presignResponse = await preparePrivateUpload({
+    context,
+    groupId,
+    kind: 'category-thumbnail',
+    fileExtension,
+    contentType: `image/${fileExtension}`,
+    contentLength: asset.fileSize ?? 0,
+    isCategoryThumbnail: true,
+  });
+  if (presignResponse?.status !== 200 && presignResponse?.status !== 201) {
+    throw new Error('Could not prepare upload.');
+  }
+
+  const uploadPlan = presignResponse.data;
+  const uploadResponse = await performImageUpload({
+    plan: uploadPlan,
+    fileUrl: asset.uri,
+    fileExtension,
+    contentLength: asset.fileSize ?? 0,
+    context,
+  });
+  if (uploadResponse?.status !== 200 && uploadResponse?.status !== 204) {
+    throw new Error('Upload failed.');
+  }
+
+  return { imageId: uploadPlan.imageId };
+}

--- a/services/groups/groupApi.js
+++ b/services/groups/groupApi.js
@@ -1,7 +1,17 @@
 import axios from 'axios';
 import { getBackendHeaders, setHeaders, mapRequestError } from '../../utils/auth';
+import { clearGroupFeedCache, purgeAllPrivateCaches } from './groupFeedCache';
+import { clearGroupThumbnails } from './groupCategoryThumbnails';
 
 const BASE_URL = `${process.env.EXPO_PUBLIC_APP_BACKEND_URL}api/v1/private_groups`;
+
+async function clearDeletedGroupCaches(groupId) {
+  await Promise.allSettled([
+    clearGroupFeedCache(groupId),
+    clearGroupThumbnails(groupId),
+    purgeAllPrivateCaches(),
+  ]);
+}
 
 function normalizeGroupRow(row, userId) {
   if (!row || typeof row !== 'object') {
@@ -81,7 +91,13 @@ export async function deleteGroup(context, groupId) {
   const config = { headers: setHeaders({ token }) };
 
   return axios.delete(`${BASE_URL}/${groupId}/`, config)
-    .then((response) => ({ status: response.status, data: response.data }))
+    .then(async (response) => {
+      if (response?.status === 200 || response?.status === 204) {
+        await clearDeletedGroupCaches(groupId);
+      }
+
+      return { status: response.status, data: response.data };
+    })
     .catch(mapRequestError);
 }
 

--- a/services/groups/groupCategoriesApi.js
+++ b/services/groups/groupCategoriesApi.js
@@ -14,28 +14,25 @@ export async function listGroupCategories(context, groupId) {
     .catch(mapRequestError);
 }
 
-export async function createGroupCategory(context, groupId, { name, sortOrder } = {}) {
+export async function createGroupCategory(context, groupId, { name, sortOrder, thumbnailImageId } = {}) {
   const { token } = await getBackendHeaders(context);
   const config = { headers: setHeaders({ token }) };
-  const body = {
-    private_category: {
-      name,
-      sort_order: sortOrder,
-    },
-  };
+  const private_category = { name, sort_order: sortOrder };
+  if (thumbnailImageId !== undefined) private_category.thumbnail_image_id = thumbnailImageId;
+  const body = { private_category };
 
   return axios.post(`${categoriesUrl(groupId)}/`, body, config)
     .then((response) => ({ status: response.status, data: response.data?.data ?? response.data }))
     .catch(mapRequestError);
 }
 
-export async function updateGroupCategory(context, groupId, categoryId, { name, sortOrder, thumbnailUrl } = {}) {
+export async function updateGroupCategory(context, groupId, categoryId, { name, sortOrder, thumbnailImageId } = {}) {
   const { token } = await getBackendHeaders(context);
   const config = { headers: setHeaders({ token }) };
   const private_category = {};
   if (name !== undefined) private_category.name = name;
   if (sortOrder !== undefined) private_category.sort_order = sortOrder;
-  if (thumbnailUrl !== undefined) private_category.thumbnail_url = thumbnailUrl;
+  if (thumbnailImageId !== undefined) private_category.thumbnail_image_id = thumbnailImageId;
   const body = { private_category };
 
   return axios.patch(`${categoriesUrl(groupId)}/${categoryId}/`, body, config)

--- a/services/groups/groupCategoryThumbnails.js
+++ b/services/groups/groupCategoryThumbnails.js
@@ -1,6 +1,11 @@
 import axios from 'axios';
 import { File, Paths } from 'expo-file-system';
 import { fromByteArray } from 'base64-js';
+import {
+  usesBackendStorage,
+  setStorageDownloadHeaders,
+  getBackendHeaders,
+} from '../../utils/imagesRequests';
 
 const THUMB_PREFIX = 'private-thumb-';
 const DELETE_EXTENSIONS = ['png', 'jpeg', 'webp', 'jpg'];
@@ -45,6 +50,12 @@ function bytesFromArrayBufferLike(data) {
   return null;
 }
 
+function extractBase64FromDataUrl(value) {
+  if (typeof value !== 'string') return null;
+  const match = value.match(/^data:image\/(?:png|jpe?g|gif|webp|heic|heif);base64,([\s\S]*)$/);
+  return match ? match[1] : null;
+}
+
 export async function resolveCategoryThumbnail(context, { groupId, category } = {}) {
   const imageId = category?.thumbnail_image_id;
   if (!imageId) return null;
@@ -65,25 +76,34 @@ export async function resolveCategoryThumbnail(context, { groupId, category } = 
   }
 
   let response;
+  let base64ToWrite = null;
   try {
-    response = await axios.get(presignedUrl, {
-      responseType: 'arraybuffer',
-      timeout: 15000,
-    });
+    if (usesBackendStorage(presignedUrl)) {
+      const { token } = await getBackendHeaders(context);
+      response = await axios.get(presignedUrl, {
+        headers: setStorageDownloadHeaders(token),
+        timeout: 15000,
+      });
+      base64ToWrite = extractBase64FromDataUrl(response?.data);
+    } else {
+      response = await axios.get(presignedUrl, {
+        responseType: 'arraybuffer',
+        timeout: 15000,
+      });
+      const bytes = bytesFromArrayBufferLike(response?.data);
+      base64ToWrite = bytes ? fromByteArray(bytes) : null;
+    }
   } catch {
     return presignedUrl;
   }
 
-  if (!response?.data) return presignedUrl;
+  if (!base64ToWrite) return presignedUrl;
 
-  const bytes = bytesFromArrayBufferLike(response.data);
-  if (!bytes) return presignedUrl;
-
-  const finalExt = ext || extFromContentType(response.headers?.['content-type']);
+  const finalExt = ext || extFromContentType(response?.headers?.['content-type']);
 
   try {
     const file = new File(Paths.cache, `${THUMB_PREFIX}${groupId}-${imageId}.${finalExt}`);
-    file.write(fromByteArray(bytes), { encoding: 'base64' });
+    file.write(base64ToWrite, { encoding: 'base64' });
     return file.uri;
   } catch {
     return presignedUrl;

--- a/services/groups/groupCategoryThumbnails.js
+++ b/services/groups/groupCategoryThumbnails.js
@@ -1,0 +1,126 @@
+import axios from 'axios';
+import { File, Paths } from 'expo-file-system';
+import { fromByteArray } from 'base64-js';
+
+const THUMB_PREFIX = 'private-thumb-';
+const DELETE_EXTENSIONS = ['png', 'jpeg', 'webp', 'jpg'];
+
+function localThumbUri(groupId, id, ext) {
+  return new File(Paths.cache, `${THUMB_PREFIX}${groupId}-${id}.${ext}`).uri;
+}
+
+function localThumbExists(groupId, id, ext) {
+  try {
+    return !!new File(localThumbUri(groupId, id, ext)).exists;
+  } catch {
+    return false;
+  }
+}
+
+function deriveExtFromUrl(url) {
+  try {
+    const u = new URL(url);
+    const parts = u.pathname.split('.');
+    const last = parts[parts.length - 1];
+    if (last && /^[a-zA-Z0-9]{2,5}$/.test(last)) return last.toLowerCase();
+  } catch {
+    // not a URL
+  }
+  return null;
+}
+
+function extFromContentType(contentType) {
+  if (!contentType) return 'png';
+  const ct = contentType.split(';')[0].toLowerCase();
+  if (ct.includes('jpeg') || ct.includes('jpg')) return 'jpeg';
+  if (ct.includes('webp')) return 'webp';
+  return 'png';
+}
+
+function bytesFromArrayBufferLike(data) {
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  if (ArrayBuffer.isView(data)) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  }
+  return null;
+}
+
+export async function resolveCategoryThumbnail(context, { groupId, category } = {}) {
+  const imageId = category?.thumbnail_image_id;
+  if (!imageId) return null;
+
+  const presignedUrl = category?.thumbnail_url;
+  if (!presignedUrl || typeof presignedUrl !== 'string') return null;
+
+  const ext = deriveExtFromUrl(presignedUrl);
+
+  if (ext && localThumbExists(groupId, imageId, ext)) {
+    return localThumbUri(groupId, imageId, ext);
+  }
+
+  try {
+    Paths.cache.create({ idempotent: true, intermediates: true });
+  } catch {
+    // best-effort
+  }
+
+  let response;
+  try {
+    response = await axios.get(presignedUrl, {
+      responseType: 'arraybuffer',
+      timeout: 15000,
+    });
+  } catch {
+    return presignedUrl;
+  }
+
+  if (!response?.data) return presignedUrl;
+
+  const bytes = bytesFromArrayBufferLike(response.data);
+  if (!bytes) return presignedUrl;
+
+  const finalExt = ext || extFromContentType(response.headers?.['content-type']);
+
+  try {
+    const file = new File(Paths.cache, `${THUMB_PREFIX}${groupId}-${imageId}.${finalExt}`);
+    file.write(fromByteArray(bytes), { encoding: 'base64' });
+    return file.uri;
+  } catch {
+    return presignedUrl;
+  }
+}
+
+export function deleteCategoryThumbnailFile(groupId, id) {
+  try {
+    for (const ext of DELETE_EXTENSIONS) {
+      const file = new File(Paths.cache, `${THUMB_PREFIX}${groupId}-${id}.${ext}`);
+      if (file?.exists) file.delete();
+    }
+  } catch {
+    // best-effort
+  }
+}
+
+export function clearGroupThumbnails(groupId) {
+  try {
+    const cacheDir = Paths.cache;
+    const entries = typeof cacheDir?.list === 'function' ? cacheDir.list() : [];
+    if (!Array.isArray(entries)) return;
+
+    const prefix = `${THUMB_PREFIX}${groupId}-`;
+    for (const entry of entries) {
+      const uri = typeof entry === 'string' ? entry : entry?.uri;
+      const name = typeof uri === 'string' ? uri.split('/').pop() : '';
+      if (!name.startsWith(prefix)) continue;
+
+      try {
+        const file = new File(Paths.cache, name);
+        if (file?.exists) file.delete();
+      } catch {
+        // best-effort
+      }
+    }
+  } catch {
+    // best-effort
+  }
+}

--- a/services/groups/groupMembershipApi.js
+++ b/services/groups/groupMembershipApi.js
@@ -1,7 +1,24 @@
 import axios from 'axios';
 import { getBackendHeaders, setHeaders, mapRequestError } from '../../utils/auth';
+import { clearGroupFeedCache } from './groupFeedCache';
+import { clearGroupThumbnails } from './groupCategoryThumbnails';
 
 const BASE_URL = `${process.env.EXPO_PUBLIC_APP_BACKEND_URL}api/v1/private_groups`;
+
+async function clearDepartedGroupCaches(groupId) {
+  await Promise.allSettled([
+    clearGroupFeedCache(groupId),
+    clearGroupThumbnails(groupId),
+  ]);
+}
+
+function isSameUser(left, right) {
+  if (left == null || right == null) {
+    return false;
+  }
+
+  return String(left) === String(right);
+}
 
 export async function listMembers({ context, groupId }) {
   const { token } = await getBackendHeaders(context);
@@ -12,12 +29,18 @@ export async function listMembers({ context, groupId }) {
     .catch(mapRequestError);
 }
 
-export async function removeMember({ context, groupId, membershipId }) {
-  const { token } = await getBackendHeaders(context);
+export async function removeMember({ context, groupId, membershipId, removedUserId }) {
+  const { token, userId } = await getBackendHeaders(context);
   const config = { headers: setHeaders({ token }) };
 
   return axios.delete(`${BASE_URL}/${groupId}/memberships/${membershipId}`, config)
-    .then((response) => ({ status: response.status, data: response.data }))
+    .then(async (response) => {
+      if ((response?.status === 200 || response?.status === 204) && isSameUser(removedUserId, userId)) {
+        await clearDepartedGroupCaches(groupId);
+      }
+
+      return { status: response.status, data: response.data };
+    })
     .catch(mapRequestError);
 }
 
@@ -26,7 +49,13 @@ export async function leaveGroup({ context, groupId }) {
   const config = { headers: setHeaders({ token }) };
 
   return axios.post(`${BASE_URL}/${groupId}/memberships/leave`, {}, config)
-    .then((response) => ({ status: response.status, data: response.data }))
+    .then(async (response) => {
+      if (response?.status === 200 || response?.status === 204) {
+        await clearDepartedGroupCaches(groupId);
+      }
+
+      return { status: response.status, data: response.data };
+    })
     .catch(mapRequestError);
 }
 

--- a/utils/apiClient.js
+++ b/utils/apiClient.js
@@ -11,6 +11,14 @@ export function isAuthEndpoint(url) {
   return url.endsWith('/auth/sign_in') || url.endsWith('/auth');
 }
 
+export function isImageStorageEndpoint(url) {
+  if (typeof url !== 'string' || url === '') {
+    return false;
+  }
+
+  return url.includes('/local_image_storage/');
+}
+
 export function setUnauthorizedHandler(handler) {
   unauthorizedHandler = typeof handler === 'function' ? handler : null;
 }
@@ -31,6 +39,7 @@ export function installAxiosUnauthorizedHandler() {
       if (
         status === 401 &&
         !isAuthEndpoint(requestUrl) &&
+        !isImageStorageEndpoint(requestUrl) &&
         typeof unauthorizedHandler === 'function'
       ) {
         try {
@@ -40,9 +49,6 @@ export function installAxiosUnauthorizedHandler() {
         }
       }
 
-      // devise-jwt + JTIMatcher has no refresh-token mechanism: a 401 here means
-      // the token was revoked server-side (re-login elsewhere, reseed, etc.) and
-      // the user must re-authenticate. No silent refresh is possible.
       return Promise.reject(error);
     }
   );

--- a/utils/imagesRequests.js
+++ b/utils/imagesRequests.js
@@ -2,6 +2,8 @@ import axios from "axios";
 import { File, Paths } from 'expo-file-system';
 import Image from "../models/image";
 import { setHeaders, getBackendHeaders } from "./auth";
+
+export { getBackendHeaders };
 import { saveLastImageUuid } from "./storageDatum";
 import { fetchPrivateFeedPageForGame } from "../services/groups/groupFeedApi";
 
@@ -27,14 +29,14 @@ function setUploadHeaders({ plan, fileExtension, contentLength, token }) {
   return headers;
 };
 
-function setStorageDownloadHeaders(token) {
+export function setStorageDownloadHeaders(token) {
   return {
     Authorization: token,
     HTTP_AUTHORIZATION: token,
   };
 };
 
-function usesBackendStorage(storageUrl) {
+export function usesBackendStorage(storageUrl) {
   const backendUrl = process.env.EXPO_PUBLIC_APP_BACKEND_URL;
 
   return typeof storageUrl === 'string' && typeof backendUrl === 'string' && storageUrl.startsWith(backendUrl);


### PR DESCRIPTION
This pull request introduces comprehensive end-to-end (E2E) Maestro test flows for private group category management, including both non-destructive (UI-only) and destructive (backend-mutating) scenarios. It also adds and enhances test coverage for category thumbnail upload and deletion logic, and improves utility and test code for image storage endpoint handling. The changes ensure that owner-only category management features are robustly tested and that thumbnail upload flows behave correctly, including proper cleanup of old thumbnails.

**E2E Maestro Flows for Private Category Management:**

* Added `.maestro/private-manage-mode-smoke.yml` for non-destructive smoke testing of the owner-only manage UI on private group categories, asserting the presence of update/delete options and per-card icons without modifying data. (`[.maestro/private-manage-mode-smoke.ymlR1-R143](diffhunk://#diff-e858d651df7084ed4a9cfb249baf2622337330e4060bafe2eb086f096ba81dfeR1-R143)`)
* Added `.maestro/private-category-delete.yml` for destructive E2E testing of the owner-only delete-category flow, including backend DELETE requests and post-deletion assertions. (`[.maestro/private-category-delete.ymlR1-R135](diffhunk://#diff-94f6327dc5c355942f32d056ea9586274a56accaca5e54267272681abb41d835R1-R135)`)
* Updated `.maestro/README.md` with documentation and preconditions for the new private group flows, including notes on destructive behavior and test setup requirements. (`[[1]](diffhunk://#diff-bac010a359d10f3ad99107f1772028c0d9271afc953a1f2b6a1b2630f666107bR13-R14)`, `[[2]](diffhunk://#diff-bac010a359d10f3ad99107f1772028c0d9271afc953a1f2b6a1b2630f666107bR88-R106)`)

**Category Thumbnail Upload and Deletion Test Coverage:**

* Enhanced `GroupSettingsScreen` tests to cover category thumbnail upload flows, including: picker launch, upload preparation, updating categories with new thumbnail IDs, and ensuring previous local thumbnails are deleted before updates. (`[[1]](diffhunk://#diff-9f11aadd9a1f3c5197b0610adc492d31c98065dc010d0080f35230256594db00R80-R95)`, `[[2]](diffhunk://#diff-9f11aadd9a1f3c5197b0610adc492d31c98065dc010d0080f35230256594db00L101-R117)`, `[[3]](diffhunk://#diff-9f11aadd9a1f3c5197b0610adc492d31c98065dc010d0080f35230256594db00R180-R280)`)
* Mocked `deleteCategoryThumbnailFile` and related services to support new test cases. (`[__tests__/screens/GroupSettingsScreen.test.jsR62-R65](diffhunk://#diff-9f11aadd9a1f3c5197b0610adc492d31c98065dc010d0080f35230256594db00R62-R65)`)

**Utility and API Client Improvements:**

* Added and tested the `isImageStorageEndpoint` utility to distinguish image storage URLs from regular API endpoints, ensuring correct handling of 401 responses for those endpoints. (`[[1]](diffhunk://#diff-ac5eae0b8a7f6fe5ee5cafee19fdb7a146f79cda5aecbebe9b7032e4b07728b3R18)`, `[[2]](diffhunk://#diff-ac5eae0b8a7f6fe5ee5cafee19fdb7a146f79cda5aecbebe9b7032e4b07728b3R54-R80)`, `[[3]](diffhunk://#diff-ac5eae0b8a7f6fe5ee5cafee19fdb7a146f79cda5aecbebe9b7032e4b07728b3R129-R146)`)

**Test Consistency and Minor Fixes:**

* Fixed thumbnail URL handling in `GuessCategoryCard` tests to match the actual prop structure (`string` vs `{ uri: ... }`). (`[[1]](diffhunk://#diff-ddd333f313ddc60dad22cf6c288315cce88ff652366ab18778e514e9c28045c6L25-R25)`, `[[2]](diffhunk://#diff-ddd333f313ddc60dad22cf6c288315cce88ff652366ab18778e514e9c28045c6L92-R92)`)
* Added a missing `removedUserId` assertion in `MemberManagementScreen` tests. (`[__tests__/screens/MemberManagementScreen.test.jsR149](diffhunk://#diff-8198ea1bb90dbd12b2b2666891c30b7549fdfef4b37ca970f28ed35a256a6299R149)`)

These changes collectively improve the reliability and coverage of both manual and automated testing for private group category management features.