### PR TITLE
Feature/private groups homescreen

### DIFF
--- a/__tests__/screens/PrivateHomeScreen.test.js
+++ b/__tests__/screens/PrivateHomeScreen.test.js
@@ -533,5 +533,148 @@ describe('PrivateHomeScreen', () => {
       const deleteOrder = deletePrivateImage.mock.invocationCallOrder[0];
       expect(updateOrder).toBeLessThan(deleteOrder);
     });
+
+    it('guards against double-tap re-entry on the Choose button (uploads once)', async () => {
+      let resolveUpload;
+      uploadHomeBackground.mockImplementation(
+        () => new Promise((resolve) => { resolveUpload = resolve; })
+      );
+
+      const { renderer, navigation } = await renderScreen({
+        groupsData: {
+          owned: [{
+            id: 'g-7',
+            name: 'Waldos',
+            role: 'owner',
+            home_button_backgrounds: { hide: hideSlot },
+          }],
+          joined: [],
+        },
+      });
+
+      const headerRoot = await renderHeader(navigation);
+
+      await act(async () => {
+        headerRoot.root.findByProps({ testID: 'private-home.button.customize-colors' }).props.onPress();
+      });
+
+      const chooseButton = renderer.root.findByProps({ testID: 'private-home.button-bg.hide.choose' });
+
+      let firstCall;
+      await act(async () => {
+        firstCall = chooseButton.props.onPress();
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        chooseButton.props.onPress();
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        resolveUpload({ imageId: 'img-new' });
+        await firstCall;
+        await Promise.resolve();
+      });
+
+      expect(uploadHomeBackground).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call deletePrivateImage or deleteHomeBackgroundFile when the Choose PATCH fails (non-2xx)', async () => {
+      updateGroupSettings.mockResolvedValue({ status: 422 });
+      uploadHomeBackground.mockResolvedValue({ imageId: 'img-new' });
+
+      const { renderer, navigation } = await renderScreen({
+        groupsData: {
+          owned: [{
+            id: 'g-7',
+            name: 'Waldos',
+            role: 'owner',
+            home_button_backgrounds: { hide: hideSlot },
+          }],
+          joined: [],
+        },
+      });
+
+      const headerRoot = await renderHeader(navigation);
+
+      await act(async () => {
+        headerRoot.root.findByProps({ testID: 'private-home.button.customize-colors' }).props.onPress();
+      });
+
+      const chooseButton = renderer.root.findByProps({ testID: 'private-home.button-bg.hide.choose' });
+
+      await act(async () => {
+        await chooseButton.props.onPress();
+        await Promise.resolve();
+      });
+
+      expect(updateGroupSettings).toHaveBeenCalledWith(
+        expect.anything(),
+        'g-7',
+        { hideBgImageId: 'img-new' }
+      );
+      expect(deletePrivateImage).not.toHaveBeenCalled();
+      expect(deleteHomeBackgroundFile).not.toHaveBeenCalled();
+      expect(Alert.alert).toHaveBeenCalledWith('Error', expect.any(String));
+    });
+
+    it('runs updateGroupSettings(null) then deletePrivateImage then deleteHomeBackgroundFile then refresh on Remove', async () => {
+      updateGroupSettings.mockResolvedValue({ status: 200 });
+      const refresh = jest.fn();
+
+      mockUseActiveGroup.mockReturnValue({ scope: { kind: 'private', groupId: 'g-7' }, clear: jest.fn() });
+      mockUseGroupsHub.mockReturnValue({
+        data: {
+          owned: [{
+            id: 'g-7',
+            name: 'Waldos',
+            role: 'owner',
+            home_button_backgrounds: { hide: hideSlot },
+          }],
+        },
+        refresh,
+      });
+
+      const navigation = { navigate: jest.fn(), setOptions: jest.fn() };
+      let renderer;
+      await act(async () => {
+        renderer = create(
+          <PrivateHomeScreen
+            navigation={navigation}
+            route={{ params: { scope: { kind: 'private', groupId: 'g-7' } } }}
+          />
+        );
+        await Promise.resolve();
+      });
+
+      const headerRoot = await renderHeader(navigation);
+
+      await act(async () => {
+        headerRoot.root.findByProps({ testID: 'private-home.button.customize-colors' }).props.onPress();
+      });
+
+      const removeButton = renderer.root.findByProps({ testID: 'private-home.button-bg.hide.remove' });
+
+      await act(async () => {
+        await removeButton.props.onPress();
+        await Promise.resolve();
+      });
+
+      expect(updateGroupSettings).toHaveBeenCalledWith(
+        expect.anything(),
+        'g-7',
+        { hideBgImageId: null }
+      );
+      expect(deletePrivateImage).toHaveBeenCalledWith(expect.anything(), 'g-7', 'img-hide');
+      expect(deleteHomeBackgroundFile).toHaveBeenCalledWith('g-7', 'hide', 'img-hide');
+      expect(refresh).toHaveBeenCalled();
+
+      const updateOrder = updateGroupSettings.mock.invocationCallOrder[0];
+      const deleteOrder = deletePrivateImage.mock.invocationCallOrder[0];
+      const fileDeleteOrder = deleteHomeBackgroundFile.mock.invocationCallOrder[0];
+      expect(updateOrder).toBeLessThan(deleteOrder);
+      expect(deleteOrder).toBeLessThan(fileDeleteOrder);
+    });
   });
 });

