### PR TITLE
Add private group theme context and integrate theme into UI components

### DIFF
--- a/__tests__/GuessFeedScreen.test.js
+++ b/__tests__/GuessFeedScreen.test.js
@@ -106,6 +106,10 @@ jest.mock('../utils/storageDatum', () => ({
   saveSessionLanguageFilter: jest.fn(),
 }));
 
+jest.mock('../hooks/useGroupsHub', () => ({
+  useGroupsHub: () => ({ data: null, isLoading: false, error: null, refresh: jest.fn() }),
+}));
+
 import React from 'react';
 import { Dimensions } from 'react-native';
 import { act, create } from 'react-test-renderer';

--- a/__tests__/GuessPathScreen.test.js
+++ b/__tests__/GuessPathScreen.test.js
@@ -161,7 +161,7 @@ describe('GuessPathScreen', () => {
     getSessionLanguageFilter.mockResolvedValue(null);
     saveSessionLanguageFilter.mockResolvedValue(undefined);
     mockUseGroupsHub.mockReturnValue({ data: null, refresh: jest.fn() });
-    navigation = { navigate: jest.fn(), popToTop: jest.fn(), goBack: jest.fn() };
+    navigation = { navigate: jest.fn(), popToTop: jest.fn(), goBack: jest.fn(), setOptions: jest.fn() };
   });
 
   afterEach(async () => {

--- a/__tests__/RankingScreen.test.js
+++ b/__tests__/RankingScreen.test.js
@@ -1,5 +1,7 @@
 const mockTableComponent = jest.fn(() => null);
 const mockLoadingOverlay = jest.fn(() => null);
+const mockUseActiveGroup = jest.fn(() => ({ scope: { kind: 'public' } }));
+const mockUseGroupsHub = jest.fn(() => ({ data: null }));
 
 jest.mock('../components/UI/TableComponent', () => {
   return function MockTableComponent(props) {
@@ -20,6 +22,14 @@ jest.mock('../utils/scoreRequests', () => ({
   getUserScores: jest.fn(),
 }));
 
+jest.mock('../hooks/useActiveGroup', () => ({
+  useActiveGroup: () => mockUseActiveGroup(),
+}));
+
+jest.mock('../hooks/useGroupsHub', () => ({
+  useGroupsHub: () => mockUseGroupsHub(),
+}));
+
 jest.mock('../store/auth-context', () => {
   const React = require('react');
 
@@ -36,6 +46,7 @@ import RankingScreen from '../screens/RankingScreen';
 import { AuthContext } from '../store/auth-context';
 import { getRankingData, getUserScores } from '../utils/scoreRequests';
 import { GlobalStyle } from '../constants/theme';
+import { getPrivateGroupTheme } from '../utils/privateGroupTheme';
 
 describe('RankingScreen', () => {
   const contextValue = {
@@ -434,5 +445,73 @@ describe('RankingScreen', () => {
     });
     expect(typeof props.onEndReached).toBe('function');
     expect(typeof props.onPress).toBe('function');
+  });
+
+  it('wires the header background and tint to the private group theme when a private scope is active', async () => {
+    mockUseActiveGroup.mockReturnValueOnce({
+      scope: { kind: 'private', groupId: 'g-1' },
+    });
+    mockUseGroupsHub.mockReturnValueOnce({
+      data: {
+        owned: [{
+          id: 'g-1',
+          name: 'My Group',
+          primary_color: '#198868',
+          secondary_color: '#FFCC00',
+        }],
+        joined: [],
+      },
+    });
+    getRankingData.mockResolvedValue({
+      status: 200,
+      data: { rows: [], nextCursor: null, hasMore: false },
+    });
+
+    const expectedTheme = getPrivateGroupTheme({ primaryColor: '#198868' });
+    const navigation = { setOptions: jest.fn() };
+    const route = { params: { scope: { kind: 'private', groupId: 'g-1' } } };
+
+    await act(async () => {
+      create(
+        <AuthContext.Provider value={contextValue}>
+          <RankingScreen navigation={navigation} route={route} />
+        </AuthContext.Provider>
+      );
+      await flushEffects();
+    });
+
+    const setOptionsCalls = navigation.setOptions.mock.calls.map(([opts]) => opts);
+
+    expect(setOptionsCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          headerStyle: { backgroundColor: expectedTheme.primaryColor },
+          headerTintColor: expectedTheme.headerTintColor,
+        }),
+      ])
+    );
+  });
+
+  it('does not apply group header colors in public scope', async () => {
+    getRankingData.mockResolvedValue({
+      status: 200,
+      data: { rows: [], nextCursor: null, hasMore: false },
+    });
+    const navigation = { setOptions: jest.fn() };
+
+    await act(async () => {
+      create(
+        <AuthContext.Provider value={contextValue}>
+          <RankingScreen navigation={navigation} />
+        </AuthContext.Provider>
+      );
+      await flushEffects();
+    });
+
+    const setOptionsCalls = navigation.setOptions.mock.calls.map(([opts]) => opts);
+    setOptionsCalls.forEach((opts) => {
+      expect(opts).not.toHaveProperty('headerStyle');
+      expect(opts).not.toHaveProperty('headerTintColor');
+    });
   });
 });

--- a/__tests__/TableComponent.test.js
+++ b/__tests__/TableComponent.test.js
@@ -3,6 +3,9 @@ import { FlatList, StyleSheet } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
 import TableComponent from '../components/UI/TableComponent';
+import { GlobalStyle } from '../constants/theme';
+import { PrivateGroupThemeProvider } from '../store/privateGroupTheme-context';
+import { getPrivateGroupTheme } from '../utils/privateGroupTheme';
 
 describe('TableComponent', () => {
   const data = {
@@ -66,5 +69,32 @@ describe('TableComponent', () => {
     expect(flatList.props.maxToRenderPerBatch).toBe(5);
     expect(flatList.props.updateCellsBatchingPeriod).toBe(100);
     expect(flatList.props.removeClippedSubviews).toBeTruthy();
+  });
+
+  it('uses the public palette container background when no private group theme is present', async () => {
+    const renderer = await renderTable();
+    const container = renderer.root.findByProps({ testID: 'ranking.table' });
+
+    expect(StyleSheet.flatten(container.props.style).backgroundColor).toBe(
+      GlobalStyle.color.primaryColor800
+    );
+  });
+
+  it('uses the active private group theme container background when wrapped in a provider', async () => {
+    const group = { primary_color: '#198868', secondary_color: '#FFCC00' };
+    const expectedTheme = getPrivateGroupTheme({ primaryColor: '#198868' });
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <PrivateGroupThemeProvider group={group}>
+          <TableComponent data={data} onPress={jest.fn()} />
+        </PrivateGroupThemeProvider>
+      );
+    });
+
+    const container = renderer.root.findByProps({ testID: 'ranking.table' });
+
+    expect(StyleSheet.flatten(container.props.style).backgroundColor).toBe(expectedTheme.screen);
   });
 });

