### PR TITLE
Fix/bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@
 - Prefer Jest for unit and mocked integration coverage. Use Maestro for full-device journeys, gesture-heavy flows, or deterministic E2E behavior.
 - Keep source-of-truth runtime rules here; keep one-off proposals in `planning/` instead.
 - Ignore `.expo/`, `node_modules/`, and packaged APK artifacts unless task explicitly targets them.
+- If something is implemented for public or private groups, check that it works in both contexts, unless explicitly stated otherwise. Private groups have their own backend isolation rules and may require extra setup to test.
 
 ## Verification
 

--- a/__tests__/CategoryChips.test.js
+++ b/__tests__/CategoryChips.test.js
@@ -82,8 +82,7 @@ describe('CategoryChips', () => {
   it('renders the null-thumbnail fallback for categories without thumbnails', async () => {
     const renderer = await renderChips({ selected: null });
 
-    expect(renderer.root.findByProps({ testID: 'categories.chip.other.fallback' })).toBeTruthy();
-    expect(renderer.root.findByProps({ testID: 'categories.chip.nature.fallback' })).toBeTruthy();
+    expect(renderer.root.findByProps({ testID: 'categories.chip.recent.fallback' })).toBeTruthy();
   });
 
   it('uses the local asset when a private default category has no remote thumbnail', async () => {
@@ -100,9 +99,11 @@ describe('CategoryChips', () => {
     });
 
     const images = renderer.root.findAllByType('Image');
+    const privateDefaultImage = images.find(
+      (image) => image.props.source === CATEGORY_ASSETS.nature
+    );
 
-    expect(images).toHaveLength(1);
-    expect(images[0].props.source).toBe(CATEGORY_ASSETS.nature);
+    expect(privateDefaultImage).toBeTruthy();
     expect(() => renderer.root.findByProps({ testID: 'categories.chip.966b8efe-887d-44da-b6a6-5eac0791b4ff.fallback' })).toThrow();
   });
 });

--- a/__tests__/CategoryChips.test.js
+++ b/__tests__/CategoryChips.test.js
@@ -13,6 +13,7 @@ import { act, create } from 'react-test-renderer';
 
 import CategoryChips from '../components/UI/CategoryChips';
 import { GlobalStyle } from '../constants/theme';