--- a/__tests__/screens/PrivateHomeScreen.test.js
+++ b/__tests__/screens/PrivateHomeScreen.test.js
@@ -70,6 +70,17 @@ jest.mock('../../components/Groups/LockedGroupMemberBanner', () => {
 
 jest.mock('../../services/groups/groupApi', () => ({
   updateGroupSettings: jest.fn(),
+  deletePrivateImage: jest.fn(),
+}));
+
+jest.mock('../../services/groups/groupHomeBackgrounds', () => ({
+  resolveHomeBackground: jest.fn(),
+  deleteHomeBackgroundFile: jest.fn(),
+  SLOTS: ['hide', 'find', 'ranking'],
+}));
+
+jest.mock('../../services/groups/homeBackgroundUpload', () => ({
+  uploadHomeBackground: jest.fn(),
 }));
 
 jest.mock('../../hooks/useActiveGroup', () => ({
@@ -86,13 +97,18 @@ import { Share, Alert } from 'react-native';
 
 import PrivateHomeScreen from '../../screens/Groups/PrivateHomeScreen';
 import { handleOrientation } from '../../utils/orientation';
-import { updateGroupSettings } from '../../services/groups/groupApi';
+import { updateGroupSettings, deletePrivateImage } from '../../services/groups/groupApi';
+import { resolveHomeBackground, deleteHomeBackgroundFile } from '../../services/groups/groupHomeBackgrounds';
+import { uploadHomeBackground } from '../../services/groups/homeBackgroundUpload';
 
 describe('PrivateHomeScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
     jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    resolveHomeBackground.mockResolvedValue(null);
+    uploadHomeBackground.mockResolvedValue(null);
+    deletePrivateImage.mockResolvedValue({ status: 200 });
   });
 
   async function renderScreen({
@@ -411,6 +427,111 @@ describe('PrivateHomeScreen', () => {
       expect(visibleOwnerModals).toHaveLength(0);
 
       expect(mockLockedGroupMemberBanner.mock.calls).toHaveLength(0);
+    });
+  });
+
+  describe('home button backgrounds', () => {
+    const hideSlot = {
+      image_id: 'img-hide',
+      file_extension: 'png',
+      url: 'https://example.com/hide.png',
+    };
+
+    function lastHomeCardProps(testID) {
+      const calls = mockHomeCard.mock.calls.filter(
+        ([props]) => props && props.testID === testID
+      );
+      return calls[calls.length - 1][0];
+    }
+
+    it('passes the resolved uri to the Hide HomeCard when a hide background is present', async () => {
+      resolveHomeBackground.mockResolvedValue('file:///private-home-bg/g-7/hide-img-hide.png');
+
+      await renderScreen({
+        groupsData: {
+          owned: [{
+            id: 'g-7',
+            name: 'Waldos',
+            role: 'owner',
+            home_button_backgrounds: { hide: hideSlot },
+          }],
+          joined: [],
+        },
+      });
+
+      expect(resolveHomeBackground).toHaveBeenCalledWith(
+        expect.objectContaining({
+          groupId: 'g-7',
+          slot: 'hide',
+          imageId: 'img-hide',
+          fileExtension: 'png',
+          url: 'https://example.com/hide.png',
+        })
+      );
+
+      expect(lastHomeCardProps('private-home.button.hide').backgroundImage).toEqual({
+        uri: 'file:///private-home-bg/g-7/hide-img-hide.png',
+      });
+    });
+
+    it('falls back to the bundled asset when no background is set for the slot', async () => {
+      const bundledHide = require('../../assets/home/WoIstWaldo-character-hide.webp');
+
+      await renderScreen({
+        groupsData: {
+          owned: [{ id: 'g-7', name: 'Waldos', role: 'owner' }],
+          joined: [],
+        },
+      });
+
+      expect(resolveHomeBackground).not.toHaveBeenCalled();
+
+      expect(lastHomeCardProps('private-home.button.hide').backgroundImage).toBe(bundledHide);
+    });
+
+    it('runs updateGroupSettings then deletePrivateImage in order when the owner chooses a new hide background', async () => {
+      updateGroupSettings.mockResolvedValue({ status: 200 });
+      uploadHomeBackground.mockResolvedValue({ imageId: 'img-new' });
+
+      const { renderer, navigation } = await renderScreen({
+        groupsData: {
+          owned: [{
+            id: 'g-7',
+            name: 'Waldos',
+            role: 'owner',
+            home_button_backgrounds: { hide: hideSlot },
+          }],
+          joined: [],
+        },
+      });
+
+      const headerRoot = await renderHeader(navigation);
+
+      await act(async () => {
+        headerRoot.root.findByProps({ testID: 'private-home.button.customize-colors' }).props.onPress();
+      });
+
+      const chooseButton = renderer.root.findByProps({ testID: 'private-home.button-bg.hide.choose' });
+
+      await act(async () => {
+        await chooseButton.props.onPress();
+        await Promise.resolve();
+      });
+
+      expect(uploadHomeBackground).toHaveBeenCalledWith(
+        expect.objectContaining({ groupId: 'g-7' })
+      );
+      expect(updateGroupSettings).toHaveBeenCalledWith(
+        expect.anything(),
+        'g-7',
+        { hideBgImageId: 'img-new' }
+      );
+      expect(deletePrivateImage).toHaveBeenCalledWith(expect.anything(), 'g-7', 'img-hide');
+      expect(deleteHomeBackgroundFile).toHaveBeenCalledWith('g-7', 'hide', 'img-hide');
+
+      const updateOrder = updateGroupSettings.mock.invocationCallOrder[0];
+      const deleteOrder = deletePrivateImage.mock.invocationCallOrder[0];
+      expect(updateOrder).toBeLessThan(deleteOrder);
     });
   });
 });

--- a/__tests__/services/groupApi.test.js
+++ b/__tests__/services/groupApi.test.js
@@ -24,16 +24,22 @@ jest.mock('../../services/groups/groupCategoryThumbnails', () => ({
   clearGroupThumbnails: jest.fn(),
 }));
 
+jest.mock('../../services/groups/groupHomeBackgrounds', () => ({
+  clearGroupHomeBackgrounds: jest.fn(),
+}));
+
 import axios from 'axios';
 import { getBackendHeaders, setHeaders } from '../../utils/auth';
 import { clearGroupFeedCache, purgeAllPrivateCaches } from '../../services/groups/groupFeedCache';
 import { clearGroupThumbnails } from '../../services/groups/groupCategoryThumbnails';
+import { clearGroupHomeBackgrounds } from '../../services/groups/groupHomeBackgrounds';
 
 import {
   fetchGroups,
   createGroup,
   updateGroupSettings,
   deleteGroup,
+  deletePrivateImage,
   setActiveGroup,
 } from '../../services/groups/groupApi';
 import {
@@ -126,6 +132,52 @@ describe('services/groups', () => {
       );
     });
 
+    it('updateGroupSettings PATCHes hide_bg_image_id and null-clears when null is supplied', async () => {
+      axios.patch.mockResolvedValue({ status: 200, data: { id: 'g-1' } });
+
+      await updateGroupSettings(CONTEXT, 'g-1', {
+        hideBgImageId: 'img-1',
+        findBgImageId: 'img-2',
+        rankingBgImageId: 'img-3',
+      });
+
+      expect(axios.patch).toHaveBeenCalledWith(
+        'https://backend.example/api/v1/private_groups/g-1/',
+        {
+          private_group: {
+            hide_bg_image_id: 'img-1',
+            find_bg_image_id: 'img-2',
+            ranking_bg_image_id: 'img-3',
+          },
+        },
+        { headers: AUTH_HEADERS }
+      );
+    });
+
+    it('updateGroupSettings sends null to clear a slot', async () => {
+      axios.patch.mockResolvedValue({ status: 200, data: { id: 'g-1' } });
+
+      await updateGroupSettings(CONTEXT, 'g-1', { hideBgImageId: null });
+
+      expect(axios.patch).toHaveBeenCalledWith(
+        'https://backend.example/api/v1/private_groups/g-1/',
+        { private_group: { hide_bg_image_id: null } },
+        { headers: AUTH_HEADERS }
+      );
+    });
+
+    it('deletePrivateImage DELETEs the nested private image endpoint', async () => {
+      axios.delete.mockResolvedValue({ status: 204, data: null });
+
+      const response = await deletePrivateImage(CONTEXT, 'g-1', 'img-7');
+
+      expect(axios.delete).toHaveBeenCalledWith(
+        'https://backend.example/api/v1/private_groups/g-1/images/img-7',
+        { headers: AUTH_HEADERS }
+      );
+      expect(response.status).toBe(204);
+    });
+
     it('deleteGroup DELETEs the group endpoint and clears private caches on success', async () => {
       axios.delete.mockResolvedValue({ status: 204, data: null });
 
@@ -137,6 +189,7 @@ describe('services/groups', () => {
       );
       expect(clearGroupFeedCache).toHaveBeenCalledWith('g-1');
       expect(clearGroupThumbnails).toHaveBeenCalledWith('g-1');
+      expect(clearGroupHomeBackgrounds).toHaveBeenCalledWith('g-1');
       expect(purgeAllPrivateCaches).toHaveBeenCalledTimes(1);
       expect(response.status).toBe(204);
     });

--- a/__tests__/services/groupHomeBackgrounds.test.js
+++ b/__tests__/services/groupHomeBackgrounds.test.js
@@ -13,6 +13,7 @@ jest.mock('expo-file-system', () => {
     createdUris: [],
     writtenUris: [],
     writeError: null,
+    listings: {},
   };
 
   function joinArgs(args) {
@@ -50,6 +51,7 @@ jest.mock('expo-file-system', () => {
     this.create = jest.fn(() => {
       state.createdUris.push(this.uri);
     });
+    this.list = jest.fn(() => state.listings[this.uri] || []);
   });
 
   const cacheStore = {
@@ -64,6 +66,7 @@ jest.mock('expo-file-system', () => {
     state.createdUris.length = 0;
     state.writtenUris.length = 0;
     state.writeError = null;
+    state.listings = {};
     cacheStore.list = () => [];
     cacheStore.create = jest.fn();
     File.mockClear();
@@ -79,7 +82,8 @@ jest.mock('expo-file-system', () => {
     }
   };
 
-  return { File, Paths };
+  const Directory = File;
+  return { File, Directory, Paths };
 });
 
 jest.mock('../../utils/imagesRequests', () => ({
@@ -100,6 +104,7 @@ import {
   deleteHomeBackgroundFile,
   clearGroupHomeBackgrounds,
 } from '../../services/groups/groupHomeBackgrounds';
+import { usesBackendStorage } from '../../utils/imagesRequests';
 
 const CONTEXT = { token: 'Bearer t', userId: 'u-1' };
 
@@ -108,6 +113,8 @@ describe('services/groups/groupHomeBackgrounds', () => {
     axios.get.mockReset();
     fromByteArray.mockClear();
     File.__reset();
+    usesBackendStorage.mockReset();
+    usesBackendStorage.mockReturnValue(false);
   });
 
   it('exports the three slot keys', () => {
@@ -184,6 +191,62 @@ describe('services/groups/groupHomeBackgrounds', () => {
     expect(File.__state.writtenUris).toHaveLength(0);
   });
 
+  it('downloads from backend storage with text + data-url prefix stripping and writes the cached file', async () => {
+    usesBackendStorage.mockReturnValue(true);
+    File.__state.existsOverride = false;
+    const dataUrl = 'data:image/jpeg;base64,ChQe';
+    axios.get.mockResolvedValue({
+      data: dataUrl,
+      headers: { 'content-type': 'text/plain' },
+    });
+
+    const uri = await resolveHomeBackground({
+      context: CONTEXT,
+      groupId: 'g-2',
+      slot: 'hide',
+      imageId: 'img-be-1',
+      fileExtension: 'jpeg',
+      url: 'https://api.example.com/storage/home/img-be-1.jpeg',
+    });
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://api.example.com/storage/home/img-be-1.jpeg',
+      {
+        headers: { Authorization: 'Bearer t', HTTP_AUTHORIZATION: 'Bearer t' },
+        responseType: 'text',
+        timeout: 15000,
+      }
+    );
+    expect(fromByteArray).not.toHaveBeenCalled();
+    expect(uri).toEqual(
+      expect.stringContaining('private-home-bg/g-2/hide-img-be-1.jpeg')
+    );
+    expect(File.__state.writtenUris).toHaveLength(1);
+    expect(File.__state.writtenUris[0]).toEqual({
+      uri: expect.stringContaining('private-home-bg/g-2/hide-img-be-1.jpeg'),
+      data: 'ChQe',
+      options: { encoding: 'base64' },
+    });
+  });
+
+  it('returns null instead of the remote url when a backend-storage download fails', async () => {
+    usesBackendStorage.mockReturnValue(true);
+    File.__state.existsOverride = false;
+    axios.get.mockRejectedValue(new Error('401'));
+
+    const uri = await resolveHomeBackground({
+      context: CONTEXT,
+      groupId: 'g-2',
+      slot: 'find',
+      imageId: 'img-be-2',
+      fileExtension: 'png',
+      url: 'https://api.example.com/storage/home/img-be-2.png',
+    });
+
+    expect(uri).toBeNull();
+    expect(File.__state.writtenUris).toHaveLength(0);
+  });
+
   it('returns null when imageId or slot is missing', async () => {
     const uri = await resolveHomeBackground({
       context: CONTEXT,
@@ -224,5 +287,28 @@ describe('services/groups/groupHomeBackgrounds', () => {
 
     expect(() => clearGroupHomeBackgrounds('g-1')).not.toThrow();
     expect(File.__state.deletedUris).toHaveLength(0);
+  });
+
+  it('clearGroupHomeBackgrounds deletes each cached child file before deleting the directory', () => {
+    File.__state.existsOverride = true;
+    const groupDirUri = 'file:///cache/private-home-bg/g-1';
+    File.__state.listings[groupDirUri] = [
+      'file:///cache/private-home-bg/g-1/hide-img-1.png',
+      'file:///cache/private-home-bg/g-1/find-img-2.jpeg',
+      'file:///cache/private-home-bg/g-1/ranking-img-3.webp',
+    ];
+
+    clearGroupHomeBackgrounds('g-1');
+
+    const deleted = File.__state.deletedUris;
+    expect(deleted).toEqual(
+      expect.arrayContaining([
+        'file:///cache/private-home-bg/g-1/hide-img-1.png',
+        'file:///cache/private-home-bg/g-1/find-img-2.jpeg',
+        'file:///cache/private-home-bg/g-1/ranking-img-3.webp',
+        groupDirUri,
+      ])
+    );
+    expect(deleted[deleted.length - 1]).toBe(groupDirUri);
   });
 });

--- a/__tests__/services/groupHomeBackgrounds.test.js
+++ b/__tests__/services/groupHomeBackgrounds.test.js
@@ -1,0 +1,228 @@
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+jest.mock('base64-js', () => ({
+  fromByteArray: jest.fn((bytes) => `b64:${bytes.length}`),
+}));
+
+jest.mock('expo-file-system', () => {
+  const state = {
+    existsOverride: null,
+    deletedUris: [],
+    createdUris: [],
+    writtenUris: [],
+    writeError: null,
+  };
+
+  function joinArgs(args) {
+    let base = '';
+    for (const arg of args) {
+      if (arg == null) continue;
+      const text = typeof arg === 'string' ? arg : arg?.uri;
+      if (typeof text !== 'string' || text.length === 0) continue;
+      if (base.length === 0) {
+        base = text;
+      } else if (base.endsWith('/')) {
+        base = `${base}${text}`;
+      } else {
+        base = `${base}/${text}`;
+      }
+    }
+    return base;
+  }
+
+  const File = jest.fn().mockImplementation(function MockFile(...args) {
+    this.uri = joinArgs(args);
+    const override = state.existsOverride;
+    this.exists = typeof override === 'function'
+      ? override(this.uri)
+      : (override === null ? true : override);
+    this.write = jest.fn((data, options) => {
+      if (state.writeError) {
+        throw state.writeError;
+      }
+      state.writtenUris.push({ uri: this.uri, data, options });
+    });
+    this.delete = jest.fn(() => {
+      state.deletedUris.push(this.uri);
+    });
+    this.create = jest.fn(() => {
+      state.createdUris.push(this.uri);
+    });
+  });
+
+  const cacheStore = {
+    uri: 'file:///cache/',
+    list: () => [],
+    create: jest.fn(),
+  };
+
+  function resetMockState() {
+    state.existsOverride = null;
+    state.deletedUris.length = 0;
+    state.createdUris.length = 0;
+    state.writtenUris.length = 0;
+    state.writeError = null;
+    cacheStore.list = () => [];
+    cacheStore.create = jest.fn();
+    File.mockClear();
+  }
+
+  File.__state = state;
+  File.__cacheStore = cacheStore;
+  File.__reset = resetMockState;
+
+  const Paths = class MockPaths {
+    static get cache() {
+      return cacheStore;
+    }
+  };
+
+  return { File, Paths };
+});
+
+jest.mock('../../utils/imagesRequests', () => ({
+  usesBackendStorage: jest.fn(() => false),
+  setStorageDownloadHeaders: jest.fn((token) => ({
+    Authorization: token,
+    HTTP_AUTHORIZATION: token,
+  })),
+  getBackendHeaders: jest.fn(async () => ({ token: 'Bearer t' })),
+}));
+
+import axios from 'axios';
+import { fromByteArray } from 'base64-js';
+import { File } from 'expo-file-system';
+import {
+  SLOTS,
+  resolveHomeBackground,
+  deleteHomeBackgroundFile,
+  clearGroupHomeBackgrounds,
+} from '../../services/groups/groupHomeBackgrounds';
+
+const CONTEXT = { token: 'Bearer t', userId: 'u-1' };
+
+describe('services/groups/groupHomeBackgrounds', () => {
+  beforeEach(() => {
+    axios.get.mockReset();
+    fromByteArray.mockClear();
+    File.__reset();
+  });
+
+  it('exports the three slot keys', () => {
+    expect(SLOTS).toEqual(['hide', 'find', 'ranking']);
+  });
+
+  it('returns the cached URI without downloading when the local file already exists', async () => {
+    File.__state.existsOverride = true;
+
+    const uri = await resolveHomeBackground({
+      context: CONTEXT,
+      groupId: 'g-1',
+      slot: 'hide',
+      imageId: 'img-1',
+      fileExtension: 'png',
+      url: 'https://presigned.example.com/home/img-1.png',
+    });
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(uri).toEqual(expect.stringContaining('private-home-bg/g-1/hide-img-1.png'));
+    expect(File.__state.writtenUris).toHaveLength(0);
+  });
+
+  it('ensures the nested dir, downloads, and writes the file when missing', async () => {
+    File.__state.existsOverride = false;
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    axios.get.mockResolvedValue({
+      data: bytes,
+      headers: { 'content-type': 'image/png' },
+    });
+
+    const uri = await resolveHomeBackground({
+      context: CONTEXT,
+      groupId: 'g-1',
+      slot: 'find',
+      imageId: 'img-2',
+      fileExtension: 'png',
+      url: 'https://presigned.example.com/home/img-2.png',
+    });
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://presigned.example.com/home/img-2.png',
+      { responseType: 'arraybuffer', timeout: 15000 }
+    );
+    expect(fromByteArray).toHaveBeenCalledWith(bytes);
+    expect(uri).toEqual(
+      expect.stringContaining('private-home-bg/g-1/find-img-2.png')
+    );
+    expect(File.__state.createdUris).toEqual([
+      expect.stringContaining('private-home-bg/g-1'),
+    ]);
+    expect(File.__state.writtenUris).toHaveLength(1);
+    expect(File.__state.writtenUris[0]).toEqual({
+      uri: expect.stringContaining('private-home-bg/g-1/find-img-2.png'),
+      data: 'b64:4',
+      options: { encoding: 'base64' },
+    });
+  });
+
+  it('falls back to the remote url when the download fails', async () => {
+    File.__state.existsOverride = false;
+    axios.get.mockRejectedValue(new Error('network down'));
+
+    const uri = await resolveHomeBackground({
+      context: CONTEXT,
+      groupId: 'g-1',
+      slot: 'ranking',
+      imageId: 'img-3',
+      fileExtension: 'png',
+      url: 'https://presigned.example.com/home/img-3.png',
+    });
+
+    expect(uri).toBe('https://presigned.example.com/home/img-3.png');
+    expect(File.__state.writtenUris).toHaveLength(0);
+  });
+
+  it('returns null when imageId or slot is missing', async () => {
+    const uri = await resolveHomeBackground({
+      context: CONTEXT,
+      groupId: 'g-1',
+      slot: 'hide',
+      imageId: null,
+      fileExtension: 'png',
+      url: 'https://presigned.example.com/home/x.png',
+    });
+
+    expect(uri).toBeNull();
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  it('deleteHomeBackgroundFile best-effort deletes the slot cache file across extensions', () => {
+    File.__state.existsOverride = true;
+
+    deleteHomeBackgroundFile('g-1', 'hide', 'img-1');
+
+    const deleted = File.__state.deletedUris.filter((u) =>
+      u.includes('private-home-bg/g-1/hide-img-1')
+    );
+    expect(deleted.length).toBeGreaterThan(0);
+  });
+
+  it('clearGroupHomeBackgrounds deletes the nested group directory', () => {
+    File.__state.existsOverride = true;
+
+    clearGroupHomeBackgrounds('g-1');
+
+    expect(File.__state.deletedUris).toEqual([
+      expect.stringContaining('private-home-bg/g-1'),
+    ]);
+  });
+
+  it('clearGroupHomeBackgrounds is best-effort when the dir is absent', () => {
+    File.__state.existsOverride = false;
+
+    expect(() => clearGroupHomeBackgrounds('g-1')).not.toThrow();
+    expect(File.__state.deletedUris).toHaveLength(0);
+  });
+});

--- a/__tests__/services/homeBackgroundUpload.test.js
+++ b/__tests__/services/homeBackgroundUpload.test.js
@@ -6,12 +6,20 @@ const mockManipulate = jest.fn();
 const mockResize = jest.fn();
 const mockRenderAsync = jest.fn();
 const mockSaveAsync = jest.fn();
+const mockFileSizeFor = jest.fn();
 
 jest.mock('expo-image-manipulator', () => ({
   ImageManipulator: {
     manipulate: (...args) => mockManipulate(...args),
   },
   SaveFormat: { JPEG: 'jpeg', PNG: 'png', WEBP: 'webp' },
+}));
+
+jest.mock('expo-file-system', () => ({
+  File: function File(uri) {
+    this.uri = uri;
+    this.size = mockFileSizeFor(uri);
+  },
 }));
 
 jest.mock('../../services/groups/groupUploadApi', () => ({
@@ -54,6 +62,9 @@ describe('services/groups/homeBackgroundUpload', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetManipulatorChain();
+    mockFileSizeFor.mockImplementation((uri) =>
+      uri === 'file:///tmp/manipulated.jpg' ? 150_000 : undefined
+    );
   });
 
   it('returns null when the picker is cancelled', async () => {
@@ -97,16 +108,16 @@ describe('services/groups/homeBackgroundUpload', () => {
       context: CONTEXT,
       groupId: 'g-1',
       kind: 'home-button-background',
-      fileExtension: 'jpg',
-      contentType: 'image/jpg',
-      contentLength: 2_000_000,
+      fileExtension: 'jpeg',
+      contentType: 'image/jpeg',
+      contentLength: 150_000,
       isHomeButtonBackground: true,
     });
     expect(performImageUpload).toHaveBeenCalledWith({
       plan: { imageId: 'img-9', url: 'https://upload.example/' },
       fileUrl: 'file:///tmp/manipulated.jpg',
-      fileExtension: 'jpg',
-      contentLength: 2_000_000,
+      fileExtension: 'jpeg',
+      contentLength: 150_000,
       context: CONTEXT,
     });
     expect(result).toEqual({ imageId: 'img-9' });

--- a/__tests__/services/homeBackgroundUpload.test.js
+++ b/__tests__/services/homeBackgroundUpload.test.js
@@ -1,0 +1,148 @@
+jest.mock('expo-image-picker', () => ({
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+const mockManipulate = jest.fn();
+const mockResize = jest.fn();
+const mockRenderAsync = jest.fn();
+const mockSaveAsync = jest.fn();
+
+jest.mock('expo-image-manipulator', () => ({
+  ImageManipulator: {
+    manipulate: (...args) => mockManipulate(...args),
+  },
+  SaveFormat: { JPEG: 'jpeg', PNG: 'png', WEBP: 'webp' },
+}));
+
+jest.mock('../../services/groups/groupUploadApi', () => ({
+  preparePrivateUpload: jest.fn(),
+}));
+
+jest.mock('../../utils/imagesRequests', () => ({
+  performImageUpload: jest.fn(),
+}));
+
+import * as ImagePicker from 'expo-image-picker';
+import { preparePrivateUpload } from '../../services/groups/groupUploadApi';
+import { performImageUpload } from '../../utils/imagesRequests';
+import { uploadHomeBackground } from '../../services/groups/homeBackgroundUpload';
+
+const CONTEXT = { token: 'Bearer t', userId: 'u-1' };
+
+function resetManipulatorChain() {
+  mockManipulate.mockReset();
+  mockResize.mockReset();
+  mockRenderAsync.mockReset();
+  mockSaveAsync.mockReset();
+
+  mockManipulate.mockImplementation(() => {
+    const context = {
+      resize: mockResize.mockReturnValue(context),
+      renderAsync: mockRenderAsync.mockResolvedValue({
+        saveAsync: mockSaveAsync.mockResolvedValue({
+          uri: 'file:///tmp/manipulated.jpg',
+          width: 1080,
+          height: 810,
+        }),
+      }),
+    };
+    return context;
+  });
+}
+
+describe('services/groups/homeBackgroundUpload', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetManipulatorChain();
+  });
+
+  it('returns null when the picker is cancelled', async () => {
+    ImagePicker.launchImageLibraryAsync.mockResolvedValue({ canceled: true });
+
+    const result = await uploadHomeBackground({ context: CONTEXT, groupId: 'g-1' });
+
+    expect(result).toBeNull();
+    expect(preparePrivateUpload).not.toHaveBeenCalled();
+    expect(performImageUpload).not.toHaveBeenCalled();
+  });
+
+  it('picks, downscales, presigns as home-button-background, uploads, and returns imageId', async () => {
+    ImagePicker.launchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///photos/big.jpg',
+          width: 4032,
+          height: 3024,
+          fileSize: 2_000_000,
+        },
+      ],
+    });
+    preparePrivateUpload.mockResolvedValue({
+      status: 200,
+      data: { imageId: 'img-9', url: 'https://upload.example/' },
+    });
+    performImageUpload.mockResolvedValue({ status: 200 });
+
+    const result = await uploadHomeBackground({ context: CONTEXT, groupId: 'g-1' });
+
+    expect(ImagePicker.launchImageLibraryAsync).toHaveBeenCalledWith({
+      allowsEditing: true,
+      aspect: [4, 3],
+      mediaTypes: ['images'],
+    });
+    expect(mockManipulate).toHaveBeenCalledWith('file:///photos/big.jpg');
+    expect(mockResize).toHaveBeenCalledWith({ width: 1080 });
+    expect(preparePrivateUpload).toHaveBeenCalledWith({
+      context: CONTEXT,
+      groupId: 'g-1',
+      kind: 'home-button-background',
+      fileExtension: 'jpg',
+      contentType: 'image/jpg',
+      contentLength: 2_000_000,
+      isHomeButtonBackground: true,
+    });
+    expect(performImageUpload).toHaveBeenCalledWith({
+      plan: { imageId: 'img-9', url: 'https://upload.example/' },
+      fileUrl: 'file:///tmp/manipulated.jpg',
+      fileExtension: 'jpg',
+      contentLength: 2_000_000,
+      context: CONTEXT,
+    });
+    expect(result).toEqual({ imageId: 'img-9' });
+  });
+
+  it('skips the resize step when the picked asset is already narrower than 1080px', async () => {
+    ImagePicker.launchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [
+        { uri: 'file:///photos/small.jpg', width: 800, height: 600, fileSize: 100 },
+      ],
+    });
+    preparePrivateUpload.mockResolvedValue({
+      status: 200,
+      data: { imageId: 'img-1' },
+    });
+    performImageUpload.mockResolvedValue({ status: 200 });
+
+    await uploadHomeBackground({ context: CONTEXT, groupId: 'g-1' });
+
+    expect(mockResize).not.toHaveBeenCalled();
+    expect(preparePrivateUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'home-button-background', isHomeButtonBackground: true })
+    );
+  });
+
+  it('throws when presign does not return a success status', async () => {
+    ImagePicker.launchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file:///photos/big.jpg', width: 2000, fileSize: 1000 }],
+    });
+    preparePrivateUpload.mockResolvedValue({ status: 422, data: {} });
+
+    await expect(
+      uploadHomeBackground({ context: CONTEXT, groupId: 'g-1' })
+    ).rejects.toThrow('Could not prepare upload.');
+    expect(performImageUpload).not.toHaveBeenCalled();
+  });
+});

--- a/components/UI/CenteredModal.js
+++ b/components/UI/CenteredModal.js
@@ -63,6 +63,7 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     alignItems: 'center',
     maxWidth: '80%',
+    maxHeight: '85%',
   },
   modalText: {
     fontSize: 18,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "expo-constants": "~56.0.18",
         "expo-dev-client": "^56.0.20",
         "expo-file-system": "~56.0.8",
-        "expo-image-manipulator": "^57.0.2",
+        "expo-image-manipulator": "~56.0.21",
         "expo-image-picker": "~56.0.18",
         "expo-linking": "^56.0.14",
         "expo-media-library": "~56.0.7",
@@ -4593,22 +4593,13 @@
       }
     },
     "node_modules/expo-image-manipulator": {
-      "version": "57.0.2",
-      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-57.0.2.tgz",
-      "integrity": "sha512-kpV7oUJ+9/Fi3dAq2n4KuHnBMRrK7NsYgVyb9Oe8ekBp7jyWf6ndVk484dW3zwsM+DYaC0OkML3TvlQwQwa/1w==",
+      "version": "56.0.21",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-56.0.21.tgz",
+      "integrity": "sha512-4ccJzeKDC/DholrOLHl1/L7maPW8cvyOflhNNfCl0CVJYK06YkZlDbGjN6Q0I5XnsQb/6Zgg2+P2p/NIBGTxcw==",
       "license": "MIT",
       "dependencies": {
-        "expo-image-loader": "~57.0.0"
+        "expo-image-loader": "~56.0.3"
       },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-image-manipulator/node_modules/expo-image-loader": {
-      "version": "57.0.0",
-      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-57.0.0.tgz",
-      "integrity": "sha512-EhwnoPC4T/EMdB7Nsg7qITzhO/qB0hUnmVghmtAKQwwDVaLWWYCGE4NLkes3zk9Ub451SmS/swgPp4PCPzOlnw==",
-      "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo-constants": "~56.0.18",
         "expo-dev-client": "^56.0.20",
         "expo-file-system": "~56.0.8",
+        "expo-image-manipulator": "^57.0.2",
         "expo-image-picker": "~56.0.18",
         "expo-linking": "^56.0.14",
         "expo-media-library": "~56.0.7",
@@ -4586,6 +4587,27 @@
       "version": "56.0.3",
       "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-56.0.3.tgz",
       "integrity": "sha512-JgUo4fUeU1ZC+z8iBFj8v7yoGQnZrLbOVPyNE+DWVrld55F2F6R1ck+rmdm/8TNWLz1LhNQfD7c3XYP1ZikxXA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator": {
+      "version": "57.0.2",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-57.0.2.tgz",
+      "integrity": "sha512-kpV7oUJ+9/Fi3dAq2n4KuHnBMRrK7NsYgVyb9Oe8ekBp7jyWf6ndVk484dW3zwsM+DYaC0OkML3TvlQwQwa/1w==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~57.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator/node_modules/expo-image-loader": {
+      "version": "57.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-57.0.0.tgz",
+      "integrity": "sha512-EhwnoPC4T/EMdB7Nsg7qITzhO/qB0hUnmVghmtAKQwwDVaLWWYCGE4NLkes3zk9Ub451SmS/swgPp4PCPzOlnw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "expo-constants": "~56.0.18",
     "expo-dev-client": "^56.0.20",
     "expo-file-system": "~56.0.8",
-    "expo-image-manipulator": "^57.0.2",
+    "expo-image-manipulator": "~56.0.21",
     "expo-image-picker": "~56.0.18",
     "expo-linking": "^56.0.14",
     "expo-media-library": "~56.0.7",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo-constants": "~56.0.18",
     "expo-dev-client": "^56.0.20",
     "expo-file-system": "~56.0.8",
+    "expo-image-manipulator": "^57.0.2",
     "expo-image-picker": "~56.0.18",
     "expo-linking": "^56.0.14",
     "expo-media-library": "~56.0.7",

--- a/screens/Groups/PrivateHomeScreen.js
+++ b/screens/Groups/PrivateHomeScreen.js
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, Share, Alert, ScrollView } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 
@@ -55,6 +55,12 @@ export default function PrivateHomeScreen({ navigation, route }) {
   const [isLockedOwnerModalVisible, setIsLockedOwnerModalVisible] = useState(isLocked && isOwner);
   const [bgUris, setBgUris] = useState({});
   const [savingSlot, setSavingSlot] = useState({});
+  const savingSlotRef = useRef({});
+
+  const setSaving = useCallback((slot, value) => {
+    savingSlotRef.current = { ...savingSlotRef.current, [slot]: value };
+    setSavingSlot((prev) => ({ ...prev, [slot]: value }));
+  }, []);
 
   useEffect(() => {
     setIsLockedOwnerModalVisible(isLocked && isOwner);
@@ -146,13 +152,17 @@ export default function PrivateHomeScreen({ navigation, route }) {
 
   const chooseSlotBackground = useCallback(async (slot) => {
     if (!groupId) return;
+    if (savingSlotRef.current[slot]) return;
     const settingsKey = SLOT_SETTINGS_KEY[slot];
     const prevImageId = group?.home_button_backgrounds?.[slot]?.image_id;
-    setSavingSlot((prev) => ({ ...prev, [slot]: true }));
+    setSaving(slot, true);
     try {
       const { imageId } = await uploadHomeBackground({ context: authContext, groupId });
       if (!imageId) return;
-      await updateGroupSettings(authContext, groupId, { [settingsKey]: imageId });
+      const response = await updateGroupSettings(authContext, groupId, { [settingsKey]: imageId });
+      if (response?.status !== 200 && response?.status !== 204) {
+        throw new Error(`PATCH failed with status ${response?.status}`);
+      }
       if (prevImageId) {
         await deletePrivateImage(authContext, groupId, prevImageId);
         deleteHomeBackgroundFile(groupId, slot, prevImageId);
@@ -161,27 +171,31 @@ export default function PrivateHomeScreen({ navigation, route }) {
     } catch (err) {
       Alert.alert('Error', err?.message ?? 'Could not update background.');
     } finally {
-      setSavingSlot((prev) => ({ ...prev, [slot]: false }));
+      setSaving(slot, false);
     }
-  }, [authContext, groupId, group, refresh]);
+  }, [authContext, groupId, group, refresh, setSaving]);
 
   const removeSlotBackground = useCallback(async (slot) => {
     if (!groupId) return;
+    if (savingSlotRef.current[slot]) return;
     const settingsKey = SLOT_SETTINGS_KEY[slot];
     const prevImageId = group?.home_button_backgrounds?.[slot]?.image_id;
     if (!prevImageId) return;
-    setSavingSlot((prev) => ({ ...prev, [slot]: true }));
+    setSaving(slot, true);
     try {
-      await updateGroupSettings(authContext, groupId, { [settingsKey]: null });
+      const response = await updateGroupSettings(authContext, groupId, { [settingsKey]: null });
+      if (response?.status !== 200 && response?.status !== 204) {
+        throw new Error(`PATCH failed with status ${response?.status}`);
+      }
       await deletePrivateImage(authContext, groupId, prevImageId);
       deleteHomeBackgroundFile(groupId, slot, prevImageId);
       await refresh();
     } catch (err) {
       Alert.alert('Error', err?.message ?? 'Could not remove background.');
     } finally {
-      setSavingSlot((prev) => ({ ...prev, [slot]: false }));
+      setSaving(slot, false);
     }
-  }, [authContext, groupId, group, refresh]);
+  }, [authContext, groupId, group, refresh, setSaving]);
 
   useEffect(() => {
     navigation.setOptions({

--- a/screens/Groups/PrivateHomeScreen.js
+++ b/screens/Groups/PrivateHomeScreen.js
@@ -1,11 +1,12 @@
 import { useCallback, useContext, useEffect, useState } from 'react';
-import { View, Text, StyleSheet, Share, Alert } from 'react-native';
+import { View, Text, StyleSheet, Share, Alert, ScrollView } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 
 import CenteredModal from '../../components/UI/CenteredModal';
 import ColorPalettePicker from '../../components/UI/ColorPalettePicker';
 import HomeCard from '../../components/UI/HomeCard';
 import IconButton from '../../components/UI/IconButton';
+import BigButton from '../../components/UI/BigButton';
 import LockedGroupOwnerModal from '../../components/Groups/LockedGroupOwnerModal';
 import LockedGroupMemberBanner from '../../components/Groups/LockedGroupMemberBanner';
 import { GlobalStyle } from '../../constants/theme';
@@ -13,11 +14,25 @@ import { handleOrientation } from '../../utils/orientation';
 import { useActiveGroup } from '../../hooks/useActiveGroup';
 import { useGroupsHub } from '../../hooks/useGroupsHub';
 import { AuthContext } from '../../store/auth-context';
-import { updateGroupSettings } from '../../services/groups/groupApi';
+import { updateGroupSettings, deletePrivateImage } from '../../services/groups/groupApi';
+import { resolveHomeBackground, deleteHomeBackgroundFile } from '../../services/groups/groupHomeBackgrounds';
+import { uploadHomeBackground } from '../../services/groups/homeBackgroundUpload';
 
 const HideImage = require('../../assets/home/WoIstWaldo-character-hide.webp');
 const FindImage = require('../../assets/home/WoIstWaldo-character-guess-4-3.webp');
 const RankingImage = require('../../assets/home/WoIstWaldo-character-stats.webp');
+
+const BACKGROUND_SLOTS = [
+  { slot: 'hide', label: 'Hide Waldo' },
+  { slot: 'find', label: 'Find Waldo' },
+  { slot: 'ranking', label: 'Ranking' },
+];
+
+const SLOT_SETTINGS_KEY = {
+  hide: 'hideBgImageId',
+  find: 'findBgImageId',
+  ranking: 'rankingBgImageId',
+};
 
 export default function PrivateHomeScreen({ navigation, route }) {
   const routeScope = route?.params?.scope;
@@ -38,6 +53,8 @@ export default function PrivateHomeScreen({ navigation, route }) {
   const [editorSecondary, setEditorSecondary] = useState(group?.secondary_color ?? GlobalStyle.color.secondaryColor);
   const [isSavingColors, setIsSavingColors] = useState(false);
   const [isLockedOwnerModalVisible, setIsLockedOwnerModalVisible] = useState(isLocked && isOwner);
+  const [bgUris, setBgUris] = useState({});
+  const [savingSlot, setSavingSlot] = useState({});
 
   useEffect(() => {
     setIsLockedOwnerModalVisible(isLocked && isOwner);
@@ -47,6 +64,41 @@ export default function PrivateHomeScreen({ navigation, route }) {
     setEditorPrimary(group?.primary_color ?? GlobalStyle.color.primaryColor);
     setEditorSecondary(group?.secondary_color ?? GlobalStyle.color.secondaryColor);
   }, [group?.primary_color, group?.secondary_color]);
+
+  useEffect(() => {
+    let mounted = true;
+    if (!groupId) {
+      setBgUris({});
+      return;
+    }
+    const snapshots = {
+      hide: group?.home_button_backgrounds?.hide,
+      find: group?.home_button_backgrounds?.find,
+      ranking: group?.home_button_backgrounds?.ranking,
+    };
+    setBgUris({});
+    BACKGROUND_SLOTS.forEach(async ({ slot }) => {
+      const slotData = snapshots[slot];
+      if (!slotData?.image_id) return;
+      const imageIdAtCall = slotData.image_id;
+      const uri = await resolveHomeBackground({
+        context: authContext,
+        groupId,
+        slot,
+        imageId: imageIdAtCall,
+        fileExtension: slotData.file_extension,
+        url: slotData.url,
+      });
+      if (!mounted) return;
+      setBgUris((prev) => (uri ? { ...prev, [slot]: uri } : prev));
+    });
+    return () => { mounted = false; };
+  }, [
+    group?.home_button_backgrounds?.hide?.image_id,
+    group?.home_button_backgrounds?.find?.image_id,
+    group?.home_button_backgrounds?.ranking?.image_id,
+    groupId,
+  ]);
 
   const shareCode = useCallback(async () => {
     const code = group?.joining_code;
@@ -91,6 +143,45 @@ export default function PrivateHomeScreen({ navigation, route }) {
       setIsSavingColors(false);
     }
   }, [authContext, groupId, editorPrimary, editorSecondary, refresh]);
+
+  const chooseSlotBackground = useCallback(async (slot) => {
+    if (!groupId) return;
+    const settingsKey = SLOT_SETTINGS_KEY[slot];
+    const prevImageId = group?.home_button_backgrounds?.[slot]?.image_id;
+    setSavingSlot((prev) => ({ ...prev, [slot]: true }));
+    try {
+      const { imageId } = await uploadHomeBackground({ context: authContext, groupId });
+      if (!imageId) return;
+      await updateGroupSettings(authContext, groupId, { [settingsKey]: imageId });
+      if (prevImageId) {
+        await deletePrivateImage(authContext, groupId, prevImageId);
+        deleteHomeBackgroundFile(groupId, slot, prevImageId);
+      }
+      await refresh();
+    } catch (err) {
+      Alert.alert('Error', err?.message ?? 'Could not update background.');
+    } finally {
+      setSavingSlot((prev) => ({ ...prev, [slot]: false }));
+    }
+  }, [authContext, groupId, group, refresh]);
+
+  const removeSlotBackground = useCallback(async (slot) => {
+    if (!groupId) return;
+    const settingsKey = SLOT_SETTINGS_KEY[slot];
+    const prevImageId = group?.home_button_backgrounds?.[slot]?.image_id;
+    if (!prevImageId) return;
+    setSavingSlot((prev) => ({ ...prev, [slot]: true }));
+    try {
+      await updateGroupSettings(authContext, groupId, { [settingsKey]: null });
+      await deletePrivateImage(authContext, groupId, prevImageId);
+      deleteHomeBackgroundFile(groupId, slot, prevImageId);
+      await refresh();
+    } catch (err) {
+      Alert.alert('Error', err?.message ?? 'Could not remove background.');
+    } finally {
+      setSavingSlot((prev) => ({ ...prev, [slot]: false }));
+    }
+  }, [authContext, groupId, group, refresh]);
 
   useEffect(() => {
     navigation.setOptions({
@@ -207,14 +298,14 @@ export default function PrivateHomeScreen({ navigation, route }) {
       <HomeCard
         text="Hide Waldo"
         onPress={() => goScoped('HidingPathScreen')}
-        backgroundImage={HideImage}
+        backgroundImage={bgUris.hide ? { uri: bgUris.hide } : HideImage}
         heightPercent={40}
         testID="private-home.button.hide"
       />
       <HomeCard
         text="Find Waldo"
         onPress={isLocked ? undefined : () => goScoped('GuessPathScreen')}
-        backgroundImage={FindImage}
+        backgroundImage={bgUris.find ? { uri: bgUris.find } : FindImage}
         heightPercent={40}
         testID="private-home.button.find"
         accessibilityState={isLocked ? { disabled: true } : undefined}
@@ -223,7 +314,7 @@ export default function PrivateHomeScreen({ navigation, route }) {
       <HomeCard
         text="Ranking"
         onPress={() => goScoped('RankingScreen')}
-        backgroundImage={RankingImage}
+        backgroundImage={bgUris.ranking ? { uri: bgUris.ranking } : RankingImage}
         heightPercent={20}
         testID="private-home.button.ranking"
       />
@@ -238,7 +329,7 @@ export default function PrivateHomeScreen({ navigation, route }) {
         confirmLabel={isSavingColors ? 'Saving...' : 'Save'}
         cancelLabel="Cancel"
       >
-        <View>
+        <ScrollView keyboardShouldPersistTaps="handled">
           <ColorPalettePicker
             label="Primary color"
             value={editorPrimary}
@@ -251,7 +342,30 @@ export default function PrivateHomeScreen({ navigation, route }) {
             onValueChange={setEditorSecondary}
             testIDPrefix="private-home.color-secondary"
           />
-        </View>
+          <Text style={styles.sectionTitle}>Button backgrounds</Text>
+          {BACKGROUND_SLOTS.map(({ slot, label }) => {
+            const slotData = group?.home_button_backgrounds?.[slot];
+            return (
+              <View key={slot} style={styles.slotRow}>
+                <Text style={styles.slotLabel}>{label}</Text>
+                <BigButton
+                  text={savingSlot[slot] ? 'Saving...' : 'Choose image'}
+                  onPress={() => chooseSlotBackground(slot)}
+                  testID={`private-home.button-bg.${slot}.choose`}
+                  accessibilityLabel={`Choose ${label} background`}
+                />
+                {slotData && (
+                  <BigButton
+                    text="Remove"
+                    onPress={() => removeSlotBackground(slot)}
+                    testID={`private-home.button-bg.${slot}.remove`}
+                    accessibilityLabel={`Remove ${label} background`}
+                  />
+                )}
+              </View>
+            );
+          })}
+        </ScrollView>
       </CenteredModal>
 
       <LockedGroupOwnerModal
@@ -269,4 +383,7 @@ const styles = StyleSheet.create({
   container: { flex: 1, padding: 10, gap: 10 },
   title: { fontSize: 22, fontWeight: '700', textAlign: 'center', color: '#fff' },
   lockBadge: { fontSize: 14, color: '#ffd700', textAlign: 'center' },
+  sectionTitle: { fontSize: 16, fontWeight: '600', marginTop: 16, marginBottom: 8, color: '#333' },
+  slotRow: { alignItems: 'center', marginBottom: 8 },
+  slotLabel: { fontSize: 14, fontWeight: '500', color: '#333', marginBottom: 4 },
 });

--- a/services/groups/groupApi.js
+++ b/services/groups/groupApi.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { getBackendHeaders, setHeaders, mapRequestError } from '../../utils/auth';
 import { clearGroupFeedCache, purgeAllPrivateCaches } from './groupFeedCache';
 import { clearGroupThumbnails } from './groupCategoryThumbnails';
+import { clearGroupHomeBackgrounds } from './groupHomeBackgrounds';
 
 const BASE_URL = `${process.env.EXPO_PUBLIC_APP_BACKEND_URL}api/v1/private_groups`;
 
@@ -9,6 +10,7 @@ async function clearDeletedGroupCaches(groupId) {
   await Promise.allSettled([
     clearGroupFeedCache(groupId),
     clearGroupThumbnails(groupId),
+    clearGroupHomeBackgrounds(groupId),
     purgeAllPrivateCaches(),
   ]);
 }
@@ -72,17 +74,36 @@ export async function createGroup(context, { name, primaryColor, secondaryColor 
     .catch(mapRequestError);
 }
 
-export async function updateGroupSettings(context, groupId, { name, primaryColor, secondaryColor } = {}) {
+export async function updateGroupSettings(context, groupId, {
+  name,
+  primaryColor,
+  secondaryColor,
+  hideBgImageId,
+  findBgImageId,
+  rankingBgImageId,
+} = {}) {
   const { token } = await getBackendHeaders(context);
   const config = { headers: setHeaders({ token }) };
   const private_group = {};
   if (name !== undefined) private_group.name = name;
   if (primaryColor !== undefined) private_group.primary_color = primaryColor;
   if (secondaryColor !== undefined) private_group.secondary_color = secondaryColor;
+  if (hideBgImageId !== undefined) private_group.hide_bg_image_id = hideBgImageId;
+  if (findBgImageId !== undefined) private_group.find_bg_image_id = findBgImageId;
+  if (rankingBgImageId !== undefined) private_group.ranking_bg_image_id = rankingBgImageId;
   const body = { private_group };
 
   return axios.patch(`${BASE_URL}/${groupId}/`, body, config)
     .then((response) => ({ status: response.status, data: unwrapData(response.data) }))
+    .catch(mapRequestError);
+}
+
+export async function deletePrivateImage(context, groupId, imageId) {
+  const { token } = await getBackendHeaders(context);
+  const config = { headers: setHeaders({ token }) };
+
+  return axios.delete(`${BASE_URL}/${groupId}/images/${imageId}`, config)
+    .then((response) => ({ status: response.status, data: response.data }))
     .catch(mapRequestError);
 }
 

--- a/services/groups/groupHomeBackgrounds.js
+++ b/services/groups/groupHomeBackgrounds.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { File, Paths } from 'expo-file-system';
+import { File, Directory, Paths } from 'expo-file-system';
 import { fromByteArray } from 'base64-js';
 import {
   usesBackendStorage,
@@ -13,7 +13,7 @@ const HOME_BG_DIR = 'private-home-bg';
 const DELETE_EXTENSIONS = ['png', 'jpeg', 'webp', 'jpg'];
 
 function groupDir(groupId) {
-  return new File(Paths.cache, HOME_BG_DIR, String(groupId));
+  return new Directory(Paths.cache, HOME_BG_DIR, String(groupId));
 }
 
 function localHomeBgFile(groupId, slot, imageId, ext) {
@@ -38,8 +38,17 @@ function localHomeBgExists(groupId, slot, imageId, ext) {
 }
 
 function ensureGroupDir(groupId) {
+  const dir = groupDir(groupId);
   try {
-    groupDir(groupId).create({ idempotent: true, intermediates: true });
+    dir.create({ idempotent: true, intermediates: true });
+    return;
+  } catch {
+    // A prior build may have created a FILE at this path; clear it and retry.
+  }
+  try {
+    const stale = new File(Paths.cache, HOME_BG_DIR, String(groupId));
+    if (stale.exists) stale.delete();
+    dir.create({ idempotent: true, intermediates: true });
   } catch {
     // best-effort
   }
@@ -93,13 +102,15 @@ export async function resolveHomeBackground({
 
   ensureGroupDir(groupId);
 
+  const isBackend = usesBackendStorage(url);
   let response;
   let base64ToWrite = null;
   try {
-    if (usesBackendStorage(url)) {
+    if (isBackend) {
       const { token } = await getBackendHeaders(context);
       response = await axios.get(url, {
         headers: setStorageDownloadHeaders(token),
+        responseType: 'text',
         timeout: 15000,
       });
       base64ToWrite = extractBase64FromDataUrl(response?.data);
@@ -111,21 +122,21 @@ export async function resolveHomeBackground({
       const bytes = bytesFromArrayBufferLike(response?.data);
       base64ToWrite = bytes ? fromByteArray(bytes) : null;
     }
-  } catch {
-    return url;
+  } catch (err) {
+    return isBackend ? null : url;
   }
 
-  if (!base64ToWrite) return url;
+  if (!base64ToWrite) return isBackend ? null : url;
 
   const finalExt = ext || extFromContentType(response?.headers?.['content-type']);
-  if (!finalExt) return url;
+  if (!finalExt) return isBackend ? null : url;
 
   try {
     const file = localHomeBgFile(groupId, slot, imageId, finalExt);
     file.write(base64ToWrite, { encoding: 'base64' });
     return file.uri;
-  } catch {
-    return url;
+  } catch (err) {
+    return isBackend ? null : url;
   }
 }
 
@@ -143,7 +154,24 @@ export function deleteHomeBackgroundFile(groupId, slot, imageId) {
 export function clearGroupHomeBackgrounds(groupId) {
   try {
     const dir = groupDir(groupId);
-    if (dir?.exists) dir.delete();
+    if (!dir?.exists) return;
+
+    const entries = typeof dir.list === 'function' ? dir.list() : [];
+    if (Array.isArray(entries)) {
+      for (const entry of entries) {
+        const uri = typeof entry === 'string' ? entry : entry?.uri;
+        const name = typeof uri === 'string' ? uri.split('/').pop() : '';
+        if (!name) continue;
+        try {
+          const child = new File(Paths.cache, HOME_BG_DIR, String(groupId), name);
+          if (child?.exists) child.delete();
+        } catch {
+          // best-effort
+        }
+      }
+    }
+
+    dir.delete();
   } catch {
     // best-effort
   }

--- a/services/groups/groupHomeBackgrounds.js
+++ b/services/groups/groupHomeBackgrounds.js
@@ -1,0 +1,150 @@
+import axios from 'axios';
+import { File, Paths } from 'expo-file-system';
+import { fromByteArray } from 'base64-js';
+import {
+  usesBackendStorage,
+  setStorageDownloadHeaders,
+  getBackendHeaders,
+} from '../../utils/imagesRequests';
+
+export const SLOTS = ['hide', 'find', 'ranking'];
+
+const HOME_BG_DIR = 'private-home-bg';
+const DELETE_EXTENSIONS = ['png', 'jpeg', 'webp', 'jpg'];
+
+function groupDir(groupId) {
+  return new File(Paths.cache, HOME_BG_DIR, String(groupId));
+}
+
+function localHomeBgFile(groupId, slot, imageId, ext) {
+  return new File(
+    Paths.cache,
+    HOME_BG_DIR,
+    String(groupId),
+    `${slot}-${imageId}.${ext}`
+  );
+}
+
+function localHomeBgUri(groupId, slot, imageId, ext) {
+  return localHomeBgFile(groupId, slot, imageId, ext).uri;
+}
+
+function localHomeBgExists(groupId, slot, imageId, ext) {
+  try {
+    return !!localHomeBgFile(groupId, slot, imageId, ext).exists;
+  } catch {
+    return false;
+  }
+}
+
+function ensureGroupDir(groupId) {
+  try {
+    groupDir(groupId).create({ idempotent: true, intermediates: true });
+  } catch {
+    // best-effort
+  }
+}
+
+function bytesFromArrayBufferLike(data) {
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  if (ArrayBuffer.isView(data)) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  }
+  return null;
+}
+
+function extractBase64FromDataUrl(value) {
+  if (typeof value !== 'string') return null;
+  const match = value.match(/^data:image\/(?:png|jpe?g|gif|webp|heic|heif);base64,([\s\S]*)$/);
+  return match ? match[1] : null;
+}
+
+function extFromContentType(contentType) {
+  if (!contentType) return 'png';
+  const ct = contentType.split(';')[0].toLowerCase();
+  if (ct.includes('jpeg') || ct.includes('jpg')) return 'jpeg';
+  if (ct.includes('webp')) return 'webp';
+  return 'png';
+}
+
+function normalizeExt(ext) {
+  if (typeof ext !== 'string' || !ext) return null;
+  const trimmed = ext.replace(/^\./, '').toLowerCase();
+  return /^[a-zA-Z0-9]{2,5}$/.test(trimmed) ? trimmed : null;
+}
+
+export async function resolveHomeBackground({
+  context,
+  groupId,
+  slot,
+  imageId,
+  fileExtension,
+  url,
+}) {
+  if (!imageId || !SLOTS.includes(slot)) return null;
+
+  const ext = normalizeExt(fileExtension);
+
+  if (ext && localHomeBgExists(groupId, slot, imageId, ext)) {
+    return localHomeBgUri(groupId, slot, imageId, ext);
+  }
+
+  if (!url || typeof url !== 'string') return null;
+
+  ensureGroupDir(groupId);
+
+  let response;
+  let base64ToWrite = null;
+  try {
+    if (usesBackendStorage(url)) {
+      const { token } = await getBackendHeaders(context);
+      response = await axios.get(url, {
+        headers: setStorageDownloadHeaders(token),
+        timeout: 15000,
+      });
+      base64ToWrite = extractBase64FromDataUrl(response?.data);
+    } else {
+      response = await axios.get(url, {
+        responseType: 'arraybuffer',
+        timeout: 15000,
+      });
+      const bytes = bytesFromArrayBufferLike(response?.data);
+      base64ToWrite = bytes ? fromByteArray(bytes) : null;
+    }
+  } catch {
+    return url;
+  }
+
+  if (!base64ToWrite) return url;
+
+  const finalExt = ext || extFromContentType(response?.headers?.['content-type']);
+  if (!finalExt) return url;
+
+  try {
+    const file = localHomeBgFile(groupId, slot, imageId, finalExt);
+    file.write(base64ToWrite, { encoding: 'base64' });
+    return file.uri;
+  } catch {
+    return url;
+  }
+}
+
+export function deleteHomeBackgroundFile(groupId, slot, imageId) {
+  try {
+    for (const ext of DELETE_EXTENSIONS) {
+      const file = localHomeBgFile(groupId, slot, imageId, ext);
+      if (file?.exists) file.delete();
+    }
+  } catch {
+    // best-effort
+  }
+}
+
+export function clearGroupHomeBackgrounds(groupId) {
+  try {
+    const dir = groupDir(groupId);
+    if (dir?.exists) dir.delete();
+  } catch {
+    // best-effort
+  }
+}

--- a/services/groups/groupMembershipApi.js
+++ b/services/groups/groupMembershipApi.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { getBackendHeaders, setHeaders, mapRequestError } from '../../utils/auth';
 import { clearGroupFeedCache } from './groupFeedCache';
 import { clearGroupThumbnails } from './groupCategoryThumbnails';
+import { clearGroupHomeBackgrounds } from './groupHomeBackgrounds';
 
 const BASE_URL = `${process.env.EXPO_PUBLIC_APP_BACKEND_URL}api/v1/private_groups`;
 
@@ -9,6 +10,7 @@ async function clearDepartedGroupCaches(groupId) {
   await Promise.allSettled([
     clearGroupFeedCache(groupId),
     clearGroupThumbnails(groupId),
+    clearGroupHomeBackgrounds(groupId),
   ]);
 }
 

--- a/services/groups/groupUploadApi.js
+++ b/services/groups/groupUploadApi.js
@@ -14,6 +14,8 @@ function mapUploadKind(kind) {
     case 'button-image':
     case 'category-thumbnail':
       return 'groupUi';
+    case 'home-button-background':
+      return 'homeUi';
     default:
       return kind;
   }
@@ -30,6 +32,7 @@ export async function preparePrivateUpload({
   isButtonBackground,
   isButtonImage,
   isCategoryThumbnail,
+  isHomeButtonBackground,
   categoryId,
   description,
   imageHeight,
@@ -54,6 +57,7 @@ export async function preparePrivateUpload({
   if (isButtonBackground) privateImage.is_button_background = true;
   if (isButtonImage) privateImage.is_button_image = true;
   if (isCategoryThumbnail) privateImage.is_category_thumbnail = true;
+  if (isHomeButtonBackground) privateImage.is_home_button_background = true;
   if (categoryId) privateImage.category_id = categoryId;
   if (description !== undefined) privateImage.description = description;
   if (imageHeight !== undefined) privateImage.image_height = imageHeight;

--- a/services/groups/homeBackgroundUpload.js
+++ b/services/groups/homeBackgroundUpload.js
@@ -1,0 +1,58 @@
+import * as ImagePicker from 'expo-image-picker';
+import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
+
+import { preparePrivateUpload } from './groupUploadApi';
+import { performImageUpload } from '../../utils/imagesRequests';
+
+const MAX_WIDTH = 1080;
+
+export async function uploadHomeBackground({ context, groupId }) {
+  const result = await ImagePicker.launchImageLibraryAsync({
+    allowsEditing: true,
+    aspect: [4, 3],
+    mediaTypes: ['images'],
+  });
+  if (result?.canceled || !result?.assets?.length) {
+    return null;
+  }
+
+  const asset = result.assets[0];
+
+  const manipulator = ImageManipulator.manipulate(asset.uri);
+  if (asset.width && asset.width > MAX_WIDTH) {
+    manipulator.resize({ width: MAX_WIDTH });
+  }
+  const rendered = await manipulator.renderAsync();
+  const saved = await rendered.saveAsync({
+    compress: 0.7,
+    format: SaveFormat.JPEG,
+  });
+  const fileExtension = 'jpg';
+
+  const presignResponse = await preparePrivateUpload({
+    context,
+    groupId,
+    kind: 'home-button-background',
+    fileExtension,
+    contentType: `image/${fileExtension}`,
+    contentLength: asset.fileSize ?? 0,
+    isHomeButtonBackground: true,
+  });
+  if (presignResponse?.status !== 200 && presignResponse?.status !== 201) {
+    throw new Error('Could not prepare upload.');
+  }
+
+  const uploadPlan = presignResponse.data;
+  const uploadResponse = await performImageUpload({
+    plan: uploadPlan,
+    fileUrl: saved.uri,
+    fileExtension,
+    contentLength: asset.fileSize ?? 0,
+    context,
+  });
+  if (uploadResponse?.status !== 200 && uploadResponse?.status !== 204) {
+    throw new Error('Upload failed.');
+  }
+
+  return { imageId: uploadPlan.imageId };
+}

--- a/services/groups/homeBackgroundUpload.js
+++ b/services/groups/homeBackgroundUpload.js
@@ -1,5 +1,6 @@
 import * as ImagePicker from 'expo-image-picker';
 import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
+import { File } from 'expo-file-system';
 
 import { preparePrivateUpload } from './groupUploadApi';
 import { performImageUpload } from '../../utils/imagesRequests';
@@ -27,7 +28,17 @@ export async function uploadHomeBackground({ context, groupId }) {
     compress: 0.7,
     format: SaveFormat.JPEG,
   });
-  const fileExtension = 'jpg';
+  const fileExtension = 'jpeg';
+
+  let contentLength = asset.fileSize ?? 0;
+  try {
+    const renderedSize = new File(saved.uri).size;
+    if (renderedSize) {
+      contentLength = renderedSize;
+    }
+  } catch {
+    // fall back to original asset size
+  }
 
   const presignResponse = await preparePrivateUpload({
     context,
@@ -35,7 +46,7 @@ export async function uploadHomeBackground({ context, groupId }) {
     kind: 'home-button-background',
     fileExtension,
     contentType: `image/${fileExtension}`,
-    contentLength: asset.fileSize ?? 0,
+    contentLength,
     isHomeButtonBackground: true,
   });
   if (presignResponse?.status !== 200 && presignResponse?.status !== 201) {
@@ -47,7 +58,7 @@ export async function uploadHomeBackground({ context, groupId }) {
     plan: uploadPlan,
     fileUrl: saved.uri,
     fileExtension,
-    contentLength: asset.fileSize ?? 0,
+    contentLength,
     context,
   });
   if (uploadResponse?.status !== 200 && uploadResponse?.status !== 204) {

--- a/utils/imagesRequests.js
+++ b/utils/imagesRequests.js
@@ -367,7 +367,7 @@ export async function performImageUpload({ plan, fileUrl, fileExtension, content
     const response = await requestWithMethod(plan.url, `data:image/${fileExtension};base64,` + base64, config)
       .then((response) => {
         if (response.status === 200) {
-          console.log("post img base64 ok", response);
+          console.log("post img base64 ok", Object.keys(response).filter((key) => key !== 'data'));
         };
         return response;
       })


### PR DESCRIPTION
This pull request adds comprehensive tests for the new group home button background image feature, covering both the UI interaction and the underlying file and API handling. It introduces new mocks and test cases to ensure correct behavior when setting, removing, and resolving custom home button backgrounds in private groups, as well as caching and cleanup of background image files.

The most important changes are:

**Testing home button background image logic in the UI:**
- Adds a new test suite to `PrivateHomeScreen.test.js` that covers setting, removing, and resolving custom background images for group home buttons, including edge cases like double-tap prevention and error handling.
- Mocks and verifies the use of new service functions (`resolveHomeBackground`, `uploadHomeBackground`, `deleteHomeBackgroundFile`, `deletePrivateImage`) and ensures correct interaction order between API calls and file cleanup. [[1]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645R73-R83) [[2]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645L89-R111)

**Testing background file handling and caching logic:**
- Introduces a new test file `groupHomeBackgrounds.test.js` with detailed unit tests for the file system operations, download logic, cache invalidation, and error handling for group home background images.

**Testing API integration for group background images:**
- Adds tests to `groupApi.test.js` for the new `updateGroupSettings` PATCH logic (including null-clearing backgrounds), and for the `deletePrivateImage` endpoint.
- Ensures that deleting a group also clears cached background images by testing calls to `clearGroupHomeBackgrounds`. [[1]](diffhunk://#diff-d1db516b45c0cc418e70eb4c9797a4037458e078c3364d1c4b5225e38ca26b5dR27-R42) [[2]](diffhunk://#diff-d1db516b45c0cc418e70eb4c9797a4037458e078c3364d1c4b5225e38ca26b5dR192)

These changes ensure robust coverage for the new group home background image functionality, both at the UI and service levels.