--- a/__tests__/components/HomeCard.test.js
+++ b/__tests__/components/HomeCard.test.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import { StyleSheet, Text } from 'react-native';
+
+import HomeCard from '../../components/UI/HomeCard';
+import { PrivateGroupThemeProvider } from '../../store/privateGroupTheme-context';
+import { GlobalStyle } from '../../constants/theme';
+import { getPrivateGroupTheme } from '../../utils/privateGroupTheme';
+
+describe('HomeCard', () => {
+  function render(element) {
+    let renderer;
+    act(() => {
+      renderer = create(element);
+    });
+    return renderer;
+  }
+
+  function findInnerContainer(renderer) {
+    const textNode = renderer.root.findByType(Text);
+    return textNode.parent;
+  }
+
+  it('falls back to GlobalStyle.color.primaryColor500 for the inner background when no provider is present', () => {
+    const renderer = render(<HomeCard text="X" onPress={jest.fn()} />);
+
+    const inner = findInnerContainer(renderer);
+    expect(StyleSheet.flatten(inner.props.style).backgroundColor).toBe(GlobalStyle.color.primaryColor500);
+  });
+
+  it('uses the resolved group primaryColor for the inner background inside a PrivateGroupThemeProvider', () => {
+    const expectedTheme = getPrivateGroupTheme({ primaryColor: '#198868' });
+    const renderer = render(
+      <PrivateGroupThemeProvider group={{ primary_color: '#198868', secondary_color: '#FFCC00' }}>
+        <HomeCard text="X" onPress={jest.fn()} />
+      </PrivateGroupThemeProvider>
+    );
+
+    const inner = findInnerContainer(renderer);
+    expect(StyleSheet.flatten(inner.props.style).backgroundColor).toBe(expectedTheme.primaryColor);
+  });
+
+  it('does not apply the fallback background style when backgroundImage is provided', () => {
+    const renderer = render(
+      <PrivateGroupThemeProvider group={{ primary_color: '#198868', secondary_color: '#FFCC00' }}>
+        <HomeCard
+          text="X"
+          onPress={jest.fn()}
+          backgroundImage={{ uri: 'file:///tmp/waldo.png' }}
+        />
+      </PrivateGroupThemeProvider>
+    );
+
+    const inner = findInnerContainer(renderer);
+    const backgroundColor = StyleSheet.flatten(inner.props.style).backgroundColor;
+    expect(backgroundColor).not.toBe('#198868');
+    expect(backgroundColor).not.toBe(GlobalStyle.color.primaryColor500);
+  });
+});

--- a/__tests__/components/buttons-theme.test.js
+++ b/__tests__/components/buttons-theme.test.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import { StyleSheet, View } from 'react-native';
+
+import Button from '../../components/UI/Button';
+import BigButton from '../../components/UI/BigButton';
+import TableButton from '../../components/UI/TableButton';
+import { PrivateGroupThemeProvider } from '../../store/privateGroupTheme-context';
+import { GlobalStyle } from '../../constants/theme';
+import { getPrivateGroupTheme } from '../../utils/privateGroupTheme';
+
+const OWNER_GROUP = { primary_color: '#198868', secondary_color: '#FFCC00' };
+
+describe('button private group theme integration', () => {
+  function render(element) {
+    let renderer;
+    act(() => {
+      renderer = create(element);
+    });
+    return renderer;
+  }
+
+  function readBackgroundColor(styleValue) {
+    return StyleSheet.flatten(styleValue).backgroundColor;
+  }
+
+  describe('Button', () => {
+    function findOuterView(renderer) {
+      return renderer.root.findAllByType(View)[0];
+    }
+
+    it('falls back to GlobalStyle.color.primaryColor100 fill when no provider is present', () => {
+      const renderer = render(<Button>label</Button>);
+      const outer = findOuterView(renderer);
+      expect(readBackgroundColor(outer.props.style)).toBe(GlobalStyle.color.primaryColor100);
+    });
+
+    it('uses the normalized owner primaryColor fill when wrapped in a PrivateGroupThemeProvider', () => {
+      const expectedTheme = getPrivateGroupTheme({ primaryColor: OWNER_GROUP.primary_color });
+      const renderer = render(
+        <PrivateGroupThemeProvider group={OWNER_GROUP}>
+          <Button>label</Button>
+        </PrivateGroupThemeProvider>
+      );
+      const outer = findOuterView(renderer);
+      expect(readBackgroundColor(outer.props.style)).toBe(expectedTheme.primaryColor);
+    });
+  });
+
+  describe('BigButton', () => {
+    function readPressableFill(renderer) {
+      const nodes = renderer.root.findAll((inst) => typeof inst.props?.style === 'function');
+      expect(nodes.length).toBeGreaterThan(0);
+      const resolved = nodes[0].props.style({ pressed: false });
+      return readBackgroundColor(resolved);
+    }
+
+    function readPressedFill(renderer) {
+      const nodes = renderer.root.findAll((inst) => typeof inst.props?.style === 'function');
+      expect(nodes.length).toBeGreaterThan(0);
+      const resolved = nodes[0].props.style({ pressed: true });
+      return readBackgroundColor(resolved);
+    }
+
+    it('falls back to GlobalStyle.color.primaryColor fill when no provider is present', () => {
+      const renderer = render(<BigButton text="go" />);
+      expect(readPressableFill(renderer)).toBe(GlobalStyle.color.primaryColor);
+    });
+
+    it('falls back to GlobalStyle.color.primaryColor700 pressed fill when no provider is present', () => {
+      const renderer = render(<BigButton text="go" />);
+      expect(readPressedFill(renderer)).toBe(GlobalStyle.color.primaryColor700);
+    });
+
+    it('uses the normalized owner primaryColor fill when wrapped in a PrivateGroupThemeProvider', () => {
+      const expectedTheme = getPrivateGroupTheme({ primaryColor: OWNER_GROUP.primary_color });
+      const renderer = render(
+        <PrivateGroupThemeProvider group={OWNER_GROUP}>
+          <BigButton text="go" />
+        </PrivateGroupThemeProvider>
+      );
+      expect(readPressableFill(renderer)).toBe(expectedTheme.primaryColor);
+    });
+  });
+
+  describe('TableButton', () => {
+    function findBtnView(renderer) {
+      return renderer.root.findByType(View);
+    }
+
+    it('falls back to GlobalStyle.color.primaryColor fill when no provider is present', () => {
+      const renderer = render(<TableButton onPress={jest.fn()} />);
+      const btn = findBtnView(renderer);
+      expect(readBackgroundColor(btn.props.style)).toBe(GlobalStyle.color.primaryColor);
+    });
+
+    it('uses the normalized owner primaryColor fill when wrapped in a PrivateGroupThemeProvider', () => {
+      const expectedTheme = getPrivateGroupTheme({ primaryColor: OWNER_GROUP.primary_color });
+      const renderer = render(
+        <PrivateGroupThemeProvider group={OWNER_GROUP}>
+          <TableButton onPress={jest.fn()} />
+        </PrivateGroupThemeProvider>
+      );
+      const btn = findBtnView(renderer);
+      expect(readBackgroundColor(btn.props.style)).toBe(expectedTheme.primaryColor);
+    });
+  });
+});