+import { CATEGORY_ASSETS } from '../utils/categoryAssets';
 
 describe('CategoryChips', () => {
   const categories = [
@@ -83,5 +84,25 @@ describe('CategoryChips', () => {
 
     expect(renderer.root.findByProps({ testID: 'categories.chip.other.fallback' })).toBeTruthy();
     expect(renderer.root.findByProps({ testID: 'categories.chip.nature.fallback' })).toBeTruthy();
+  });
+
+  it('uses the local asset when a private default category has no remote thumbnail', async () => {
+    const renderer = await renderChips({
+      categories: [
+        {
+          id: '966b8efe-887d-44da-b6a6-5eac0791b4ff',
+          key: '966b8efe-887d-44da-b6a6-5eac0791b4ff',
+          name: 'Nature',
+          thumbnailUrl: null,
+        },
+      ],
+      selected: null,
+    });
+
+    const images = renderer.root.findAllByType('Image');
+
+    expect(images).toHaveLength(1);
+    expect(images[0].props.source).toBe(CATEGORY_ASSETS.nature);
+    expect(() => renderer.root.findByProps({ testID: 'categories.chip.966b8efe-887d-44da-b6a6-5eac0791b4ff.fallback' })).toThrow();
   });
 });

--- a/__tests__/GuessCategoryCard.test.js
+++ b/__tests__/GuessCategoryCard.test.js
@@ -84,6 +84,21 @@ describe('GuessCategoryCard', () => {
     expect(image.props.source).toBe(CATEGORY_ASSETS.nature);
   });
 
+  it('uses the local asset when thumbnailUrl is missing and a private default category name is known', async () => {
+    const renderer = await renderCard({
+      category: {
+        id: '966b8efe-887d-44da-b6a6-5eac0791b4ff',
+        key: '966b8efe-887d-44da-b6a6-5eac0791b4ff',
+        name: 'Nature',
+      },
+      thumbnailUrl: undefined,
+    });
+
+    const image = renderer.root.findByType('ImageBackground');
+
+    expect(image.props.source).toBe(CATEGORY_ASSETS.nature);
+  });
+
   it('prefers an explicit remote thumbnailUrl string over the local asset', async () => {
     const renderer = await renderCard({ thumbnailUrl: 'https://example/x.png' });
 

--- a/__tests__/GuessPathScreen.test.js
+++ b/__tests__/GuessPathScreen.test.js
@@ -52,6 +52,7 @@ jest.mock('../utils/categoryRequests', () => ({
 }));
 
 jest.mock('../utils/storageDatum', () => ({
+  getPreferredLanguage: jest.fn(),
   getSessionLanguageFilter: jest.fn(),
   saveSessionLanguageFilter: jest.fn(),
 }));
@@ -92,6 +93,7 @@ import GuessPathScreen from '../screens/GuessScreens/GuessPathScreen';
 import { AuthContext } from '../store/auth-context';
 import { getCategories } from '../utils/categoryRequests';
 import {
+  getPreferredLanguage,
   getSessionLanguageFilter,
   saveSessionLanguageFilter,
 } from '../utils/storageDatum';
@@ -158,6 +160,7 @@ describe('GuessPathScreen', () => {
     resolveCategoryThumbnail.mockResolvedValue(null);
     deleteCategoryThumbnailFile.mockReturnValue(undefined);
     uploadCategoryThumbnail.mockResolvedValue(null);
+    getPreferredLanguage.mockResolvedValue(null);
     getSessionLanguageFilter.mockResolvedValue(null);
     saveSessionLanguageFilter.mockResolvedValue(undefined);
     mockUseGroupsHub.mockReturnValue({ data: null, refresh: jest.fn() });
@@ -320,6 +323,28 @@ describe('GuessPathScreen', () => {
     expect(navigation.navigate).toHaveBeenCalledWith('GuessFeedScreen', {
       category: expect.objectContaining({ key: 'nature', name: 'Nature' }),
       language: 'any',
+    });
+  });
+
+  it('falls back to the preferred language when the session filter is unset', async () => {
+    getPreferredLanguage.mockResolvedValue('fr');
+
+    const renderer = await renderScreen();
+
+    expect(
+      renderer.root.findByProps({ testID: 'guess-path.filter.language.current' }).props
+        .children
+    ).toBe('fr');
+
+    const natureCard = getCardPropsByKey('nature');
+
+    await act(async () => {
+      natureCard.onPress();
+    });
+
+    expect(navigation.navigate).toHaveBeenCalledWith('GuessFeedScreen', {
+      category: expect.objectContaining({ key: 'nature', name: 'Nature' }),
+      language: 'fr',
     });
   });
 

--- a/__tests__/SwipeImage.test.js
+++ b/__tests__/SwipeImage.test.js
@@ -236,21 +236,23 @@ describe('SwipeImage', () => {
     ], 'all', 'any');
   });
 
-  it('does not restart the synthetic all feed from head when the public exhausted sentinel is stored', async () => {
+  it('re-queries the server on cold mount when the exhausted sentinel is stored so new uploads surface', async () => {
+    // Regression: a stored PUBLIC_FEED_END_CURSOR used to short-circuit the
+    // cold-mount load, so once a category ever returned empty it never queried
+    // the server again — newly uploaded cards stayed invisible until reinstall.
     getLocalImages.mockResolvedValue(null);
     getLastImageUuid.mockResolvedValue(PUBLIC_FEED_END_CURSOR);
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [
+        { pictureId: 'fresh-after-exhaust', imageFile: 'file:///fresh.jpg' },
+      ],
+    });
 
-    const { renderer } = await renderSwipeImage();
+    await renderSwipeImage();
 
-    expect(getImages).not.toHaveBeenCalled();
-
-    const renderedText = renderer.root
-      .findAll((node) => node.type === 'Text')
-      .map((node) => node.props.children)
-      .flat()
-      .join(' ');
-
-    expect(renderedText).toContain('No more images to guess right now!');
+    expect(getImages).toHaveBeenCalledWith(null, contextValue, expect.objectContaining({}));
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).toContain('fresh-after-exhaust');
   });
 
   it('normalizes the synthetic all card so category_id stays undefined while category_key is threaded', async () => {

--- a/__tests__/cardDeck.test.js
+++ b/__tests__/cardDeck.test.js
@@ -1,4 +1,5 @@
 jest.mock('../utils/storageDatum', () => ({
+  PUBLIC_FEED_END_CURSOR: '__public_feed_end__',
   getLastImageUuid: jest.fn(),
   storeImageList: jest.fn(),
   updateImageList: jest.fn(),
@@ -13,9 +14,10 @@ jest.mock('../services/groups/groupFeedCache', () => ({
   writeGroupFeedCache: jest.fn(),
 }));
 
-import { updateImageList } from '../utils/storageDatum';
+import { getLastImageUuid, updateImageList } from '../utils/storageDatum';
+import { getImages } from '../utils/imagesRequests';
 import { readGroupFeedCache, writeGroupFeedCache } from '../services/groups/groupFeedCache';
-import { appendCardBatch } from '../services/cardDeck';
+import { appendCardBatch, fetchCardBatch } from '../services/cardDeck';
 
 describe('appendCardBatch', () => {
   beforeEach(() => {
@@ -148,6 +150,95 @@ describe('appendCardBatch', () => {
       'g-3',
       { categoryId: undefined, language: 'fr' },
       expect.objectContaining({ images: [{ listId: 1 }] }),
+    );
+  });
+});
+
+describe('fetchCardBatch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getLastImageUuid.mockResolvedValue(null);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+  });
+
+  it('normalizes a synthetic "any" language to undefined so the backend does not filter by a non-existent language code', async () => {
+    // Regression: GuessPathScreen passes navigationLanguage='any' when the user
+    // never opened the language filter. That literal flowed all the way to the
+    // backend as ?language=any, and Image.batch_with_existing_storage applied
+    // WHERE language='any' — matching zero rows (no image has language='any').
+    // Categories with otherwise-matching cards appeared permanently empty.
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'any',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ language: undefined, category_key: 'nature', category_id: 'cat-nature' }),
+    );
+    expect(getImages.mock.calls[0][2].language).not.toBe('any');
+  });
+
+  it('forwards a real language code untouched', async () => {
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ language: 'fr' }),
+    );
+  });
+
+  it('normalizes an undefined language to undefined on the server (parity with the any/undefined branch)', async () => {
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: undefined,
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ language: undefined }),
+    );
+    expect(getImages.mock.calls[0][2].language).not.toBe('any');
+  });
+
+  it('treats a legacy stored exhausted sentinel as a fresh cursor so pictureIdOverride===undefined paths self-heal', async () => {
+    // Regression: prior app versions persisted PUBLIC_FEED_END_CURSOR to mark a
+    // category exhausted. After the brick fix, the cold-mount path bypasses the
+    // cursor (always passes null), but refillOrFallback's foreground load and
+    // the background prefetcher still call fetchCardBatch with no override —
+    // which used to read the stale sentinel and POST {name:'__public_feed_end__'}
+    // to the backend every session. Treat the sentinel as null so those paths
+    // also re-query from head and overwrite the stale key with a real cursor.
+    getLastImageUuid.mockResolvedValue('__public_feed_end__');
+
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+      // pictureIdOverride intentionally omitted (refillOrFallback / prefetcher shape)
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ category_key: 'nature' }),
     );
   });
 });