--- a/__tests__/screens/PrivateHomeScreen.test.js
+++ b/__tests__/screens/PrivateHomeScreen.test.js
@@ -146,19 +146,6 @@ describe('PrivateHomeScreen', () => {
     return headerRoot;
   }
 
-  it('renders the active group name in private-home.title and forces portrait orientation', async () => {
-    const { renderer } = await renderScreen({
-      scope: { kind: 'private', groupId: 'g-7' },
-      groupsData: {
-        owned: [{ id: 'g-7', name: 'Waldos Of The World', role: 'owner' }],
-        joined: [],
-      },
-    });
-
-    const titleNode = renderer.root.findByProps({ testID: 'private-home.title' });
-    expect(titleNode.props.children).toBe('Waldos Of The World');
-    expect(handleOrientation).toHaveBeenCalledWith('portrait');
-  });
 
   it('does not render the legacy back-to-public button', async () => {
     const { renderer } = await renderScreen({
@@ -243,6 +230,18 @@ describe('PrivateHomeScreen', () => {
       const options = lastSetOptions(navigation);
       expect(options.headerStyle.backgroundColor).toBe('#6528F7');
       expect(options.headerTintColor).toBe(expectedTheme.headerTintColor);
+    });
+
+    it('paints the outer container with the resolved group screen color', async () => {
+      const { renderer } = await renderScreen({ groupsData: ownerData });
+      const expectedTheme = getPrivateGroupTheme({ primaryColor: '#6528F7' });
+
+      let container = renderer.root;
+      while (container && container.type !== 'View') {
+        container = container.parent;
+      }
+      expect(container).toBeTruthy();
+      expect(StyleSheet.flatten(container.props.style).backgroundColor).toBe(expectedTheme.screen);
     });
 
     it('lets the owner customize colors via the header button', async () => {

--- a/__tests__/store/privateGroupTheme-context.test.js
+++ b/__tests__/store/privateGroupTheme-context.test.js
@@ -1,0 +1,214 @@
+import React, { useEffect } from 'react';
+import { act, create } from 'react-test-renderer';
+
+import {
+  PrivateGroupThemeProvider,
+  usePrivateGroupTheme,
+  useAccentColor,
+  useGroupSurfaceColor,
+  useScopedPrivateGroupTheme,
+} from '../../store/privateGroupTheme-context';
+import { GlobalStyle } from '../../constants/theme';
+import { getPrivateGroupTheme } from '../../utils/privateGroupTheme';
+
+const mockUseActiveGroup = jest.fn();
+const mockUseGroupsHub = jest.fn();
+
+jest.mock('../../hooks/useActiveGroup', () => ({
+  useActiveGroup: () => mockUseActiveGroup(),
+}));
+
+jest.mock('../../hooks/useGroupsHub', () => ({
+  useGroupsHub: () => mockUseGroupsHub(),
+}));
+
+function ThemeProbe({ onValue }) {
+  const theme = usePrivateGroupTheme();
+  useEffect(() => {
+    onValue(theme);
+  }, [onValue, theme]);
+  return null;
+}
+
+function AccentProbe({ onValue }) {
+  const accent = useAccentColor();
+  useEffect(() => {
+    onValue(accent);
+  }, [onValue, accent]);
+  return null;
+}
+
+function SurfaceProbe({ onValue }) {
+  const surface = useGroupSurfaceColor();
+  useEffect(() => {
+    onValue(surface);
+  }, [onValue, surface]);
+  return null;
+}
+
+function ScopedThemeProbe({ scopeOverride, onValue }) {
+  const value = useScopedPrivateGroupTheme(scopeOverride);
+  useEffect(() => {
+    onValue(value);
+  }, [onValue, value]);
+  return null;
+}
+
+describe('PrivateGroupThemeContext', () => {
+  it('usePrivateGroupTheme returns null when rendered outside any provider', async () => {
+    let theme;
+    await act(async () => {
+      create(<ThemeProbe onValue={(value) => { theme = value; }} />);
+    });
+    expect(theme).toBeNull();
+  });
+
+  it('usePrivateGroupTheme returns the memoized theme whose primaryColor is the normalized group primary_color', async () => {
+    let theme;
+    await act(async () => {
+      create(
+        <PrivateGroupThemeProvider group={{ primary_color: '#198868', secondary_color: '#FFCC00' }}>
+          <ThemeProbe onValue={(value) => { theme = value; }} />
+        </PrivateGroupThemeProvider>
+      );
+    });
+    expect(theme).not.toBeNull();
+    expect(theme.primaryColor).toBe('#198868');
+  });
+
+  it('memoizes the theme across renders with the same colors and returns a new object when colors change', async () => {
+    let firstTheme;
+    let sameColorsTheme;
+    let changedColorsTheme;
+
+    let renderer;
+    await act(async () => {
+      renderer = create(
+        <PrivateGroupThemeProvider group={{ primary_color: '#198868', secondary_color: '#FFCC00' }}>
+          <ThemeProbe onValue={(value) => { firstTheme = value; }} />
+        </PrivateGroupThemeProvider>
+      );
+    });
+
+    await act(async () => {
+      renderer.update(
+        <PrivateGroupThemeProvider group={{ primary_color: '#198868', secondary_color: '#FFCC00' }}>
+          <ThemeProbe onValue={(value) => { sameColorsTheme = value; }} />
+        </PrivateGroupThemeProvider>
+      );
+    });
+
+    expect(sameColorsTheme).toBe(firstTheme);
+
+    await act(async () => {
+      renderer.update(
+        <PrivateGroupThemeProvider group={{ primary_color: '#FF0000', secondary_color: '#FFCC00' }}>
+          <ThemeProbe onValue={(value) => { changedColorsTheme = value; }} />
+        </PrivateGroupThemeProvider>
+      );
+    });
+
+    expect(changedColorsTheme).not.toBe(firstTheme);
+    expect(changedColorsTheme.primaryColor).toBe('#FF0000');
+  });
+
+  it('useAccentColor falls back to GlobalStyle.color.primaryColor500 outside a provider', async () => {
+    let accent;
+    await act(async () => {
+      create(<AccentProbe onValue={(value) => { accent = value; }} />);
+    });
+    expect(accent).toBe(GlobalStyle.color.primaryColor500);
+  });
+
+  it('useGroupSurfaceColor falls back to GlobalStyle.color.primaryColor900 outside a provider', async () => {
+    let surface;
+    await act(async () => {
+      create(<SurfaceProbe onValue={(value) => { surface = value; }} />);
+    });
+    expect(surface).toBe(GlobalStyle.color.primaryColor900);
+  });
+
+  it('PrivateGroupThemeProvider with group=null yields a null context (public scope guard)', async () => {
+    let theme;
+    await act(async () => {
+      create(
+        <PrivateGroupThemeProvider group={null}>
+          <ThemeProbe onValue={(value) => { theme = value; }} />
+        </PrivateGroupThemeProvider>
+      );
+    });
+    expect(theme).toBeNull();
+  });
+});
+
+describe('useScopedPrivateGroupTheme', () => {
+  beforeEach(() => {
+    mockUseActiveGroup.mockReset();
+    mockUseGroupsHub.mockReset();
+    mockUseActiveGroup.mockReturnValue({ scope: { kind: 'public' } });
+    mockUseGroupsHub.mockReturnValue({ data: { owned: [], joined: [] } });
+  });
+
+  it('returns all-null/false when the active scope is public and no override is given', async () => {
+    let value;
+    await act(async () => {
+      create(<ScopedThemeProbe onValue={(v) => { value = v; }} />);
+    });
+    expect(value).toEqual({ group: null, theme: null, isPrivate: false });
+  });
+
+  it('resolves the group and theme from a private route override', async () => {
+    mockUseActiveGroup.mockReturnValue({ scope: { kind: 'public' } });
+    mockUseGroupsHub.mockReturnValue({
+      data: {
+        owned: [{ id: 'g-1', name: 'Waldos', primary_color: '#198868', secondary_color: '#FFCC00' }],
+        joined: [],
+      },
+    });
+
+    let value;
+    await act(async () => {
+      create(
+        <ScopedThemeProbe
+          scopeOverride={{ kind: 'private', groupId: 'g-1' }}
+          onValue={(v) => { value = v; }}
+        />
+      );
+    });
+
+    expect(value.isPrivate).toBe(true);
+    expect(value.group.id).toBe('g-1');
+    expect(value.theme.primaryColor).toBe(
+      getPrivateGroupTheme({ primaryColor: '#198868' }).primaryColor,
+    );
+  });
+
+  it('lets the route override take precedence over the active scope when their groupIds differ', async () => {
+    mockUseActiveGroup.mockReturnValue({ scope: { kind: 'private', groupId: 'g-active' } });
+    mockUseGroupsHub.mockReturnValue({
+      data: {
+        owned: [
+          { id: 'g-active', name: 'Active', primary_color: '#FF0000' },
+          { id: 'g-route', name: 'Route', primary_color: '#00FF00' },
+        ],
+        joined: [],
+      },
+    });
+
+    let value;
+    await act(async () => {
+      create(
+        <ScopedThemeProbe
+          scopeOverride={{ kind: 'private', groupId: 'g-route' }}
+          onValue={(v) => { value = v; }}
+        />
+      );
+    });
+
+    expect(value.isPrivate).toBe(true);
+    expect(value.group.id).toBe('g-route');
+    expect(value.theme.primaryColor).toBe(
+      getPrivateGroupTheme({ primaryColor: '#00FF00' }).primaryColor,
+    );
+  });
+});

--- a/components/UI/BigButton.js
+++ b/components/UI/BigButton.js
@@ -1,5 +1,6 @@
 import { Text, StyleSheet, Dimensions, Pressable, Platform, View } from 'react-native';
 import { GlobalStyle } from '../../constants/theme';
+import { usePrivateGroupTheme } from '../../store/privateGroupTheme-context';
 
 const screenHeight = Dimensions.get('window').height;
 const hideGuessButtonHeight = screenHeight * 0.35;
@@ -9,6 +10,9 @@ const hideGuessButtonWidth = screenWidth * 0.75;
 const rankingButtonWidth = screenWidth * 0.75;
 
 const BigButton = (({ text, onPress, buttonStyle, testID, accessibilityLabel }) => {
+  const theme = usePrivateGroupTheme();
+  const fill = theme ? theme.primaryColor : GlobalStyle.color.primaryColor;
+  const pressedFill = theme ? (theme.insetDeep ?? theme.primaryColor) : GlobalStyle.color.primaryColor700;
   return (
     <View>
         <Pressable
@@ -18,7 +22,8 @@ const BigButton = (({ text, onPress, buttonStyle, testID, accessibilityLabel }) 
         style={({ pressed }) =>
           [
             styles.homeButton,
-            pressed && styles.pressed,
+            { backgroundColor: fill },
+            pressed && { opacity: 0.75, backgroundColor: pressedFill },
             buttonStyle === 'big' ? styles.bigButton : styles.rankingButton,
             Platform.OS === 'ios' && styles.iOSButton
           ]
@@ -31,12 +36,7 @@ const BigButton = (({ text, onPress, buttonStyle, testID, accessibilityLabel }) 
 });
 
 const styles = StyleSheet.create({
-  pressed: {
-    opacity: 0.75,
-    backgroundColor: GlobalStyle.color.primaryColor700,
-  },
   homeButton: {
-    backgroundColor: GlobalStyle.color.primaryColor,
     padding: 10,
     borderRadius: 5,
     borderWidth: 1,

--- a/components/UI/Button.js
+++ b/components/UI/Button.js
@@ -1,11 +1,14 @@
 import { Pressable, Text, StyleSheet, View, Platform } from 'react-native';
 import { GlobalStyle } from '../../constants/theme';
+import { usePrivateGroupTheme } from '../../store/privateGroupTheme-context';
 
 export default function Button({ children, style, onPress, mode, thin, cancel, testID, accessibilityLabel, textStyle, disabled }) {
-
+  const theme = usePrivateGroupTheme();
+  const fill = theme ? theme.primaryColor : GlobalStyle.color.primaryColor100;
 
   return (
     <View style={[styles.button,
+      { backgroundColor: fill },
       style ?? style,
       thin && { paddingVertical: 0, paddingHorizontal: 2, padding: 0 },
       mode === "flat" && { backgroundColor: "transparent" },
@@ -24,6 +27,7 @@ export default function Button({ children, style, onPress, mode, thin, cancel, t
           <Text style={[
             styles.buttonText,
             mode === "flat" && styles.flatText,
+            mode === "flat" && { color: fill },
             cancel && mode !== "flat" && styles.cancelButtonText,
             cancel && mode === "flat" && styles.flatCancelText,
             textStyle]}
@@ -39,7 +43,7 @@ export default function Button({ children, style, onPress, mode, thin, cancel, t
 
 const styles = StyleSheet.create({
   button: {
-    backgroundColor: GlobalStyle.color.primaryColor100,
+    backgroundColor: 'transparent',
     padding: 10,
     borderRadius: 4,
     alignItems: 'center',
@@ -62,7 +66,6 @@ const styles = StyleSheet.create({
     backgroundColor: "transparent",
   },
   flatText: {
-    color: GlobalStyle.color.primaryColor100,
   },
   pressed: {
     opacity: 0.75,

--- a/components/UI/HomeCard.js
+++ b/components/UI/HomeCard.js
@@ -1,9 +1,10 @@
 import { StyleSheet, Text, Pressable, Animated, ImageBackground, View } from 'react-native';
 import { useRef } from 'react';
-import { GlobalStyle } from '../../constants/theme';
+import { useAccentColor } from '../../store/privateGroupTheme-context';
 
 const HomeCard = ({ text, onPress, backgroundImage, heightPercent, testID, accessibilityState, pointerEvents }) => {
   const scaleValue = useRef(new Animated.Value(1)).current;
+  const accentColor = useAccentColor();
 
   const handlePressIn = () => {
     Animated.spring(scaleValue, {
@@ -24,7 +25,7 @@ const HomeCard = ({ text, onPress, backgroundImage, heightPercent, testID, acces
   };
 
   const Content = (
-    <View style={[styles.innerContainer, !backgroundImage && styles.noBackground]}>
+    <View style={[styles.innerContainer, !backgroundImage && { backgroundColor: accentColor }]}>
       <Text style={styles.text}>{text}</Text>
     </View>
   );
@@ -83,9 +84,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: 'rgba(0,0,0,0.3)', // Slightly darker overlay for better text contrast
-  },
-  noBackground: {
-    backgroundColor: GlobalStyle.color.primaryColor500,
   },
   text: {
     color: 'white',

--- a/components/UI/TableButton.js
+++ b/components/UI/TableButton.js
@@ -1,9 +1,12 @@
 import { Pressable, Text, View , StyleSheet} from "react-native";
 import { GlobalStyle } from "../../constants/theme";
+import { usePrivateGroupTheme } from '../../store/privateGroupTheme-context';
 
   export default function TableButton({ onPress, buttonWidth, buttonHeight, buttonBorderRadius, testID, accessibilityLabel }) {
+    const theme = usePrivateGroupTheme();
+    const fill = theme ? theme.primaryColor : GlobalStyle.color.primaryColor;
     return(
-      <View style={[styles.btn, { width: buttonWidth, height: buttonHeight, borderRadius: buttonBorderRadius }]}>
+      <View style={[styles.btn, { width: buttonWidth, height: buttonHeight, borderRadius: buttonBorderRadius, backgroundColor: fill }]}>
         <Pressable
           accessibilityLabel={accessibilityLabel}
           onPress={onPress}
@@ -20,7 +23,6 @@ const styles = StyleSheet.create({
     opacity: 0.75,
   },
   btn: {
-    backgroundColor: GlobalStyle.color.primaryColor,
     alignSelf: "center",
     borderWidth: 1,
     borderColor: 'rgba(160, 118, 249, 0.5)',

--- a/components/UI/TableComponent.js
+++ b/components/UI/TableComponent.js
@@ -3,6 +3,7 @@ import { FlatList, StyleSheet, Text, View, useWindowDimensions } from 'react-nat
 
 import TableButton from './TableButton';
 import { GlobalStyle } from '../../constants/theme';
+import { usePrivateGroupTheme } from '../../store/privateGroupTheme-context';
 
 function buildRankingMetrics(width, height) {
   return {
@@ -80,6 +81,11 @@ const RowItem = React.memo(function RowItem({ row, onPressMore, metrics, styles 
 export default function TableComponent({ data, onPress, onEndReached }) {
   const { width, height } = useWindowDimensions();
   const metrics = useMemo(() => buildRankingMetrics(width, height), [width, height]);
+  const theme = usePrivateGroupTheme();
+  const containerBg = theme ? theme.screen : GlobalStyle.color.primaryColor800;
+  const headBg = theme ? theme.insetDeep : GlobalStyle.color.primaryColor600;
+  const scoreColor = theme ? theme.secondaryColor : GlobalStyle.color.secondaryColor;
+  const headTextColor = theme ? theme.muted : '#c8b4ff';
 
   const styles = useMemo(() => StyleSheet.create({
     container: {
@@ -87,11 +93,11 @@ export default function TableComponent({ data, onPress, onEndReached }) {
       padding: metrics.containerPaddingHorizontal,
       paddingTop: metrics.containerPaddingTop,
       paddingBottom: metrics.containerPaddingBottom,
-      backgroundColor: GlobalStyle.color.primaryColor800,
+      backgroundColor: containerBg,
     },
     head: {
       height: metrics.headerHeight,
-      backgroundColor: GlobalStyle.color.primaryColor600,
+      backgroundColor: headBg,
       flexDirection: 'row',
       alignSelf: "center",
       overflow: "hidden",
@@ -102,7 +108,7 @@ export default function TableComponent({ data, onPress, onEndReached }) {
       borderBottomColor: 'rgba(160, 118, 249, 0.5)',
     },
     headText: {
-      color: '#c8b4ff',
+      color: headTextColor,
       fontSize: metrics.headerFontSize,
       textTransform: 'uppercase',
       letterSpacing: 1,
@@ -133,10 +139,10 @@ export default function TableComponent({ data, onPress, onEndReached }) {
       fontSize: metrics.textFontSize,
     },
     score: {
-      color: GlobalStyle.color.secondaryColor,
+      color: scoreColor,
       fontWeight: '700',
     },
-  }), [metrics]);
+  }), [metrics, containerBg, headBg, scoreColor, headTextColor]);
 
   const headers = data?.tableHeaders || [];
   const rows = data?.tableScores || [];

--- a/screens/Groups/PrivateHomeScreen.js
+++ b/screens/Groups/PrivateHomeScreen.js
@@ -18,6 +18,7 @@ import { updateGroupSettings, deletePrivateImage } from '../../services/groups/g
 import { resolveHomeBackground, deleteHomeBackgroundFile } from '../../services/groups/groupHomeBackgrounds';
 import { uploadHomeBackground } from '../../services/groups/homeBackgroundUpload';
 import { getPrivateGroupTheme } from '../../utils/privateGroupTheme';
+import { PrivateGroupThemeProvider } from '../../store/privateGroupTheme-context';
 
 const HideImage = require('../../assets/home/WoIstWaldo-character-hide.webp');
 const FindImage = require('../../assets/home/WoIstWaldo-character-guess-4-3.webp');
@@ -267,15 +268,10 @@ export default function PrivateHomeScreen({ navigation, route }) {
     <View
       style={[
         styles.container,
-        { backgroundColor: groupTheme.primaryColor },
+        { backgroundColor: groupTheme.screen },
       ]}
     >
-      <Text
-        style={[styles.title, { color: groupTheme.headerTintColor }]}
-        testID="private-home.title"
-      >
-        {group?.name ?? ''}
-      </Text>
+      <PrivateGroupThemeProvider group={group}>
       {isLocked && (
         <Text testID="private-home.lock-badge" style={styles.lockBadge}>
           Locked by owner
@@ -417,6 +413,7 @@ export default function PrivateHomeScreen({ navigation, route }) {
         onTransfer={transferOwnership}
         onDismiss={dismissLockedOwnerModal}
       />
+      </PrivateGroupThemeProvider>
     </View>
   );
 }

--- a/screens/GuessScreens/GuessFeedScreen.js
+++ b/screens/GuessScreens/GuessFeedScreen.js
@@ -11,6 +11,7 @@ import {
   saveSessionLanguageFilter,
 } from '../../utils/storageDatum';
 import { useActiveGroup } from '../../hooks/useActiveGroup';
+import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../../store/privateGroupTheme-context';
 
 const DEFAULT_LANGUAGE = 'en';
 
@@ -22,6 +23,7 @@ export default function GuessFeedScreen({ navigation, route }) {
   const routeScope = route?.params?.scope;
   const { scope: activeScope } = useActiveGroup();
   const scope = routeScope ?? activeScope;
+  const { group, theme } = useScopedPrivateGroupTheme(routeScope);
   const [language, setLanguage] = useState(routeLanguage || null);
   const [showOverlay, setShowOverlay] = useState(!skipInstructions);
   const [isFilterModalVisible, setIsFilterModalVisible] = useState(false);
@@ -53,6 +55,16 @@ export default function GuessFeedScreen({ navigation, route }) {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    if (!theme) {
+      return;
+    }
+    navigation.setOptions({
+      headerStyle: { backgroundColor: theme.primaryColor },
+      headerTintColor: theme.headerTintColor,
+    });
+  }, [navigation, theme?.primaryColor, theme?.headerTintColor]);
 
   const handleOpenFilter = () => {
     setIsFilterModalVisible(true);
@@ -90,6 +102,7 @@ export default function GuessFeedScreen({ navigation, route }) {
   }
 
   return (
+    <PrivateGroupThemeProvider group={group}>
     <>
       <Text style={styles.hiddenCurrent} testID="guess-feed.filter.language.current">
         {language || DEFAULT_LANGUAGE}
@@ -151,6 +164,7 @@ export default function GuessFeedScreen({ navigation, route }) {
         </View>
       </Modal>
     </>
+    </PrivateGroupThemeProvider>
   );
 }
 

--- a/screens/GuessScreens/GuessPathScreen.js
+++ b/screens/GuessScreens/GuessPathScreen.js
@@ -28,6 +28,7 @@ import { isE2EMode } from '../../utils/e2eMode';
 import { useActiveGroup } from '../../hooks/useActiveGroup';
 import { useGroupsHub } from '../../hooks/useGroupsHub';
 import { AuthContext } from '../../store/auth-context';
+import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../../store/privateGroupTheme-context';
 import {
   createGroupCategory,
   deleteGroupCategory,
@@ -69,6 +70,7 @@ export default function GuessPathScreen({ navigation, route }) {
   const isOwner = isPrivateScope && (groupsHubData?.owned ?? []).some(
     (g) => g.id === scope.groupId
   );
+  const { group, theme } = useScopedPrivateGroupTheme(routeScope);
 
   function normalizePrivateCategory(category, resolvedThumbnailUrl = null) {
     return {
@@ -133,6 +135,16 @@ export default function GuessPathScreen({ navigation, route }) {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    if (!theme) {
+      return;
+    }
+    navigation.setOptions({
+      headerStyle: { backgroundColor: theme.primaryColor },
+      headerTintColor: theme.headerTintColor,
+    });
+  }, [navigation, theme?.primaryColor, theme?.headerTintColor]);
 
   const resolvedLanguage = sessionLanguage ?? DEFAULT_LANGUAGE;
   const navigationLanguage = sessionLanguage ?? NAVIGATION_ANY_LANGUAGE;
@@ -269,6 +281,7 @@ export default function GuessPathScreen({ navigation, route }) {
   const gridData = [RECENT_ALL_CATEGORY, ...categories];
 
   return (
+    <PrivateGroupThemeProvider group={group}>
     <>
       {isE2EMode() && (
         <Pressable
@@ -502,6 +515,7 @@ export default function GuessPathScreen({ navigation, route }) {
         </View>
       </Modal>
     </>
+    </PrivateGroupThemeProvider>
   );
 }
 

--- a/screens/GuessScreens/GuessScreen.js
+++ b/screens/GuessScreens/GuessScreen.js
@@ -1,14 +1,26 @@
+import { useEffect } from 'react';
 import { Dimensions } from 'react-native';
 
 import GuessPicture from "../../components/Picture/GuessPicture";
 
 import { isOnTarget } from "../../utils/targetLocation";
 import TutorialOverlay from '../../components/UI/TutorialOverlay';
+import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../../store/privateGroupTheme-context';
 
 export default function GuessScreen({ navigation, route }) {
 
   const { imageFile, pictureId, description, imageHeight, imageWidth, isPortrait, hiddenLocation, listId, isTutorial, category, language, scope, skipInstructions } = route.params;
   const isPrivate = scope?.kind === 'private';
+
+  const { group, theme } = useScopedPrivateGroupTheme(scope);
+
+  useEffect(() => {
+    if (!theme) return;
+    navigation.setOptions({
+      headerStyle: { backgroundColor: theme.primaryColor },
+      headerTintColor: theme.headerTintColor,
+    });
+  }, [navigation, theme?.primaryColor, theme?.headerTintColor]);
 
   const screenWidth = Dimensions.get('window').width;
   const screenHeight = Dimensions.get('window').height;
@@ -50,6 +62,7 @@ export default function GuessScreen({ navigation, route }) {
 
 
   return(
+    <PrivateGroupThemeProvider group={group}>
     <>
     <GuessPicture
       navigation={navigation}
@@ -73,5 +86,6 @@ export default function GuessScreen({ navigation, route }) {
         />
       }
     </>  
+    </PrivateGroupThemeProvider>
   );
 };

--- a/screens/GuessScreens/ResultScreen.js
+++ b/screens/GuessScreens/ResultScreen.js
@@ -1,8 +1,8 @@
-import { useLayoutEffect, useMemo } from "react";
+import { useLayoutEffect } from "react";
 import { View, StyleSheet } from "react-native";
 
 import { handleOrientation } from "../../utils/orientation";
-import { useGroupsHub } from "../../hooks/useGroupsHub";
+import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from "../../store/privateGroupTheme-context";
 
 import ShowSuccess from "../../components/Results/ShowSuccess";
 import ShowFailure from "../../components/Results/ShowFailure";
@@ -15,21 +15,16 @@ export default function ResultScreen({ route, navigation }) {
 
   const scope = route?.params?.scope;
   const isPrivate = scope?.kind === 'private';
-  const { data } = useGroupsHub();
-
-  const group = useMemo(() => {
-    if (!isPrivate) {
-      return null;
-    }
-    const groups = [...(data?.owned ?? []), ...(data?.joined ?? [])];
-    return groups.find((g) => g.id === scope.groupId) ?? null;
-  }, [data, isPrivate, scope]);
+  const { group, theme } = useScopedPrivateGroupTheme(scope);
 
   useLayoutEffect(() => {
-    if (isPrivate && group?.name) {
-      navigation.setOptions({ title: group.name });
-    }
-  }, [isPrivate, group, navigation]);
+    if (!theme) return;
+    navigation.setOptions({
+      title: group?.name,
+      headerStyle: { backgroundColor: theme.primaryColor },
+      headerTintColor: theme.headerTintColor,
+    });
+  }, [navigation, group?.name, theme?.primaryColor, theme?.headerTintColor]);
 
   const backgroundColor = isPrivate
     ? (group?.primary_color ?? '#1D133D')
@@ -49,11 +44,13 @@ export default function ResultScreen({ route, navigation }) {
     return null;
   })();
 
-  if (backgroundColor) {
-    return <View style={[styles.wrapper, { backgroundColor }]}>{content}</View>;
-  }
-
-  return content;
+  return (
+    <PrivateGroupThemeProvider group={group}>
+      {backgroundColor ? (
+        <View style={[styles.wrapper, { backgroundColor }]}>{content}</View>
+      ) : content}
+    </PrivateGroupThemeProvider>
+  );
 };
 
 const styles = StyleSheet.create({

--- a/screens/HideScreens/HideScreen.js
+++ b/screens/HideScreens/HideScreen.js
@@ -1,8 +1,9 @@
+import { useEffect } from 'react';
 import { Dimensions, View, StyleSheet } from 'react-native';
 import HidePicture from '../../components/Picture/HidePicture';
 import { useActiveGroup } from '../../hooks/useActiveGroup';
-import { useGroupsHub } from '../../hooks/useGroupsHub';
 import { GlobalStyle } from '../../constants/theme';
+import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../../store/privateGroupTheme-context';
 
 export default function HideScreen({ navigation, route }) {
   const uri = route.params?.uri;
@@ -18,25 +19,32 @@ export default function HideScreen({ navigation, route }) {
   const routeScope = route.params?.scope;
   const { scope: activeScope } = useActiveGroup();
   const scope = routeScope ?? activeScope;
-  const { data } = useGroupsHub();
-  const group = scope?.kind === 'private'
-    ? [...(data?.owned ?? []), ...(data?.joined ?? [])].find((g) => g.id === scope.groupId)
-    : null;
+  const { group, theme } = useScopedPrivateGroupTheme(routeScope);
   const backgroundColor = group?.primary_color ?? GlobalStyle.color.primaryColor900;
 
+  useEffect(() => {
+    if (!theme) return;
+    navigation.setOptions({
+      headerStyle: { backgroundColor: theme.primaryColor },
+      headerTintColor: theme.headerTintColor,
+    });
+  }, [navigation, theme?.primaryColor, theme?.headerTintColor]);
+
   return (
-    <View style={[styles.container, { backgroundColor }]}>
-      <HidePicture
-        navigation={navigation}
-        uri={uri}
-        imageWidth={route.params?.imageWidth}
-        imageHeight={route.params?.imageHeight}
-        screenDimensions={screenDimensions}
-        imageIsPortrait={isPortrait}
-        isTutorial={isTutorial}
-        scope={scope}
-      />
-    </View>
+    <PrivateGroupThemeProvider group={group}>
+      <View style={[styles.container, { backgroundColor }]}>
+        <HidePicture
+          navigation={navigation}
+          uri={uri}
+          imageWidth={route.params?.imageWidth}
+          imageHeight={route.params?.imageHeight}
+          screenDimensions={screenDimensions}
+          imageIsPortrait={isPortrait}
+          isTutorial={isTutorial}
+          scope={scope}
+        />
+      </View>
+    </PrivateGroupThemeProvider>
   );
 };
 

--- a/screens/HideScreens/HidingPathScreen.js
+++ b/screens/HideScreens/HidingPathScreen.js
@@ -1,15 +1,29 @@
+import { useEffect } from 'react';
 import { View } from 'react-native';
 import LogicalImagePicker from '../../components/Picture/LogicalImagePicker';
 import { useActiveGroup } from '../../hooks/useActiveGroup';
+import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../../store/privateGroupTheme-context';
 
 export default function HidingPathScreen({ navigation, route }) {
   const isTutorial = route?.params?.isTutorial;
   const routeScope = route?.params?.scope;
   const { scope: activeScope } = useActiveGroup();
   const scope = routeScope ?? activeScope;
+  const { group, theme } = useScopedPrivateGroupTheme(routeScope);
+
+  useEffect(() => {
+    if (!theme) return;
+    navigation.setOptions({
+      headerStyle: { backgroundColor: theme.primaryColor },
+      headerTintColor: theme.headerTintColor,
+    });
+  }, [navigation, theme?.primaryColor, theme?.headerTintColor]);
+
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <LogicalImagePicker navigation={navigation} isTutorial={isTutorial} scope={scope} />
-    </View>
+    <PrivateGroupThemeProvider group={group}>
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <LogicalImagePicker navigation={navigation} isTutorial={isTutorial} scope={scope} />
+      </View>
+    </PrivateGroupThemeProvider>
   );
 };

--- a/screens/RankingScreen.js
+++ b/screens/RankingScreen.js
@@ -7,8 +7,8 @@ import { getRankingData, getUserScores } from '../utils/scoreRequests';
 import TableComponent from '../components/UI/TableComponent';
 import LoadingOverlay from '../components/UI/LoadingOverlay';
 import { AuthContext } from '../store/auth-context';
+import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../store/privateGroupTheme-context';
 import { useActiveGroup } from '../hooks/useActiveGroup';
-import { useGroupsHub } from '../hooks/useGroupsHub';
 
 // Bounded resident window: 150 rows ≈ 7–8 cursor pages of 20 rows.
 // Keeps memory stable on low-end devices while allowing deep browsing.
@@ -26,15 +26,9 @@ export default function RankingScreen({ route, navigation }) {
 
   const context = useContext(AuthContext);
   const routeScope = route?.params?.scope;
+  const { group, theme, isPrivate } = useScopedPrivateGroupTheme(routeScope);
   const { scope: activeScope } = useActiveGroup();
-  const scope = routeScope ?? activeScope;
-  const isPrivate = scope?.kind === 'private';
-  const { data } = useGroupsHub();
-  const group = isPrivate
-    ? [...(data?.owned ?? []), ...(data?.joined ?? [])].find((entry) => entry.id === scope.groupId)
-    : null;
-
-  const rankingScope = isPrivate ? scope : 'initial';
+  const rankingScope = isPrivate ? (routeScope ?? activeScope) : 'initial';
 
   const tableHeaders = RANKING?.tableHeaders;
 
@@ -88,8 +82,16 @@ export default function RankingScreen({ route, navigation }) {
   };
 
   useEffect(() => {
-    navigation.setOptions({ title: group?.name ?? 'Ranking' });
-  }, [navigation, group?.name]);
+    if (theme) {
+      navigation.setOptions({
+        title: group?.name ?? 'Ranking',
+        headerStyle: { backgroundColor: theme.primaryColor },
+        headerTintColor: theme.headerTintColor,
+      });
+    } else {
+      navigation.setOptions({ title: group?.name ?? 'Ranking' });
+    }
+  }, [navigation, group?.name, theme?.primaryColor, theme?.headerTintColor]);
 
 
 
@@ -181,7 +183,7 @@ export default function RankingScreen({ route, navigation }) {
   }, [handleRankingData])
 
   return (
-    <>
+    <PrivateGroupThemeProvider group={group}>
       {rankingDatum ? (
         <View style={styles.screen} testID="ranking.screen">
           <TableComponent data={rankingDatum} onPress={showSpecificDatum} onEndReached={handleEndReached} />
@@ -189,7 +191,7 @@ export default function RankingScreen({ route, navigation }) {
       ) : (
         <LoadingOverlay message={"Loading ranking table..."}/>
       )}
-    </>
+    </PrivateGroupThemeProvider>
   );
 };
 

--- a/screens/SetInstructionScreen.js
+++ b/screens/SetInstructionScreen.js
@@ -21,6 +21,7 @@ import { listGroupCategories } from '../services/groups/groupCategoriesApi';
 
 import LoadingOverlay from '../components/UI/LoadingOverlay';
 import { checkSecureStoreItem } from '../utils/auth';
+import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../store/privateGroupTheme-context';
 
 const NON_UPLOAD_CATEGORY_KEYS = new Set(['all', 'other']);
 const DEFAULT_CATEGORY_LOAD_ERROR_MESSAGE = 'Unable to load categories. Please try again.';
@@ -64,6 +65,7 @@ export default function SetInstructionsScreen({ navigation, route }) {
 
   const context = useContext(AuthContext);
   const isPrivateScope = scope?.kind === 'private' && !!scope?.groupId;
+  const { group, theme } = useScopedPrivateGroupTheme(scope);
   const selectableCategories = categories.filter((category) => isUploadableCategoryKey(category?.key));
 
   function normalizePrivateCategory(category) {
@@ -124,6 +126,17 @@ export default function SetInstructionsScreen({ navigation, route }) {
       isMountedRef.current = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (!theme) {
+      return;
+    }
+
+    navigation.setOptions({
+      headerStyle: { backgroundColor: theme.primaryColor },
+      headerTintColor: theme.headerTintColor,
+    });
+  }, [navigation, theme?.primaryColor, theme?.headerTintColor]);
 
   const getPermissions = async () => {
     let currentPermission = permissionResponse;
@@ -333,53 +346,55 @@ export default function SetInstructionsScreen({ navigation, route }) {
 
 
   return (
-    <View style={styles.container} testID="set-instructions.screen">
-      <ImageBackground
-        accessibilityLabel="Set instructions image"
-        source={{uri : uri}}
-        resizeMode='stretch'
-        style={imageDimensionStyle}
-        testID="set-instructions.image"
-      >
-        <HideDescription
-          onSubmit={handlePressDescription}
-          onCancel={onCancelGoBack}
-          language={language}
-          onLanguageChange={handleLanguageChange}
-          languageError={languageError}
-          categories={selectableCategories}
-          categoriesError={categoriesError}
-          onRetryCategories={loadCategories}
-          selectedCategory={selectedCategory}
-          onCategorySelect={handleCategorySelect}
-        />
-        <Ionicons name={"close-circle-outline"} color={"white"} size={target.targetSize} style={[target.targetStyle, { opacity: 0.5 }]}/>
-      </ImageBackground>
-      {
-        showModal &&
-          <CenteredModal 
-            onPress={handleConfirmModal} 
-            onCancel={onCancelModal} 
-            isModalVisible={showModal}
-            testIDPrefix="set-instructions.confirm-modal"
-          >
-            <ModalContent
-              description={description}
-              screenHeight={screenHeight}
-              screenWidth={screenWidth}
-              guessPath={false} 
-            />
-          </CenteredModal> 
-      }
-      {
-        isTutorial && 
-          <TutorialOverlay 
-            screen={"SetInstructionScreen"}
-            isPortrait={isPortrait}
-            instructionsPosition={{top:0, left: 0}}
+    <PrivateGroupThemeProvider group={group}>
+      <View style={styles.container} testID="set-instructions.screen">
+        <ImageBackground
+          accessibilityLabel="Set instructions image"
+          source={{uri : uri}}
+          resizeMode='stretch'
+          style={imageDimensionStyle}
+          testID="set-instructions.image"
+        >
+          <HideDescription
+            onSubmit={handlePressDescription}
+            onCancel={onCancelGoBack}
+            language={language}
+            onLanguageChange={handleLanguageChange}
+            languageError={languageError}
+            categories={selectableCategories}
+            categoriesError={categoriesError}
+            onRetryCategories={loadCategories}
+            selectedCategory={selectedCategory}
+            onCategorySelect={handleCategorySelect}
           />
+          <Ionicons name={"close-circle-outline"} color={"white"} size={target.targetSize} style={[target.targetStyle, { opacity: 0.5 }]}/>
+        </ImageBackground>
+        {
+          showModal &&
+            <CenteredModal
+              onPress={handleConfirmModal}
+              onCancel={onCancelModal}
+              isModalVisible={showModal}
+              testIDPrefix="set-instructions.confirm-modal"
+            >
+              <ModalContent
+                description={description}
+                screenHeight={screenHeight}
+                screenWidth={screenWidth}
+                guessPath={false}
+              />
+            </CenteredModal>
         }
-    </View>
+        {
+          isTutorial &&
+            <TutorialOverlay
+              screen={"SetInstructionScreen"}
+              isPortrait={isPortrait}
+              instructionsPosition={{top:0, left: 0}}
+            />
+          }
+      </View>
+    </PrivateGroupThemeProvider>
   )
 };
 

--- a/store/privateGroupTheme-context.js
+++ b/store/privateGroupTheme-context.js
@@ -1,0 +1,57 @@
+import { createContext, useContext, useMemo } from "react";
+
+import { GlobalStyle } from "../constants/theme";
+import { useActiveGroup } from "../hooks/useActiveGroup";
+import { useGroupsHub } from "../hooks/useGroupsHub";
+import { getPrivateGroupTheme } from "../utils/privateGroupTheme";
+
+const PrivateGroupThemeContext = createContext(null);
+
+export function PrivateGroupThemeProvider({ group, children }) {
+  const theme = useMemo(
+    () => getPrivateGroupTheme({
+      primaryColor: group?.primary_color,
+      secondaryColor: group?.secondary_color,
+    }),
+    [group?.primary_color, group?.secondary_color],
+  );
+
+  const value = group ? theme : null;
+
+  return (
+    <PrivateGroupThemeContext.Provider value={value}>
+      {children}
+    </PrivateGroupThemeContext.Provider>
+  );
+}
+
+export function usePrivateGroupTheme() {
+  return useContext(PrivateGroupThemeContext);
+}
+
+export function useAccentColor() {
+  return usePrivateGroupTheme()?.primaryColor ?? GlobalStyle.color.primaryColor500;
+}
+
+export function useGroupSurfaceColor() {
+  return usePrivateGroupTheme()?.screen ?? GlobalStyle.color.primaryColor900;
+}
+
+export function useScopedPrivateGroupTheme(routeScopeOverride) {
+  const { scope: activeScope } = useActiveGroup();
+  const { data } = useGroupsHub();
+  const scope = routeScopeOverride ?? activeScope;
+  const isPrivate = !!(scope?.kind === 'private' && scope?.groupId);
+  const group = useMemo(() => {
+    if (!isPrivate) return null;
+    const all = [...(data?.owned ?? []), ...(data?.joined ?? [])];
+    return all.find((g) => g.id === scope.groupId) ?? null;
+  }, [isPrivate, scope?.groupId, data]);
+  const theme = useMemo(
+    () => group
+      ? getPrivateGroupTheme({ primaryColor: group.primary_color, secondaryColor: group.secondary_color })
+      : null,
+    [group],
+  );
+  return { group, theme, isPrivate };
+}


### PR DESCRIPTION
- Implement PrivateGroupThemeContext to manage theming based on private group settings.
- Create tests for button components to validate theme integration.
- Update Button, BigButton, TableButton, and HomeCard components to use the new theme context.
- Modify PrivateHomeScreen and Guess screens to apply group-specific theming.
- Ensure fallback to global styles when no theme is provided.
- Refactor existing components to utilize the new context for consistent theming across the application.