--- a/__tests__/imagesRequests.test.js
+++ b/__tests__/imagesRequests.test.js
@@ -15,7 +15,6 @@ jest.mock('../utils/auth', () => ({
 }));
 
 jest.mock('../utils/storageDatum', () => ({
-  PUBLIC_FEED_END_CURSOR: '__public_feed_end__',
   saveLastImageUuid: jest.fn(),
 }));
 
@@ -43,7 +42,7 @@ import { File, Paths } from 'expo-file-system';
 
 import { getBackendHeaders, setHeaders } from '../utils/auth';
 import { getImages, performImageUpload, prepareImageUpload, saveImageInfos, buildImageObject } from '../utils/imagesRequests';
-import { PUBLIC_FEED_END_CURSOR, saveLastImageUuid } from '../utils/storageDatum';
+import { saveLastImageUuid } from '../utils/storageDatum';
 
 describe('imagesRequests utilities', () => {
   beforeEach(() => {
@@ -152,15 +151,11 @@ describe('imagesRequests utilities', () => {
 
     expect(response).toEqual({ isError: false, images: [] });
     expect(axios.get).toHaveBeenCalledTimes(1);
-    expect(saveLastImageUuid).toHaveBeenCalledWith(PUBLIC_FEED_END_CURSOR, undefined, undefined);
-  });
-
-  it('short-circuits the public exhausted sentinel without hitting the network', async () => {
-    const response = await getImages(PUBLIC_FEED_END_CURSOR, { token: 'Bearer token' }, { language: 'fr' });
-
-    expect(response).toEqual({ isError: false, images: [] });
-    expect(axios.get).not.toHaveBeenCalled();
-    expect(axios.post).not.toHaveBeenCalled();
+    // Regression: an empty batch must NOT persist the exhausted sentinel.
+    // Saving it bricked the category forever (no new uploads ever surfaced).
+    // The caller decides exhaustion via the empty images array; the cursor
+    // stays on the last successfully fetched image so a later retry can page.
+    expect(saveLastImageUuid).not.toHaveBeenCalled();
   });
 
   it('downloads backend-hosted images with auth headers', async () => {

--- a/__tests__/scoreRequests.test.js
+++ b/__tests__/scoreRequests.test.js
@@ -149,7 +149,7 @@ describe('scoreRequests utilities', () => {
 
       const result = await submitScoreBatch({
         items: [
-          { guessId: 'g-1', pictureId: 'img-1', points: 7, scope: { kind: 'private', groupId: 'g-9' } },
+          { guessId: 'g-1', pictureId: 'img-1', points: 7, streak: 5, scope: { kind: 'private', groupId: 'g-9' } },
         ],
         context: { token: 'Bearer token' },
       });
@@ -159,7 +159,7 @@ describe('scoreRequests utilities', () => {
         {
           batch: {
             results: [
-              { guess_id: 'g-1', image_id: 'img-1', earned_points: 7 },
+              { guess_id: 'g-1', image_id: 'img-1', earned_points: 7, streak: 5 },
             ],
           },
         },
@@ -169,12 +169,12 @@ describe('scoreRequests utilities', () => {
       expect(setHeaders).toHaveBeenCalledWith({ token: 'Bearer token' });
     });
 
-    it('does not include streak on the private batch payload', async () => {
+    it('defaults streak to 0 on the private batch payload when the item omits it', async () => {
       axios.post.mockResolvedValue({ status: 200, data: { ok: true } });
 
       await submitScoreBatch({
         items: [
-          { guessId: 'g-1', pictureId: 'img-1', points: 7, streak: 5, scope: { kind: 'private', groupId: 'g-9' } },
+          { guessId: 'g-1', pictureId: 'img-1', points: 7, scope: { kind: 'private', groupId: 'g-9' } },
         ],
         context: { token: 'Bearer token' },
       });
@@ -186,8 +186,8 @@ describe('scoreRequests utilities', () => {
         guess_id: 'g-1',
         image_id: 'img-1',
         earned_points: 7,
+        streak: 0,
       });
-      expect(body.batch.results[0]).not.toHaveProperty('streak');
     });
 
     it('calls setHeaders with only the token and no uid/expiry/access_token/client', async () => {

--- a/__tests__/storageDatum.test.js
+++ b/__tests__/storageDatum.test.js
@@ -112,7 +112,7 @@ describe('storageDatum utilities', () => {
     expect(await getLastImageUuid()).toBe('uuid-1');
   });
 
-  it('round-trips the session language filter and defaults to en when unset', async () => {
+  it('round-trips the session language filter and returns null when unset', async () => {
     await saveSessionLanguageFilter('fr');
     expect(AsyncStorage.setItem).toHaveBeenCalledWith('sessionLanguageFilter', 'fr');
 
@@ -120,7 +120,7 @@ describe('storageDatum utilities', () => {
     expect(await getSessionLanguageFilter()).toBe('fr');
 
     AsyncStorage.getItem.mockResolvedValueOnce(null);
-    expect(await getSessionLanguageFilter()).toBe('en');
+    expect(await getSessionLanguageFilter()).toBeNull();
   });
 
   it('round-trips the preferred language and returns null when unset', async () => {

--- a/app.json
+++ b/app.json
@@ -27,9 +27,6 @@
         "backgroundColor": "#ffffff"
       },
       "permissions": [
-        "android.permission.RECORD_AUDIO",
-        "android.permission.READ_EXTERNAL_STORAGE",
-        "android.permission.WRITE_EXTERNAL_STORAGE",
         "android.permission.ACCESS_MEDIA_LOCATION"
       ],
       "package": "com.alegarn.WoIstWaldoProject"

--- a/components/UI/CategoryChips.js
+++ b/components/UI/CategoryChips.js
@@ -1,5 +1,6 @@
 import { Pressable, Text, View, Image, StyleSheet } from 'react-native';
 
+import { getCategoryAssetSource } from '../../utils/categoryAssets';
 import { GlobalStyle } from '../../constants/theme';
 
 const OTHER_CATEGORY = {
@@ -20,8 +21,9 @@ export default function CategoryChips({ selected, onSelect, categories = [], tes
       {visibleCategories.map((category) => {
         const chipValue = category.key === OTHER_CATEGORY.key ? null : category.key;
         const isSelected = category.key === OTHER_CATEGORY.key ? selected == null : selected === category.key;
-        const hasThumbnail = Boolean(category.thumbnailUrl);
-        // TODO: backend serves placeholder thumbnail_url (seeds set nil); fallback renders until real assets are uploaded.
+        const thumbnailSource = typeof category?.thumbnailUrl === 'string' && category.thumbnailUrl.length > 0
+          ? { uri: category.thumbnailUrl }
+          : getCategoryAssetSource(category);
         return (
           <Pressable
             key={category.key}
@@ -33,8 +35,8 @@ export default function CategoryChips({ selected, onSelect, categories = [], tes
               isSelected && styles.chipSelected,
               isSelected && isOverlay && styles.chipSelectedOverlay,
             ]}>
-            {hasThumbnail ? (
-              <Image source={{ uri: category.thumbnailUrl }} style={styles.thumbnail} />
+            {thumbnailSource ? (
+              <Image source={thumbnailSource} style={styles.thumbnail} />
             ) : (
               <View
                 testID={`${testIDPrefix}.chip.${category.key}.fallback`}

--- a/components/UI/GuessCategoryCard.js
+++ b/components/UI/GuessCategoryCard.js
@@ -1,6 +1,6 @@
 import { Pressable, View, Text, ImageBackground, StyleSheet } from 'react-native';
 
-import { getCategoryAsset } from '../../utils/categoryAssets';
+import { getCategoryAssetSource } from '../../utils/categoryAssets';
 import { GlobalStyle } from '../../constants/theme';
 
 function isRemoteThumbnail(value) {
@@ -10,7 +10,7 @@ function isRemoteThumbnail(value) {
 export default function GuessCategoryCard({ category, thumbnailUrl, count, onPress, testIDPrefix }) {
   const cardTestID = `${testIDPrefix}.card.${category.id}`;
   const useRemote = isRemoteThumbnail(thumbnailUrl);
-  const source = useRemote ? { uri: thumbnailUrl } : getCategoryAsset(category?.key);
+  const source = useRemote ? { uri: thumbnailUrl } : getCategoryAssetSource(category);
 
   return (
     <Pressable onPress={onPress} testID={cardTestID} style={styles.card}>

--- a/components/UI/SwipeImage.js
+++ b/components/UI/SwipeImage.js
@@ -7,7 +7,7 @@ import SwipeableCard from './SwipeableCard';
 import LoadingOverlay from './LoadingOverlay';
 import useBadgeDetail from './useBadgeDetail';
 
-import { PUBLIC_FEED_END_CURSOR, getE2EHiddenGuessCard, getLocalImages, getLastImageId, getLastImageUuid, removeImageFromList, deleteImageFromStorage } from '../../utils/storageDatum';
+import { getE2EHiddenGuessCard, getLocalImages, getLastImageId, removeImageFromList, deleteImageFromStorage } from '../../utils/storageDatum';
 import { AuthContext } from '../../store/auth-context';
 import { buildE2EGuessCardFromPayload, buildE2EGuessCards, isE2EMode } from '../../utils/e2eMode';
 import { GlobalStyle } from '../../constants/theme';
@@ -192,12 +192,12 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
     if (localImageList !== null && (localImageList?.length >= 4)) {
       setImageList(normalizeListIds(localImageList));
     } else if (localImageList === null || localImageList?.length === 0) {
-      // Empty category deck on mount — cold-start the ACTIVE category. Do NOT
-      // cross-fall back to 'recent/all' here; that refill belongs to mid-play
-      // (refillOrFallback), once the user is actually swiping and the deck
-      // empties. Loading recent/all on a cold mount is the reported bug.
-      const lastCursor = await getLastImageUuid(categoryKey, lang);
-      await handleImagesLoading(lastCursor === PUBLIC_FEED_END_CURSOR ? undefined : null);
+      // Empty category deck on mount — cold-start the ACTIVE category with a
+      // fresh server query (pictureId=null). Do NOT consult the stored cursor:
+      // it may be a stale exhausted marker, and we want new uploads to surface.
+      // Cross-fallback to 'recent/all' belongs to mid-play (refillOrFallback),
+      // once the user is actually swiping and the deck empties.
+      await handleImagesLoading(null);
     } else {
       setImageList(localImageList);
       await handleImagesLoading();

--- a/screens/GuessScreens/GuessPathScreen.js
+++ b/screens/GuessScreens/GuessPathScreen.js
@@ -21,6 +21,7 @@ import CenteredModal from '../../components/UI/CenteredModal';
 import { LANGUAGES } from '../../constants/languages';
 import { getCategories } from '../../utils/categoryRequests';
 import {
+  getPreferredLanguage,
   getSessionLanguageFilter,
   saveSessionLanguageFilter,
 } from '../../utils/storageDatum';
@@ -123,11 +124,14 @@ export default function GuessPathScreen({ navigation, route }) {
     let cancelled = false;
 
     async function loadLanguage() {
-      const stored = await getSessionLanguageFilter();
+      const [stored, preferred] = await Promise.all([
+        getSessionLanguageFilter(),
+        getPreferredLanguage(),
+      ]);
       if (cancelled) {
         return;
       }
-      setSessionLanguage(stored);
+      setSessionLanguage(stored ?? preferred ?? null);
     }
 
     loadLanguage();

--- a/screens/SetInstructionScreen.js
+++ b/screens/SetInstructionScreen.js
@@ -43,7 +43,9 @@ export default function SetInstructionsScreen({ navigation, route }) {
   const [categories, setCategories] = useState([]);
   const [categoriesError, setCategoriesError] = useState(null);
   const [selectedCategory, setSelectedCategory] = useState(null);
-  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions();
+  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions({
+    granularPermissions: ['photo'],
+  });
   const [isLoading, setIsLoading] = useState(false);
   const isSubmittingRef = useRef(false);
   const languageTouchedRef = useRef(false);
@@ -146,7 +148,7 @@ export default function SetInstructionsScreen({ navigation, route }) {
       currentPermission = await requestPermission();
     };
     if (!currentPermission?.canAskAgain || currentPermission?.status === "denied") {
-      Alert.alert("Insufficient Permissions", 'Access to  Photos and Videos / audio is denied');
+      Alert.alert("Insufficient Permissions", 'Access to  Photos and Videos is denied');
       Linking.openSettings();
     } else {
       if (currentPermission?.status === "granted") {

--- a/services/cardDeck.js
+++ b/services/cardDeck.js
@@ -6,6 +6,18 @@ function normalizeLanguage(language) {
   return language || 'any';
 }
 
+/**
+ * Server-side language filter. AsyncStorage uses 'any' as the canonical
+ * "no language filter" namespace (see normalizeLanguage), but the backend's
+ * Image.batch_with_existing_storage applies WHERE language = params[:language]
+ * verbatim — and no image row has language='any'. So 'any' must be stripped at
+ * the server boundary, or every card query under a no-filter session returns
+ * empty. Real codes ('en', 'fr', …) pass through untouched.
+ */
+function resolveServerLanguage(language) {
+  return language && language !== 'any' ? language : undefined;
+}
+
 function resolveCategoryId(categoryId) {
   return categoryId === 'all' ? undefined : categoryId;
 }
@@ -19,14 +31,18 @@ export async function fetchCardBatch({ categoryKey, categoryId, language, scope,
   const lastImageUuid = await getLastImageUuid(categoryKey, lang);
   const pictureId = pictureIdOverride !== undefined ? pictureIdOverride : lastImageUuid;
 
-  if (!isPrivateScope(scope) && pictureId === PUBLIC_FEED_END_CURSOR) {
-    return { isError: false, images: [] };
-  }
+  // Legacy self-heal: prior app versions persisted PUBLIC_FEED_END_CURSOR to
+  // mark a category exhausted. The cold-mount path now bypasses the cursor
+  // (always passes null), but refillOrFallback's foreground load and the
+  // background prefetcher still call fetchCardBatch with no override. Treat
+  // the stale sentinel as a fresh cursor so those paths also re-query from
+  // head; the next non-empty batch overwrites the stale key with a real uuid.
+  const effectivePictureId = pictureId === PUBLIC_FEED_END_CURSOR ? null : pictureId;
 
-  return getImages(pictureId, authContext, {
+  return getImages(effectivePictureId, authContext, {
     category_id: resolveCategoryId(categoryId),
     category_key: categoryKey || 'all',
-    language,
+    language: resolveServerLanguage(language),
     scope,
   });
 }

--- a/utils/categoryAssets.js
+++ b/utils/categoryAssets.js
@@ -11,8 +11,43 @@ const CATEGORY_ASSETS = {
   abstract: require('../assets/categories/abstract-image-cat.webp'),
 };
 
+const CATEGORY_NAME_TO_ASSET_KEY = {
+  all: 'all',
+  'recent/all': 'all',
+  other: 'other',
+  nature: 'nature',
+  city: 'city',
+  animals: 'animals',
+  food: 'food',
+  vehicles: 'vehicles',
+  interiors: 'interiors',
+  landmarks: 'landmarks',
+  abstract: 'abstract',
+};
+
+function normalizeAssetLookupToken(value) {
+  return typeof value === 'string'
+    ? value.trim().toLowerCase().replace(/\s*\/\s*/g, '/').replace(/\s+/g, ' ')
+    : null;
+}
+
 export function getCategoryAsset(key) {
   return CATEGORY_ASSETS[key];
+}
+
+export function resolveCategoryAssetKey(category) {
+  const explicitKey = normalizeAssetLookupToken(category?.key);
+  if (explicitKey && CATEGORY_ASSETS[explicitKey]) {
+    return explicitKey;
+  }
+
+  const normalizedName = normalizeAssetLookupToken(category?.name);
+  return normalizedName ? CATEGORY_NAME_TO_ASSET_KEY[normalizedName] : undefined;
+}
+
+export function getCategoryAssetSource(category) {
+  const assetKey = resolveCategoryAssetKey(category);
+  return assetKey ? CATEGORY_ASSETS[assetKey] : undefined;
 }
 
 export { CATEGORY_ASSETS };

--- a/utils/imagesRequests.js
+++ b/utils/imagesRequests.js
@@ -4,7 +4,7 @@ import Image from "../models/image";
 import { setHeaders, getBackendHeaders } from "./auth";
 
 export { getBackendHeaders };
-import { PUBLIC_FEED_END_CURSOR, saveLastImageUuid } from "./storageDatum";
+import { saveLastImageUuid } from "./storageDatum";
 import { fetchPrivateFeedPageForGame } from "../services/groups/groupFeedApi";
 
 function isPrivateScope(scope) {
@@ -263,10 +263,6 @@ export async function getImages(pictureId, context, filters = {}) {
     });
   }
 
-  if (pictureId === PUBLIC_FEED_END_CURSOR) {
-    return { isError: false, images: [] };
-  }
-
   const { token, userId } = await getBackendHeaders(context);
   const headers = setHeaders({ token });
 
@@ -294,7 +290,7 @@ export async function getImages(pictureId, context, filters = {}) {
     const imagesInfosData = imagesInfos?.data?.data ?? [];
 
     if (imagesInfosData.length === 0) {
-      await saveLastImageUuid(PUBLIC_FEED_END_CURSOR, filters?.category_key, filters?.language);
+      await saveLastImageUuid(filters?.category_key, filters?.language);
 
       return { isError: false, images: [] };
     };

--- a/utils/scoreRequests.js
+++ b/utils/scoreRequests.js
@@ -90,6 +90,7 @@ export async function submitScoreBatch({ items, context }) {
       guess_id: item.guessId,
       image_id: item.pictureId,
       earned_points: item.points,
+      streak: item.streak ?? 0,
     }));
 
     return axios

--- a/utils/storageDatum.js
+++ b/utils/storageDatum.js
@@ -150,7 +150,11 @@ export async function getLastImageUuid(categoryKey, language) {
 
 export async function getSessionLanguageFilter() {
   const stored = await AsyncStorage.getItem(SESSION_LANGUAGE_FILTER_KEY);
-  return stored || DEFAULT_LANGUAGE;
+
+  // Keep "unset" distinct from an explicit language choice.
+  // GuessPath/GuessFeed use this to send "any" (no server filter) while still
+  // rendering the UI sentinel as English until the user picks a filter.
+  return stored || null;
 };
 
 export async function saveSessionLanguageFilter(code) {


### PR DESCRIPTION
This pull request introduces several important regression tests and fixes around language selection, image feed exhaustion, and category asset fallback logic, as well as some minor test and documentation updates. The changes ensure that language filters behave correctly, exhausted image feeds recover properly, and category thumbnails fall back to local assets when needed, especially for private group contexts. There are also improvements to score batching and cleanup of unnecessary permissions.

**Regression fixes and improvements:**

* Language filter logic now falls back to the user's preferred language if the session language is unset, and properly normalizes "any" language to avoid backend filtering bugs. [[1]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfR329-R350) [[2]](diffhunk://#diff-4f42130569d6f0cb3f563f8e196216741a707ae38dd51ce5aab213bd2d2c1445R156-R244) [[3]](diffhunk://#diff-f68763f6ba6809915904395415e4cdc2e538914a2fba7ced56e8ed6032b0b57bL115-R123)
* The exhausted public feed sentinel (`__public_feed_end__`) is no longer persisted or used to short-circuit image fetching, ensuring new uploads appear without requiring app reinstall. [[1]](diffhunk://#diff-ed1c7ef13fec109c2b138d4a25c87ca10f4a40e0c4ce177e6b3eebcba527ad28L239-R255) [[2]](diffhunk://#diff-4f42130569d6f0cb3f563f8e196216741a707ae38dd51ce5aab213bd2d2c1445R156-R244) [[3]](diffhunk://#diff-1b2f0547cf261843d5a06a08c7e2c684bf6861235d45986e27dfdb8ec02b68c3L155-R158)
* Category chips and cards now reliably fall back to local assets when remote thumbnails are missing, with test coverage for private group default categories. [[1]](diffhunk://#diff-3f2ddfa205e012d29aed9064761b16c8546930cacb5b84f5cd2b021002ef6914L23-R26) [[2]](diffhunk://#diff-3f2ddfa205e012d29aed9064761b16c8546930cacb5b84f5cd2b021002ef6914L36-R39) [[3]](diffhunk://#diff-3f2ddfa205e012d29aed9064761b16c8546930cacb5b84f5cd2b021002ef6914R3) [[4]](diffhunk://#diff-3533c00b2b25b3f9210058c10700a2347a4aa0a39623e7bcdfb28643013507c8L3-R3) [[5]](diffhunk://#diff-ca536fe7e8a980b5df51fddd86a4dbc6eff6b94bc2061ce808cdbd4b650bf9c2L84-R107) [[6]](diffhunk://#diff-ddd333f313ddc60dad22cf6c288315cce88ff652366ab18778e514e9c28045c6R87-R101)

**Score batching and payloads:**

* Score batch requests for private groups now include a `streak` field, defaulting to 0 when omitted, and tests expect this field in the payload. [[1]](diffhunk://#diff-e02709bc9291adf431fbc663f73d70de5f0bf6da0eb9785b9564037cb8145396L152-R152) [[2]](diffhunk://#diff-e02709bc9291adf431fbc663f73d70de5f0bf6da0eb9785b9564037cb8145396L162-R162) [[3]](diffhunk://#diff-e02709bc9291adf431fbc663f73d70de5f0bf6da0eb9785b9564037cb8145396L172-R177) [[4]](diffhunk://#diff-e02709bc9291adf431fbc663f73d70de5f0bf6da0eb9785b9564037cb8145396R189-L190)

**Test and documentation updates:**

* Additional mocks and imports for language and group context handling in tests. [[1]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfR55) [[2]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfR96) [[3]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfR163) [[4]](diffhunk://#diff-4f42130569d6f0cb3f563f8e196216741a707ae38dd51ce5aab213bd2d2c1445R2) [[5]](diffhunk://#diff-4f42130569d6f0cb3f563f8e196216741a707ae38dd51ce5aab213bd2d2c1445L16-R20) [[6]](diffhunk://#diff-1b2f0547cf261843d5a06a08c7e2c684bf6861235d45986e27dfdb8ec02b68c3L18) [[7]](diffhunk://#diff-1b2f0547cf261843d5a06a08c7e2c684bf6861235d45986e27dfdb8ec02b68c3L46-R45)
* Testing guidance for public/private group behaviors added to `AGENTS.md`.
* Unused Android permissions removed from `app.json`.