### PR TITLE
Feature/guess flow streak multipliers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@
 - Prefer Jest for unit and mocked integration coverage. Use Maestro for full-device journeys, gesture-heavy flows, or deterministic E2E behavior.
 - Keep source-of-truth runtime rules here; keep one-off proposals in `planning/` instead.
 - Ignore `.expo/`, `node_modules/`, and packaged APK artifacts unless task explicitly targets them.
+- If something is implemented for public or private groups, check that it works in both contexts, unless explicitly stated otherwise. Private groups have their own backend isolation rules and may require extra setup to test.
 
 ## Verification
 

--- a/__tests__/CategoryChips.test.js
+++ b/__tests__/CategoryChips.test.js
@@ -82,8 +82,7 @@ describe('CategoryChips', () => {
   it('renders the null-thumbnail fallback for categories without thumbnails', async () => {
     const renderer = await renderChips({ selected: null });
 
-    expect(renderer.root.findByProps({ testID: 'categories.chip.other.fallback' })).toBeTruthy();
-    expect(renderer.root.findByProps({ testID: 'categories.chip.nature.fallback' })).toBeTruthy();
+    expect(renderer.root.findByProps({ testID: 'categories.chip.recent.fallback' })).toBeTruthy();
   });
 
   it('uses the local asset when a private default category has no remote thumbnail', async () => {
@@ -100,9 +99,11 @@ describe('CategoryChips', () => {
     });
 
     const images = renderer.root.findAllByType('Image');
+    const privateDefaultImage = images.find(
+      (image) => image.props.source === CATEGORY_ASSETS.nature
+    );
 
-    expect(images).toHaveLength(1);
-    expect(images[0].props.source).toBe(CATEGORY_ASSETS.nature);
+    expect(privateDefaultImage).toBeTruthy();
     expect(() => renderer.root.findByProps({ testID: 'categories.chip.966b8efe-887d-44da-b6a6-5eac0791b4ff.fallback' })).toThrow();
   });
 });

--- a/__tests__/CategoryChips.test.js
+++ b/__tests__/CategoryChips.test.js
@@ -13,6 +13,7 @@ import { act, create } from 'react-test-renderer';
 
 import CategoryChips from '../components/UI/CategoryChips';
 import { GlobalStyle } from '../constants/theme';
+import { CATEGORY_ASSETS } from '../utils/categoryAssets';
 
 describe('CategoryChips', () => {
   const categories = [
@@ -83,5 +84,25 @@ describe('CategoryChips', () => {
 
     expect(renderer.root.findByProps({ testID: 'categories.chip.other.fallback' })).toBeTruthy();
     expect(renderer.root.findByProps({ testID: 'categories.chip.nature.fallback' })).toBeTruthy();
+  });
+
+  it('uses the local asset when a private default category has no remote thumbnail', async () => {
+    const renderer = await renderChips({
+      categories: [
+        {
+          id: '966b8efe-887d-44da-b6a6-5eac0791b4ff',
+          key: '966b8efe-887d-44da-b6a6-5eac0791b4ff',
+          name: 'Nature',
+          thumbnailUrl: null,
+        },
+      ],
+      selected: null,
+    });
+
+    const images = renderer.root.findAllByType('Image');
+
+    expect(images).toHaveLength(1);
+    expect(images[0].props.source).toBe(CATEGORY_ASSETS.nature);
+    expect(() => renderer.root.findByProps({ testID: 'categories.chip.966b8efe-887d-44da-b6a6-5eac0791b4ff.fallback' })).toThrow();
   });
 });

--- a/__tests__/EnigmaOverlay.test.js
+++ b/__tests__/EnigmaOverlay.test.js
@@ -117,6 +117,25 @@ describe('EnigmaOverlay', () => {
     expect(renderer.root.findByProps({ testID: 'guess.enigma.text' }).props.children).toBe(DESCRIPTION);
   });
 
+  it('opens when defaultOpen flips from false to true on an existing instance', async () => {
+    const renderer = await renderOverlay({ defaultOpen: false });
+
+    expect(() => renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toThrow();
+
+    await act(async () => {
+      renderer.update(
+        <EnigmaOverlay
+          description={DESCRIPTION}
+          screenHeight={SCREEN_HEIGHT}
+          defaultOpen={true}
+        />
+      );
+    });
+
+    expect(renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toBeTruthy();
+    expect(renderer.root.findByProps({ testID: 'guess.enigma.text' }).props.children).toBe(DESCRIPTION);
+  });
+
   it('opens when the handle sees an up-swipe', async () => {
     const renderer = await renderOverlay();
 

--- a/__tests__/GuessCategoryCard.test.js
+++ b/__tests__/GuessCategoryCard.test.js
@@ -84,6 +84,21 @@ describe('GuessCategoryCard', () => {
     expect(image.props.source).toBe(CATEGORY_ASSETS.nature);
   });
 
+  it('uses the local asset when thumbnailUrl is missing and a private default category name is known', async () => {
+    const renderer = await renderCard({
+      category: {
+        id: '966b8efe-887d-44da-b6a6-5eac0791b4ff',
+        key: '966b8efe-887d-44da-b6a6-5eac0791b4ff',
+        name: 'Nature',
+      },
+      thumbnailUrl: undefined,
+    });
+
+    const image = renderer.root.findByType('ImageBackground');
+
+    expect(image.props.source).toBe(CATEGORY_ASSETS.nature);
+  });
+
   it('prefers an explicit remote thumbnailUrl string over the local asset', async () => {
     const renderer = await renderCard({ thumbnailUrl: 'https://example/x.png' });
 

--- a/__tests__/GuessPathScreen.test.js
+++ b/__tests__/GuessPathScreen.test.js
@@ -44,7 +44,7 @@ jest.mock('../components/UI/IconButton', () => {
 });
 
 jest.mock('../hooks/useGroupsHub', () => ({
-  useGroupsHub: () => mockUseGroupsHub(),
+  useGroupsHub: (...args) => mockUseGroupsHub(...args),
 }));
 
 jest.mock('../utils/categoryRequests', () => ({
@@ -203,6 +203,13 @@ describe('GuessPathScreen', () => {
 
     return renderer;
   }
+
+  it('does not opt into private group loading while rendering the public guess path flow', async () => {
+    await renderScreen();
+
+    expect(mockUseGroupsHub).toHaveBeenCalled();
+    expect(mockUseGroupsHub.mock.calls.every(([options]) => options?.enabled === false)).toBe(true);
+  });
 
   function getCardPropsByKey(key) {
     const call = mockGuessCategoryCard.mock.calls.find(

--- a/__tests__/GuessPathScreen.test.js
+++ b/__tests__/GuessPathScreen.test.js
@@ -52,6 +52,7 @@ jest.mock('../utils/categoryRequests', () => ({
 }));
 
 jest.mock('../utils/storageDatum', () => ({
+  getPreferredLanguage: jest.fn(),
   getSessionLanguageFilter: jest.fn(),
   saveSessionLanguageFilter: jest.fn(),
 }));
@@ -92,6 +93,7 @@ import GuessPathScreen from '../screens/GuessScreens/GuessPathScreen';
 import { AuthContext } from '../store/auth-context';
 import { getCategories } from '../utils/categoryRequests';
 import {
+  getPreferredLanguage,
   getSessionLanguageFilter,
   saveSessionLanguageFilter,
 } from '../utils/storageDatum';
@@ -158,6 +160,7 @@ describe('GuessPathScreen', () => {
     resolveCategoryThumbnail.mockResolvedValue(null);
     deleteCategoryThumbnailFile.mockReturnValue(undefined);
     uploadCategoryThumbnail.mockResolvedValue(null);
+    getPreferredLanguage.mockResolvedValue(null);
     getSessionLanguageFilter.mockResolvedValue(null);
     saveSessionLanguageFilter.mockResolvedValue(undefined);
     mockUseGroupsHub.mockReturnValue({ data: null, refresh: jest.fn() });
@@ -320,6 +323,28 @@ describe('GuessPathScreen', () => {
     expect(navigation.navigate).toHaveBeenCalledWith('GuessFeedScreen', {
       category: expect.objectContaining({ key: 'nature', name: 'Nature' }),
       language: 'any',
+    });
+  });
+
+  it('falls back to the preferred language when the session filter is unset', async () => {
+    getPreferredLanguage.mockResolvedValue('fr');
+
+    const renderer = await renderScreen();
+
+    expect(
+      renderer.root.findByProps({ testID: 'guess-path.filter.language.current' }).props
+        .children
+    ).toBe('fr');
+
+    const natureCard = getCardPropsByKey('nature');
+
+    await act(async () => {
+      natureCard.onPress();
+    });
+
+    expect(navigation.navigate).toHaveBeenCalledWith('GuessFeedScreen', {
+      category: expect.objectContaining({ key: 'nature', name: 'Nature' }),
+      language: 'fr',
     });
   });
 

--- a/__tests__/GuessScreen.test.js
+++ b/__tests__/GuessScreen.test.js
@@ -48,6 +48,22 @@ jest.mock('../utils/e2eMode', () => ({
   isE2EMode: jest.fn(() => false),
 }));
 
+jest.mock('../hooks/useStreak', () => {
+  const actual = jest.requireActual('../hooks/useStreak');
+  const spies = { onWin: jest.fn(), onLose: jest.fn(), reset: jest.fn() };
+  const useStreakMock = jest.fn((initial) => {
+    const result = actual.useStreak(initial);
+    return {
+      ...result,
+      onWin: (...args) => { spies.onWin(...args); return result.onWin(...args); },
+      onLose: (...args) => { spies.onLose(...args); return result.onLose(...args); },
+      reset: (...args) => { spies.reset(...args); return result.reset(...args); },
+    };
+  });
+  useStreakMock.__spies = spies;
+  return { useStreak: useStreakMock };
+});
+
 import React from 'react';
 import { Dimensions } from 'react-native';
 import { act, create } from 'react-test-renderer';
@@ -67,6 +83,11 @@ function lastOverlayProps() {
 
 function lastMenuProps() {
   return mockGuessExitSwipeMenu.mock.calls[mockGuessExitSwipeMenu.mock.calls.length - 1][0];
+}
+
+function streakSpies() {
+  const { useStreak } = require('../hooks/useStreak');
+  return useStreak.__spies;
 }
 
 describe('GuessScreen', () => {
@@ -125,6 +146,8 @@ describe('GuessScreen', () => {
       userId: '',
       points: 2,
       multiplier: 2,
+      streak: 1,
+      streakMultiplier: 1.0,
     });
     expect(navigation.replace).not.toHaveBeenCalledWith('AdScreen', expect.anything());
     expect(navigation.replace).not.toHaveBeenCalledWith('ResultScreen', expect.anything());
@@ -175,6 +198,8 @@ describe('GuessScreen', () => {
       userId: '',
       points: 1,
       multiplier: 1,
+      streak: 1,
+      streakMultiplier: 1.0,
     });
     expect(lastOverlayProps().multiplier).toBe(1);
     expect(lastOverlayProps().points).toBe(1);
@@ -465,5 +490,301 @@ describe('GuessScreen', () => {
 
     expect(lastPictureProps().pulseTarget).toBe(false);
     expect(lastMenuProps().showHints).toBe(false);
+  });
+
+  it('on success: calls streak.onWin and passes streakTier (tier >= 0) to SuccessOverlay', async () => {
+    const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+    const route = {
+      params: {
+        imageFile: 'file:///waldo.jpg',
+        pictureId: 'image-1',
+        description: 'Find Waldo',
+        imageHeight: 1200,
+        imageWidth: 800,
+        isPortrait: true,
+        hiddenLocation: { x: 0.5, y: 0.5 },
+        listId: 3,
+        isTutorial: false,
+        category: { id: 'cat-1', key: 'nature' },
+        language: 'fr',
+      },
+    };
+    isOnTarget.mockReturnValue(true);
+    applySuccessSideEffects.mockResolvedValue(undefined);
+
+    await act(async () => {
+      create(<GuessScreen navigation={navigation} route={route} />);
+    });
+
+    const pictureProps = lastPictureProps();
+    await act(async () => {
+      pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 }, elapsedMs: 1000 });
+    });
+
+    expect(streakSpies().onWin).toHaveBeenCalledTimes(1);
+    expect(streakSpies().onLose).not.toHaveBeenCalled();
+
+    const overlayProps = lastOverlayProps();
+    expect(overlayProps.streakTier).toBeDefined();
+    expect(overlayProps.streakTier.tier).toBeGreaterThanOrEqual(0);
+  });
+
+  it('after 3 consecutive successes, SuccessOverlay streakTier.tier === 1 (Focused)', async () => {
+    const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+    const route = {
+      params: {
+        imageFile: 'file:///waldo.jpg',
+        pictureId: 'image-1',
+        description: 'Find Waldo',
+        imageHeight: 1200,
+        imageWidth: 800,
+        isPortrait: true,
+        hiddenLocation: { x: 0.5, y: 0.5 },
+        listId: 3,
+        isTutorial: false,
+        category: { id: 'cat-1', key: 'nature' },
+        language: 'fr',
+      },
+    };
+    isOnTarget.mockReturnValue(true);
+    applySuccessSideEffects.mockResolvedValue(undefined);
+
+    await act(async () => {
+      create(<GuessScreen navigation={navigation} route={route} />);
+    });
+
+    const pictureProps = lastPictureProps();
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 }, elapsedMs: 1000 });
+      });
+    }
+
+    expect(streakSpies().onWin).toHaveBeenCalledTimes(3);
+
+    const overlayProps = lastOverlayProps();
+    expect(overlayProps.streakTier.tier).toBe(1);
+    expect(overlayProps.streakTier.label).toBe('Focused');
+  });
+
+  it('on failure: calls streak.onLose before navigating to ResultScreen', async () => {
+    const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+    const route = {
+      params: {
+        imageFile: 'file:///waldo.jpg',
+        pictureId: 'image-1',
+        description: 'Find Waldo',
+        imageHeight: 1200,
+        imageWidth: 800,
+        isPortrait: true,
+        hiddenLocation: { x: 0.5, y: 0.5 },
+        listId: 3,
+        isTutorial: false,
+        category: { id: 'cat-1', key: 'nature' },
+        language: 'fr',
+      },
+    };
+    isOnTarget.mockReturnValue(false);
+
+    await act(async () => {
+      create(<GuessScreen navigation={navigation} route={route} />);
+    });
+
+    const pictureProps = lastPictureProps();
+    await act(async () => {
+      pictureProps.toAdScreen({ location: { x: 0.1, y: 0.2 } });
+    });
+
+    expect(streakSpies().onLose).toHaveBeenCalledTimes(1);
+    expect(streakSpies().onWin).not.toHaveBeenCalled();
+    expect(navigation.replace).toHaveBeenCalledWith('ResultScreen', expect.anything());
+  });
+
+  it('after success then failure: streak resets and a fresh mount starts a tier-0 streak', async () => {
+    const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+    const route = {
+      params: {
+        imageFile: 'file:///waldo.jpg',
+        pictureId: 'image-1',
+        description: 'Find Waldo',
+        imageHeight: 1200,
+        imageWidth: 800,
+        isPortrait: true,
+        hiddenLocation: { x: 0.5, y: 0.5 },
+        listId: 3,
+        isTutorial: false,
+        category: { id: 'cat-1', key: 'nature' },
+        language: 'fr',
+      },
+    };
+    isOnTarget.mockReturnValue(true);
+    applySuccessSideEffects.mockResolvedValue(undefined);
+
+    await act(async () => {
+      create(<GuessScreen navigation={navigation} route={route} />);
+    });
+
+    const pictureProps = lastPictureProps();
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 }, elapsedMs: 1000 });
+      });
+    }
+    expect(lastOverlayProps().streakTier.tier).toBe(1);
+
+    isOnTarget.mockReturnValue(false);
+    await act(async () => {
+      pictureProps.toAdScreen({ location: { x: 0.1, y: 0.2 } });
+    });
+    expect(streakSpies().onLose).toHaveBeenCalledTimes(1);
+
+    isOnTarget.mockReturnValue(true);
+    await act(async () => {
+      create(<GuessScreen navigation={navigation} route={route} />);
+    });
+    await act(async () => {
+      lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 }, elapsedMs: 1000 });
+    });
+
+    expect(lastOverlayProps().streakTier.tier).toBe(0);
+  });
+
+  it('final points reflects both multipliers: Math.round(base * speedMul * streakMul)', async () => {
+    const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+    const route = {
+      params: {
+        imageFile: 'file:///waldo.jpg',
+        pictureId: 'image-1',
+        description: 'Find Waldo',
+        imageHeight: 1200,
+        imageWidth: 800,
+        isPortrait: true,
+        hiddenLocation: { x: 0.5, y: 0.5 },
+        listId: 3,
+        isTutorial: false,
+        category: { id: 'cat-1', key: 'nature' },
+        language: 'fr',
+      },
+    };
+    isOnTarget.mockReturnValue(true);
+    applySuccessSideEffects.mockResolvedValue(undefined);
+
+    await act(async () => {
+      create(<GuessScreen navigation={navigation} route={route} />);
+    });
+
+    const pictureProps = lastPictureProps();
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 }, elapsedMs: 1000 });
+      });
+    }
+
+    const overlayProps = lastOverlayProps();
+    expect(overlayProps.multiplier).toBe(2);
+    expect(overlayProps.streakTier.multiplier).toBe(1.5);
+    expect(overlayProps.points).toBe(3);
+  });
+
+  it('regression: 3rd consecutive win buffers post-increment streak=3, streakMultiplier=1.5, points=3 (not stale tier-0 values)', async () => {
+    const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+    const route = {
+      params: {
+        imageFile: 'file:///waldo.jpg',
+        pictureId: 'image-1',
+        description: 'Find Waldo',
+        imageHeight: 1200,
+        imageWidth: 800,
+        isPortrait: true,
+        hiddenLocation: { x: 0.5, y: 0.5 },
+        listId: 3,
+        isTutorial: false,
+        category: { id: 'cat-1', key: 'nature' },
+        language: 'fr',
+      },
+    };
+    isOnTarget.mockReturnValue(true);
+    applySuccessSideEffects.mockResolvedValue(undefined);
+
+    await act(async () => {
+      create(<GuessScreen navigation={navigation} route={route} />);
+    });
+
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 }, elapsedMs: 1000 });
+      });
+    }
+
+    expect(applySuccessSideEffects).toHaveBeenCalledTimes(3);
+    expect(applySuccessSideEffects).toHaveBeenLastCalledWith({
+      listId: 3,
+      categoryKey: 'nature',
+      language: 'fr',
+      imageFile: 'file:///waldo.jpg',
+      pictureId: 'image-1',
+      scope: undefined,
+      userId: '',
+      points: 3,
+      multiplier: 2,
+      streak: 3,
+      streakMultiplier: 1.5,
+    });
+
+    const overlayProps = lastOverlayProps();
+    expect(overlayProps.streakTier.tier).toBe(1);
+    expect(overlayProps.streakTier.multiplier).toBe(1.5);
+    expect(overlayProps.points).toBe(3);
+  });
+
+  it('regression: 7th consecutive win buffers post-increment streak=7, streakMultiplier=2.0, points=4', async () => {
+    const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+    const route = {
+      params: {
+        imageFile: 'file:///waldo.jpg',
+        pictureId: 'image-1',
+        description: 'Find Waldo',
+        imageHeight: 1200,
+        imageWidth: 800,
+        isPortrait: true,
+        hiddenLocation: { x: 0.5, y: 0.5 },
+        listId: 3,
+        isTutorial: false,
+        category: { id: 'cat-1', key: 'nature' },
+        language: 'fr',
+      },
+    };
+    isOnTarget.mockReturnValue(true);
+    applySuccessSideEffects.mockResolvedValue(undefined);
+
+    await act(async () => {
+      create(<GuessScreen navigation={navigation} route={route} />);
+    });
+
+    for (let i = 0; i < 7; i++) {
+      await act(async () => {
+        lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 }, elapsedMs: 1000 });
+      });
+    }
+
+    expect(applySuccessSideEffects).toHaveBeenCalledTimes(7);
+    expect(applySuccessSideEffects).toHaveBeenLastCalledWith({
+      listId: 3,
+      categoryKey: 'nature',
+      language: 'fr',
+      imageFile: 'file:///waldo.jpg',
+      pictureId: 'image-1',
+      scope: undefined,
+      userId: '',
+      points: 4,
+      multiplier: 2,
+      streak: 7,
+      streakMultiplier: 2.0,
+    });
+
+    const overlayProps = lastOverlayProps();
+    expect(overlayProps.streakTier.tier).toBe(2);
+    expect(overlayProps.streakTier.multiplier).toBe(2.0);
+    expect(overlayProps.points).toBe(4);
   });
 });

--- a/__tests__/GuessScreen.test.js
+++ b/__tests__/GuessScreen.test.js
@@ -48,6 +48,11 @@ jest.mock('../utils/e2eMode', () => ({
   isE2EMode: jest.fn(() => false),
 }));
 
+jest.mock('../services/cardPrefetcher', () => ({
+  prefetchIfLow: jest.fn(() => Promise.resolve()),
+  warmAllDeckIfNeeded: jest.fn(() => Promise.resolve()),
+}));
+
 jest.mock('../hooks/useStreak', () => {
   const actual = jest.requireActual('../hooks/useStreak');
   const spies = { onWin: jest.fn(), onLose: jest.fn(), reset: jest.fn() };
@@ -72,6 +77,8 @@ import GuessScreen from '../screens/GuessScreens/GuessScreen';
 import { isOnTarget } from '../utils/targetLocation';
 import { applySuccessSideEffects, resolveNextGuessParams } from '../utils/handleGuessOutcome';
 import { navigateToNextGuess } from '../utils/guessNavigation';
+import { prefetchIfLow } from '../services/cardPrefetcher';
+import { warmAllDeckIfNeeded } from '../services/cardPrefetcher';
 
 function lastPictureProps() {
   return mockGuessPicture.mock.calls[mockGuessPicture.mock.calls.length - 1][0];
@@ -294,6 +301,15 @@ describe('GuessScreen', () => {
     expect(navigation.setParams).toHaveBeenCalledWith(nextParams);
     expect(navigation.replace).not.toHaveBeenCalledWith('GuessScreen', expect.anything());
     expect(navigateToNextGuess).not.toHaveBeenCalled();
+    // Regression (T4): prefetch fired during success path but did not block overlay/setParams.
+    expect(prefetchIfLow).toHaveBeenCalledTimes(1);
+    expect(prefetchIfLow).toHaveBeenCalledWith({
+      categoryKey: 'nature',
+      categoryId: 'cat-1',
+      language: 'fr',
+      scope: undefined,
+      authContext: expect.objectContaining({ userId: '' }),
+    });
   });
 
   it('overlay onDone with null (deck exhausted) falls back to navigateToNextGuess (no setParams)', async () => {
@@ -343,6 +359,9 @@ describe('GuessScreen', () => {
       }
     );
     expect(navigation.setParams).not.toHaveBeenCalled();
+    // Regression (T5): prefetch fired on win but did not interfere with exhaustion fallback.
+    expect(prefetchIfLow).toHaveBeenCalledTimes(1);
+    expect(navigateToNextGuess).toHaveBeenCalledTimes(1);
   });
 
   it('on failure (private scope): navigates to ResultScreen with sharedParams, no side effects, overlay hidden', async () => {
@@ -786,5 +805,308 @@ describe('GuessScreen', () => {
     expect(overlayProps.streakTier.tier).toBe(2);
     expect(overlayProps.streakTier.multiplier).toBe(2.0);
     expect(overlayProps.points).toBe(4);
+  });
+
+  describe('background prefetch on streak win', () => {
+    function baseRoute(overrides = {}) {
+      return {
+        params: {
+          imageFile: 'file:///waldo.jpg',
+          pictureId: 'image-1',
+          description: 'Find Waldo',
+          imageHeight: 1200,
+          imageWidth: 800,
+          isPortrait: true,
+          hiddenLocation: { x: 0.5, y: 0.5 },
+          listId: 3,
+          isTutorial: false,
+          category: { id: 'cat-1', key: 'nature' },
+          language: 'fr',
+          ...overrides,
+        },
+      };
+    }
+
+    it('T1: on success fires prefetchIfLow after applySuccessSideEffects with identity deps', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={baseRoute()} />);
+      });
+
+      const pictureProps = lastPictureProps();
+      await act(async () => {
+        pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 } });
+      });
+
+      expect(applySuccessSideEffects).toHaveBeenCalled();
+      expect(prefetchIfLow).toHaveBeenCalledTimes(1);
+      expect(prefetchIfLow).toHaveBeenCalledWith({
+        categoryKey: 'nature',
+        categoryId: 'cat-1',
+        language: 'fr',
+        scope: undefined,
+        authContext: expect.objectContaining({ userId: '' }),
+      });
+    });
+
+    it('T2: prefetch is fire-and-forget (overlay visible even before prefetch resolves)', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+      // Never-resolving deferred: if awaited, SuccessOverlay would never show.
+      prefetchIfLow.mockReturnValue(new Promise(() => {}));
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={baseRoute()} />);
+      });
+
+      const pictureProps = lastPictureProps();
+      await act(async () => {
+        pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 } });
+      });
+
+      expect(prefetchIfLow).toHaveBeenCalledTimes(1);
+      expect(lastOverlayProps().visible).toBe(true);
+    });
+
+    it('T3: prefetch is a no-op in e2e mode (screen-side guard is internal to prefetcher)', async () => {
+      // Prefetcher guards on isE2EMode internally. Mock the module to mimic that behavior.
+      const { isE2EMode } = require('../utils/e2eMode');
+      isE2EMode.mockReturnValue(true);
+      prefetchIfLow.mockImplementation(() => {
+        // Mirror real prefetcher: e2e mode short-circuits before any work.
+        return Promise.resolve();
+      });
+
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={baseRoute()} />);
+      });
+
+      const pictureProps = lastPictureProps();
+      await act(async () => {
+        pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 } });
+      });
+
+      // Screen still calls prefetchIfLow (it does not duplicate the e2e check);
+      // the prefetcher module owns the no-op behavior.
+      expect(prefetchIfLow).toHaveBeenCalledTimes(1);
+      expect(lastOverlayProps().visible).toBe(true);
+    });
+
+    it('T6: on a miss, prefetchIfLow is never called (no deck mutation)', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+      isOnTarget.mockReturnValue(false);
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={baseRoute()} />);
+      });
+
+      const pictureProps = lastPictureProps();
+      await act(async () => {
+        pictureProps.toAdScreen({ location: { x: 0.1, y: 0.2 } });
+      });
+
+      expect(navigation.replace).toHaveBeenCalledWith('ResultScreen', expect.anything());
+      expect(prefetchIfLow).not.toHaveBeenCalled();
+    });
+
+    it('T6b: categoryKey falls back to "all" when category is null', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={baseRoute({ category: null })} />);
+      });
+
+      const pictureProps = lastPictureProps();
+      await act(async () => {
+        pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 } });
+      });
+
+      expect(prefetchIfLow).toHaveBeenCalledTimes(1);
+      expect(prefetchIfLow).toHaveBeenCalledWith(expect.objectContaining({
+        categoryKey: 'all',
+        categoryId: undefined,
+      }));
+    });
+
+    it('T7: prefetch rejection does not break the success flow (overlay still shows, setParams still fires onDone)', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+      // Lazy: build the rejected promise only when the screen calls the mock,
+      // so the call-site .catch(() => {}) attaches synchronously.
+      prefetchIfLow.mockImplementation(() => Promise.reject(new Error('network down')));
+      const nextParams = {
+        listId: 4,
+        imageFile: 'file:///next.jpg',
+        pictureId: 'image-2',
+        description: 'Next card',
+        hiddenLocation: { x: 0.3, y: 0.7 },
+        category: { id: 'cat-1', key: 'nature' },
+        language: 'fr',
+        isTutorial: false,
+        skipInstructions: true,
+      };
+      resolveNextGuessParams.mockResolvedValue({ params: nextParams });
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={baseRoute()} />);
+      });
+
+      const pictureProps = lastPictureProps();
+      await act(async () => {
+        pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 } });
+      });
+
+      // Overlay still shown despite prefetch rejection (call-site .catch swallows).
+      expect(prefetchIfLow).toHaveBeenCalledTimes(1);
+      expect(lastOverlayProps().visible).toBe(true);
+
+      const overlayProps = lastOverlayProps();
+      await act(async () => {
+        overlayProps.onDone();
+      });
+
+      // Flush the rejected promise's unhandled-rejection microtask.
+      await act(async () => { await Promise.resolve(); });
+
+      expect(navigation.setParams).toHaveBeenCalledWith(nextParams);
+      expect(navigateToNextGuess).not.toHaveBeenCalled();
+    });
+
+    it('T8: mount fires eager warm-all for real category', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={baseRoute()} />);
+      });
+
+      expect(warmAllDeckIfNeeded).toHaveBeenCalledTimes(1);
+      expect(warmAllDeckIfNeeded).toHaveBeenCalledWith(expect.objectContaining({
+        language: 'fr',
+        scope: undefined,
+        authContext: expect.objectContaining({ userId: '' }),
+      }));
+    });
+
+    it('T9: mount does NOT fire warm-all for "all" category', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={baseRoute({ category: { id: 'cat-all', key: 'all' } })} />);
+      });
+
+      expect(warmAllDeckIfNeeded).not.toHaveBeenCalled();
+    });
+
+    it('T10: handleOverlayDone waits for warm-all and retries when deck exhausted in real category', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+      warmAllDeckIfNeeded.mockResolvedValue(undefined);
+
+      const nextParams = {
+        listId: 4,
+        imageFile: 'file:///next.jpg',
+        pictureId: 'image-2',
+        description: 'Next card',
+        hiddenLocation: { x: 0.3, y: 0.7 },
+        category: { id: 'cat-1', key: 'nature' },
+        language: 'fr',
+        isTutorial: false,
+        skipInstructions: true,
+      };
+      resolveNextGuessParams
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ params: nextParams });
+
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={baseRoute()} />);
+      });
+
+      const pictureProps = lastPictureProps();
+      await act(async () => {
+        pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 } });
+      });
+
+      const overlayProps = lastOverlayProps();
+      await act(async () => {
+        overlayProps.onDone();
+      });
+
+      // mount (1) + handleOverlayDone wait (1) = 2
+      expect(warmAllDeckIfNeeded).toHaveBeenCalledTimes(2);
+      expect(resolveNextGuessParams).toHaveBeenCalledTimes(2);
+      expect(navigation.setParams).toHaveBeenCalledWith(nextParams);
+      expect(navigateToNextGuess).not.toHaveBeenCalled();
+    });
+
+    it('T11: handleOverlayDone bounces when deck is truly empty after warm retry', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+      warmAllDeckIfNeeded.mockResolvedValue(undefined);
+
+      resolveNextGuessParams.mockResolvedValue(null);
+      navigateToNextGuess.mockResolvedValue(undefined);
+
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={baseRoute()} />);
+      });
+
+      const pictureProps = lastPictureProps();
+      await act(async () => {
+        pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 } });
+      });
+
+      const overlayProps = lastOverlayProps();
+      await act(async () => {
+        overlayProps.onDone();
+      });
+
+      expect(warmAllDeckIfNeeded).toHaveBeenCalledTimes(2);
+      expect(resolveNextGuessParams).toHaveBeenCalledTimes(2);
+      expect(navigateToNextGuess).toHaveBeenCalledTimes(1);
+      expect(navigation.setParams).not.toHaveBeenCalled();
+    });
+
+    it('T12: handleOverlayDone does NOT warm when category is "all" (immediate bounce)', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+
+      resolveNextGuessParams.mockResolvedValue(null);
+      navigateToNextGuess.mockResolvedValue(undefined);
+
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={baseRoute({ category: { id: 'cat-all', key: 'all' } })} />);
+      });
+
+      const pictureProps = lastPictureProps();
+      await act(async () => {
+        pictureProps.toAdScreen({ location: { x: 0.5, y: 0.5 } });
+      });
+
+      const overlayProps = lastOverlayProps();
+      await act(async () => {
+        overlayProps.onDone();
+      });
+
+      expect(warmAllDeckIfNeeded).not.toHaveBeenCalled();
+      expect(resolveNextGuessParams).toHaveBeenCalledTimes(1);
+      expect(navigateToNextGuess).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/__tests__/RankingScreen.test.js
+++ b/__tests__/RankingScreen.test.js
@@ -132,14 +132,65 @@ describe('RankingScreen', () => {
     expect(getTableProps()).toEqual(
       expect.objectContaining({
         data: {
-          tableHeaders: ['Rank', 'Name', 'Score', 'Others'],
+          tableHeaders: ['Rank', 'Name', 'Score', 'Max Streak', 'Others'],
           tableScores: [
-            { rank: 1, name: 'waldo', score: 25, others: '' },
-            { rank: 2, name: 'odile', score: 14, others: '' },
+            { rank: 1, name: 'waldo', score: 25, maxStreak: 0, others: '' },
+            { rank: 2, name: 'odile', score: 14, maxStreak: 0, others: '' },
           ],
         },
       })
     );
+  });
+
+  it('maps max_streak from the API payload into the row as maxStreak', async () => {
+    getRankingData.mockResolvedValue({
+      status: 200,
+      data: {
+        rows: [{ rank: '1', username: 'waldo', total_score: 25, max_streak: 7 }],
+        nextCursor: null,
+        hasMore: false,
+      },
+    });
+
+    await renderScreen();
+
+    const tableScores = getTableProps().data.tableScores;
+    expect(tableScores[0].maxStreak).toBe(7);
+  });
+
+  it('defaults maxStreak to 0 when the API payload omits max_streak', async () => {
+    getRankingData.mockResolvedValue({
+      status: 200,
+      data: {
+        rows: [{ rank: '1', username: 'waldo', total_score: 25 }],
+        nextCursor: null,
+        hasMore: false,
+      },
+    });
+
+    await renderScreen();
+
+    const tableScores = getTableProps().data.tableScores;
+    expect(tableScores[0].maxStreak).toBe(0);
+  });
+
+  it('exposes a 5-column header slice with Max Streak between Score and Others', async () => {
+    getRankingData.mockResolvedValue({
+      status: 200,
+      data: {
+        rows: [{ rank: '1', username: 'waldo', total_score: 25, max_streak: 3 }],
+        nextCursor: null,
+        hasMore: false,
+      },
+    });
+
+    await renderScreen();
+
+    const headers = getTableProps().data.tableHeaders;
+    expect(headers).toEqual(['Rank', 'Name', 'Score', 'Max Streak', 'Others']);
+    expect(headers).toHaveLength(5);
+    expect(headers.indexOf('Max Streak')).toBe(3);
+    expect(headers.indexOf('Others')).toBe(4);
   });
 
   it('shows the detailed score breakdown when a username is selected from the table', async () => {
@@ -337,9 +388,9 @@ describe('RankingScreen', () => {
 
     const tableScores = getTableProps().data.tableScores;
     expect(tableScores).toEqual([
-      { rank: 1, name: 'waldo', score: 100, others: '', userId: 'u1' },
-      { rank: 2, name: 'odile', score: 80, others: '', userId: 'u2' },
-      { rank: 4, name: 'bob', score: 60, others: '', userId: 'u3' },
+      { rank: 1, name: 'waldo', score: 100, maxStreak: 0, others: '', userId: 'u1' },
+      { rank: 2, name: 'odile', score: 80, maxStreak: 0, others: '', userId: 'u2' },
+      { rank: 4, name: 'bob', score: 60, maxStreak: 0, others: '', userId: 'u3' },
     ]);
   });
 
@@ -379,10 +430,10 @@ describe('RankingScreen', () => {
 
     const tableScores = getTableProps().data.tableScores;
     expect(tableScores).toEqual([
-      { rank: 1, name: 'waldo', score: 100, others: '', userId: 'u1' },
-      { rank: 2, name: 'odile', score: 80, others: '', userId: 'u2' },
-      { rank: 3, name: 'bob', score: 60, others: '', userId: 'u3' },
-      { rank: 4, name: 'eve', score: 40, others: '', userId: 'u4' },
+      { rank: 1, name: 'waldo', score: 100, maxStreak: 0, others: '', userId: 'u1' },
+      { rank: 2, name: 'odile', score: 80, maxStreak: 0, others: '', userId: 'u2' },
+      { rank: 3, name: 'bob', score: 60, maxStreak: 0, others: '', userId: 'u3' },
+      { rank: 4, name: 'eve', score: 40, maxStreak: 0, others: '', userId: 'u4' },
     ]);
   });
 
@@ -419,8 +470,8 @@ describe('RankingScreen', () => {
 
     const tableScores = getTableProps().data.tableScores;
     expect(tableScores).toEqual([
-      { rank: 1, name: 'waldo', score: 100, others: '', userId: 'u1' },
-      { rank: 2, name: 'odile', score: 80, others: '', userId: 'u2' },
+      { rank: 1, name: 'waldo', score: 100, maxStreak: 0, others: '', userId: 'u1' },
+      { rank: 2, name: 'odile', score: 80, maxStreak: 0, others: '', userId: 'u2' },
     ]);
   });
 

--- a/__tests__/SuccessOverlay.test.js
+++ b/__tests__/SuccessOverlay.test.js
@@ -8,6 +8,8 @@ jest.mock('@react-native-vector-icons/ionicons', () => ({
 }));
 
 import SuccessOverlay from '../components/Guess/SuccessOverlay';
+import { GlobalStyle } from '../constants/theme';
+import { resolveStreakTier, NEUTRAL_TIER } from '../constants/streakTiers';
 
 function findByTestID(root, testID) {
   return root.findAll(node => node.props && node.props.testID === testID);
@@ -17,10 +19,28 @@ function findAllTextChildren(root) {
   return root.findAllByType(Text).map(node => node.props.children);
 }
 
+// Animated.View with a testID appears as 3 nodes (Animated wrapper + 2 internal Views).
+// Count distinct animated elements by collapsing the triplet.
+function countAnimated(root, testID) {
+  return Math.floor(findByTestID(root, testID).length / 3);
+}
+
+function render(props) {
+  return create(<SuccessOverlay visible={true} onDone={jest.fn()} {...props} />);
+}
+
+function pillTextStyle(root) {
+  const matches = findByTestID(root, 'guess.success.streak.pill');
+  const pill = matches[0];
+  const text = pill.findAllByType(Text)[0];
+  return text.props.style;
+}
+
 describe('SuccessOverlay', () => {
   let renderer;
   afterEach(() => {
     if (renderer) act(() => { renderer.unmount(); });
+    renderer = null;
   });
 
   it('renders the +1 label and no speed burst when multiplier is 1 (default)', () => {
@@ -85,5 +105,100 @@ describe('SuccessOverlay', () => {
       renderer = create(<SuccessOverlay visible={false} onDone={jest.fn()} multiplier={2} />);
     });
     expect(renderer.toJSON()).toBeNull();
+  });
+
+  it('renders no streak pill when streakTier is the neutral default (tier 0)', () => {
+    act(() => {
+      renderer = render({ multiplier: 1, points: 1, streakTier: NEUTRAL_TIER });
+    });
+    expect(findByTestID(renderer.root, 'guess.success.streak.pill')).toHaveLength(0);
+    expect(findByTestID(renderer.root, 'guess.success.streak.ring')).toHaveLength(0);
+  });
+
+  it('renders no streak pill when streakTier prop is omitted (back-compat)', () => {
+    act(() => {
+      renderer = create(<SuccessOverlay visible={true} onDone={jest.fn()} multiplier={1} points={1} />);
+    });
+    expect(findByTestID(renderer.root, 'guess.success.streak.pill')).toHaveLength(0);
+  });
+
+  it('renders the streak pill with the Focused label and blue flame color at tier 1', () => {
+    const tier = resolveStreakTier(3);
+    expect(tier.tier).toBe(1);
+    act(() => {
+      renderer = render({ multiplier: 1, points: 1, streakTier: tier });
+    });
+    expect(countAnimated(renderer.root, 'guess.success.streak.pill')).toBe(1);
+    expect(countAnimated(renderer.root, 'guess.success.streak.ring')).toBe(0);
+    const texts = findAllTextChildren(renderer.root);
+    expect(texts.some(t => typeof t === 'string' && t.includes('Focused'))).toBe(true);
+    expect(pillTextStyle(renderer.root)).toEqual(
+      expect.arrayContaining([{ color: GlobalStyle.color.streak.blue }])
+    );
+  });
+
+  it('renders pill + 2 glow rings with orange flame color at tier 2', () => {
+    const tier = resolveStreakTier(7);
+    expect(tier.tier).toBe(2);
+    act(() => {
+      renderer = render({ multiplier: 1, points: 1, streakTier: tier });
+    });
+    expect(countAnimated(renderer.root, 'guess.success.streak.pill')).toBe(1);
+    expect(countAnimated(renderer.root, 'guess.success.streak.ring')).toBe(2);
+    expect(pillTextStyle(renderer.root)).toEqual(
+      expect.arrayContaining([{ color: GlobalStyle.color.streak.orange }])
+    );
+  });
+
+  it('renders pill + 2 glow rings with red flame color at tier 3 (v1 fallback)', () => {
+    const tier = resolveStreakTier(12);
+    expect(tier.tier).toBe(3);
+    act(() => {
+      renderer = render({ multiplier: 1, points: 1, streakTier: tier });
+    });
+    expect(countAnimated(renderer.root, 'guess.success.streak.pill')).toBe(1);
+    expect(countAnimated(renderer.root, 'guess.success.streak.ring')).toBe(2);
+    expect(pillTextStyle(renderer.root)).toEqual(
+      expect.arrayContaining([{ color: GlobalStyle.color.streak.red }])
+    );
+  });
+
+  it('renders pill with purple flame color at tier 4', () => {
+    const tier = resolveStreakTier(20);
+    expect(tier.tier).toBe(4);
+    act(() => {
+      renderer = render({ multiplier: 1, points: 1, streakTier: tier });
+    });
+    expect(countAnimated(renderer.root, 'guess.success.streak.pill')).toBe(1);
+    expect(pillTextStyle(renderer.root)).toEqual(
+      expect.arrayContaining([{ color: GlobalStyle.color.streak.purple }])
+    );
+  });
+
+  it('renders pill with white flame color at tier 5', () => {
+    const tier = resolveStreakTier(50);
+    expect(tier.tier).toBe(5);
+    act(() => {
+      renderer = render({ multiplier: 1, points: 1, streakTier: tier });
+    });
+    expect(countAnimated(renderer.root, 'guess.success.streak.pill')).toBe(1);
+    expect(pillTextStyle(renderer.root)).toEqual(
+      expect.arrayContaining([{ color: GlobalStyle.color.streak.white }])
+    );
+  });
+
+  it('renders the speed ×N pill independently of the streak tier', () => {
+    const tier = resolveStreakTier(7);
+    act(() => {
+      renderer = render({ multiplier: 3, points: 5, streakTier: tier });
+    });
+    expect(findByTestID(renderer.root, 'guess.success.speed-badge').length).toBeGreaterThan(0);
+    const texts = findAllTextChildren(renderer.root);
+    expect(texts).toContain('×3');
+    expect(countAnimated(renderer.root, 'guess.success.streak.pill')).toBe(1);
+  });
+
+  it('exposes the neutral tier as NEUTRAL_TIER constant for callers', () => {
+    expect(NEUTRAL_TIER.tier).toBe(0);
   });
 });

--- a/__tests__/SwipeImage.test.js
+++ b/__tests__/SwipeImage.test.js
@@ -49,6 +49,7 @@ jest.mock('../utils/ratingRequests', () => ({
 }));
 
 jest.mock('../utils/storageDatum', () => ({
+  PUBLIC_FEED_END_CURSOR: '__public_feed_end__',
   getE2EHiddenGuessCard: jest.fn(),
   getLocalImages: jest.fn(),
   storeImageList: jest.fn(),
@@ -102,6 +103,7 @@ import {
   getLastImageId,
   getLastImageUuid,
   getLocalImages,
+  PUBLIC_FEED_END_CURSOR,
   removeImageFromList,
   storeImageList,
   updateImageList,
@@ -232,6 +234,23 @@ describe('SwipeImage', () => {
     expect(storeImageList).toHaveBeenCalledWith([
       expect.objectContaining({ pictureId: 'img-1', listId: 1 }),
     ], 'all', 'any');
+  });
+
+  it('does not restart the synthetic all feed from head when the public exhausted sentinel is stored', async () => {
+    getLocalImages.mockResolvedValue(null);
+    getLastImageUuid.mockResolvedValue(PUBLIC_FEED_END_CURSOR);
+
+    const { renderer } = await renderSwipeImage();
+
+    expect(getImages).not.toHaveBeenCalled();
+
+    const renderedText = renderer.root
+      .findAll((node) => node.type === 'Text')
+      .map((node) => node.props.children)
+      .flat()
+      .join(' ');
+
+    expect(renderedText).toContain('No more images to guess right now!');
   });
 
   it('normalizes the synthetic all card so category_id stays undefined while category_key is threaded', async () => {

--- a/__tests__/SwipeImage.test.js
+++ b/__tests__/SwipeImage.test.js
@@ -81,6 +81,11 @@ jest.mock('../utils/e2eMode', () => ({
   isE2EMode: jest.fn(),
 }));
 
+jest.mock('../services/cardPrefetcher', () => ({
+  prefetchIfLow: jest.fn(() => Promise.resolve()),
+  warmAllDeckIfNeeded: jest.fn(() => Promise.resolve()),
+}));
+
 import React from 'react';
 import { Alert, StyleSheet } from 'react-native';
 import { act, create } from 'react-test-renderer';
@@ -101,6 +106,8 @@ import {
   storeImageList,
   updateImageList,
 } from '../utils/storageDatum';
+import { prefetchIfLow, warmAllDeckIfNeeded } from '../services/cardPrefetcher';
+import { readGroupFeedCache } from '../services/groups/groupFeedCache';
 
 describe('SwipeImage', () => {
   const contextValue = {
@@ -289,7 +296,7 @@ describe('SwipeImage', () => {
     expect(Alert.alert).toHaveBeenCalledWith('Server error', 'Please retry later');
   });
 
-  it('deletes a dismissed card and fetches more images when the stack drops below four', async () => {
+  it('deletes a dismissed card at deck 4→3 without firing a foreground load (background prefetch owns refill)', async () => {
     getLocalImages.mockResolvedValue([
       { listId: 1, imageFile: 'file:///1.jpg' },
       { listId: 2, imageFile: 'file:///2.jpg' },
@@ -321,13 +328,12 @@ describe('SwipeImage', () => {
 
     expect(removeImageFromList).toHaveBeenCalledWith(1, 'all', 'any');
     expect(deleteImageFromStorage).toHaveBeenCalledWith('file:///1.jpg');
-    expect(getImages).toHaveBeenCalledWith('image-4', contextValue, { category_id: undefined, category_key: 'all', language: undefined });
-    expect(updateImageList).toHaveBeenCalledWith([
-      expect.objectContaining({ pictureId: 'img-5', listId: 5 }),
-    ], 'all', 'any');
+    // No foreground load at deck 3 (only background prefetch is in flight).
+    expect(getImages).not.toHaveBeenCalled();
+    expect(updateImageList).not.toHaveBeenCalled();
   });
 
-  it('silently prefetches the all deck when the stack drops below four', async () => {
+  it('delegates the warm-all prefetch to prefetchIfLow at deck 4→3 without a foreground load', async () => {
     getLocalImages.mockResolvedValue([
       { listId: 1, imageFile: 'file:///1.jpg' },
       { listId: 2, imageFile: 'file:///2.jpg' },
@@ -347,19 +353,22 @@ describe('SwipeImage', () => {
       await flushEffects();
     });
 
-    expect(getImages).toHaveBeenCalledWith(
-      null,
-      contextValue,
-      expect.objectContaining({ category_key: 'nature', category_id: 'cat-nature' }),
+    // No foreground load at deck 3 (refillOrFallback only fires at deck 0).
+    expect(getImages).not.toHaveBeenCalled();
+    expect(prefetchIfLow).toHaveBeenCalledWith({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: undefined,
+      scope: undefined,
+      authContext: contextValue,
+    });
+    const allPrefetchCalls = getImages.mock.calls.filter(
+      ([, , params]) => params?.category_key === 'all' && params?.category_id === undefined,
     );
-    expect(getImages).toHaveBeenCalledWith(
-      null,
-      contextValue,
-      expect.objectContaining({ category_key: 'all', category_id: undefined }),
-    );
+    expect(allPrefetchCalls).toHaveLength(0);
   });
 
-  it('deduplicates the all-deck prefetch via allDeckWarmedRef on a second removal', async () => {
+  it('calls prefetchIfLow on every removal (dedup is the prefetcher job, not the component)', async () => {
     getLocalImages.mockResolvedValue([
       { listId: 1, imageFile: 'file:///1.jpg' },
       { listId: 2, imageFile: 'file:///2.jpg' },
@@ -384,13 +393,14 @@ describe('SwipeImage', () => {
       await flushEffects();
     });
 
+    expect(prefetchIfLow).toHaveBeenCalledTimes(2);
     const allPrefetchCalls = getImages.mock.calls.filter(
       ([, , params]) => params?.category_key === 'all' && params?.category_id === undefined,
     );
-    expect(allPrefetchCalls).toHaveLength(1);
+    expect(allPrefetchCalls).toHaveLength(0);
   });
 
-  it('swallows all-deck prefetch errors without surfacing an Alert', async () => {
+  it('swallows prefetchIfLow rejections without surfacing an Alert (prefetcher owns error handling)', async () => {
     getLocalImages.mockResolvedValue([
       { listId: 1, imageFile: 'file:///1.jpg' },
       { listId: 2, imageFile: 'file:///2.jpg' },
@@ -398,12 +408,8 @@ describe('SwipeImage', () => {
       { listId: 4, imageFile: 'file:///4.jpg' },
     ]);
     getLastImageId.mockResolvedValue(4);
-    getImages.mockImplementation((pictureId, authContext, params) => {
-      if (params?.category_key === 'all') {
-        return Promise.reject(new Error('all-deck warmup failed'));
-      }
-      return Promise.resolve({ isError: false, images: [] });
-    });
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    prefetchIfLow.mockRejectedValueOnce(new Error('prefetcher failed'));
 
     await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
 
@@ -415,15 +421,11 @@ describe('SwipeImage', () => {
       await flushEffects();
     });
 
-    expect(getImages).toHaveBeenCalledWith(
-      null,
-      contextValue,
-      expect.objectContaining({ category_key: 'all', category_id: undefined }),
-    );
+    expect(prefetchIfLow).toHaveBeenCalled();
     expect(Alert.alert).not.toHaveBeenCalled();
   });
 
-  it('skips the all-deck prefetch entirely in e2e mode', async () => {
+  it('still delegates to prefetchIfLow in e2e mode (prefetcher owns the e2e short-circuit)', async () => {
     isE2EMode.mockReturnValue(true);
 
     await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
@@ -436,6 +438,7 @@ describe('SwipeImage', () => {
       await flushEffects();
     });
 
+    expect(prefetchIfLow).toHaveBeenCalled();
     const allPrefetchCalls = getImages.mock.calls.filter(
       ([, , params]) => params?.category_key === 'all' && params?.category_id === undefined,
     );
@@ -596,5 +599,516 @@ describe('SwipeImage', () => {
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
+  });
+});
+
+describe('SwipeImage — cardPrefetcher integration', () => {
+  const contextValue = {
+    token: 'token',
+    uid: 'waldo@example.com',
+    expiry: '123',
+    access_token: 'access-token',
+    client: 'client-id',
+    userId: '42',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isE2EMode.mockReturnValue(false);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    getImageTags.mockResolvedValue({ data: [] });
+    getImageRating.mockResolvedValue({ data: undefined });
+    getE2EHiddenGuessCard.mockResolvedValue(null);
+    buildE2EGuessCardFromPayload.mockImplementation((payload) => (
+      payload ? { listId: 1, pictureId: payload.pictureId, imageFile: payload.uri } : null
+    ));
+    buildE2EGuessCards.mockReturnValue([{ listId: 1, pictureId: 'e2e-guess-card', imageFile: 'file:///e2e.jpg' }]);
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    getLastImageId.mockResolvedValue(0);
+    getLastImageUuid.mockResolvedValue(null);
+    updateImageList.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function renderSwipeImage(startGuessing = jest.fn(), { category, language, scope } = {}) {
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <AuthContext.Provider value={contextValue}>
+          <SwipeImage
+            screenWidth={320}
+            screenHeight={640}
+            startGuessing={startGuessing}
+            category={category}
+            language={language}
+            scope={scope}
+          />
+        </AuthContext.Provider>,
+      );
+
+      await flushEffects();
+    });
+
+    return { renderer, startGuessing };
+  }
+
+  it('calls prefetchIfLow with the active category, language, scope, and authContext after a card is removed', async () => {
+    const scope = { kind: 'private', groupId: 'group-7' };
+    readGroupFeedCache.mockResolvedValue({
+      images: [
+        { listId: 1, imageFile: 'file:///1.jpg' },
+        { listId: 2, imageFile: 'file:///2.jpg' },
+        { listId: 3, imageFile: 'file:///3.jpg' },
+        { listId: 4, imageFile: 'file:///4.jpg' },
+      ],
+    });
+    getLastImageId.mockResolvedValue(4);
+
+    await renderSwipeImage(jest.fn(), {
+      category: { id: 'cat-nature', key: 'nature' },
+      language: 'fr',
+      scope,
+    });
+
+    const removableCard = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+    mockSwipeableCard.mockClear();
+
+    await act(async () => {
+      await removableCard.removeCard(1);
+      await flushEffects();
+    });
+
+    expect(prefetchIfLow).toHaveBeenCalledWith({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      scope,
+      authContext: contextValue,
+    });
+  });
+
+  it('calls prefetchIfLow at most once per removeCard (component does not pre-dedupe)', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, imageFile: 'file:///1.jpg' },
+      { listId: 2, imageFile: 'file:///2.jpg' },
+      { listId: 3, imageFile: 'file:///3.jpg' },
+      { listId: 4, imageFile: 'file:///4.jpg' },
+    ]);
+    getLastImageId.mockResolvedValue(4);
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const removableCard = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+    mockSwipeableCard.mockClear();
+
+    await act(async () => {
+      await removableCard.removeCard(1);
+      await flushEffects();
+    });
+
+    expect(prefetchIfLow).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call fetchCardBatch with categoryKey "all" from removeCard anymore (warm-all is the prefetcher job)', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, imageFile: 'file:///1.jpg' },
+      { listId: 2, imageFile: 'file:///2.jpg' },
+      { listId: 3, imageFile: 'file:///3.jpg' },
+      { listId: 4, imageFile: 'file:///4.jpg' },
+    ]);
+    getLastImageId.mockResolvedValue(4);
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const removableCard = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+    mockSwipeableCard.mockClear();
+
+    await act(async () => {
+      await removableCard.removeCard(1);
+      await flushEffects();
+    });
+
+    const allPrefetchCalls = getImages.mock.calls.filter(
+      ([, , params]) => params?.category_key === 'all' && params?.category_id === undefined,
+    );
+    expect(allPrefetchCalls).toHaveLength(0);
+    expect(prefetchIfLow).toHaveBeenCalled();
+  });
+});
+
+describe('SwipeImage — deck-empty fallback to "all"', () => {
+  const contextValue = {
+    token: 'token',
+    uid: 'waldo@example.com',
+    expiry: '123',
+    access_token: 'access-token',
+    client: 'client-id',
+    userId: '42',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isE2EMode.mockReturnValue(false);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    getImageTags.mockResolvedValue({ data: [] });
+    getImageRating.mockResolvedValue({ data: undefined });
+    getE2EHiddenGuessCard.mockResolvedValue(null);
+    buildE2EGuessCardFromPayload.mockImplementation((payload) => (
+      payload ? { listId: 1, pictureId: payload.pictureId, imageFile: payload.uri } : null
+    ));
+    buildE2EGuessCards.mockReturnValue([{ listId: 1, pictureId: 'e2e-guess-card', imageFile: 'file:///e2e.jpg' }]);
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    getLastImageId.mockResolvedValue(0);
+    getLastImageUuid.mockResolvedValue(null);
+    updateImageList.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function renderSwipeImage(startGuessing = jest.fn(), { category, language, scope } = {}) {
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <AuthContext.Provider value={contextValue}>
+          <SwipeImage
+            screenWidth={320}
+            screenHeight={640}
+            startGuessing={startGuessing}
+            category={category}
+            language={language}
+            scope={scope}
+          />
+        </AuthContext.Provider>,
+      );
+
+      await flushEffects();
+    });
+
+    return { renderer, startGuessing };
+  }
+
+  it('falls back to the warmed "all" deck from AsyncStorage when removeCard empties a real category deck (no foreground load)', async () => {
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    const allCard = { listId: 1, pictureId: 'all-1', imageFile: 'file:///a1.jpg' };
+
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        natureCallCount += 1;
+        return Promise.resolve(natureCallCount === 1 ? natureCards : []);
+      }
+      if (key === 'all') {
+        return Promise.resolve([allCard]);
+      }
+      return Promise.resolve(null);
+    });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    expect(getImages).not.toHaveBeenCalled();
+
+    const cardPropsById = {};
+    for (const listId of [1, 2, 3, 4]) {
+      cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+    }
+
+    for (const listId of [1, 2, 3, 4]) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        await cardPropsById[listId].removeCard(listId);
+        await flushEffects();
+      });
+    }
+
+    expect(getImages).not.toHaveBeenCalled();
+    expect(warmAllDeckIfNeeded).toHaveBeenCalledWith(expect.objectContaining({ language: undefined, scope: undefined }));
+    const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+    expect(renderedPictureIds).toContain('all-1');
+  });
+
+  it('uses the category prefetch result before warming or foreground-loading when the last card is removed', async () => {
+    const prefetchedNatureCard = { listId: 5, pictureId: 'nat-5', imageFile: 'file:///n5.jpg' };
+    let natureDeck = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    let allDeck = [];
+
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        return Promise.resolve([...natureDeck]);
+      }
+      if (key === 'all') {
+        return Promise.resolve([...allDeck]);
+      }
+      return Promise.resolve(null);
+    });
+    removeImageFromList.mockImplementation(async (listId, key) => {
+      if (key === 'nature') {
+        natureDeck = natureDeck.filter((item) => item.listId !== listId);
+      }
+      if (key === 'all') {
+        allDeck = allDeck.filter((item) => item.listId !== listId);
+      }
+      return null;
+    });
+    prefetchIfLow.mockImplementation(({ categoryKey }) => {
+      if (categoryKey === 'nature' && natureDeck.length === 0) {
+        natureDeck = [prefetchedNatureCard];
+      }
+      return Promise.resolve();
+    });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const cardPropsById = {};
+    for (const listId of [1, 2, 3, 4]) {
+      cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+    }
+
+    getImages.mockClear();
+    warmAllDeckIfNeeded.mockClear();
+
+    for (const listId of [1, 2, 3, 4]) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        await cardPropsById[listId].removeCard(listId);
+        await flushEffects();
+      });
+    }
+
+    expect(getImages).not.toHaveBeenCalled();
+    expect(warmAllDeckIfNeeded).not.toHaveBeenCalled();
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).toContain('nat-5');
+  });
+
+  it('fires a last-resort foreground load when both the active category deck and "all" are empty on removeCard', async () => {
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        natureCallCount += 1;
+        return Promise.resolve(natureCallCount === 1 ? natureCards : []);
+      }
+      return Promise.resolve(null);
+    });
+    getLastImageId.mockResolvedValue(4);
+    getImages.mockResolvedValue({ isError: false, images: [{ pictureId: 'fresh-1', imageFile: 'file:///f1.jpg' }] });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const cardPropsById = {};
+    for (const listId of [1, 2, 3, 4]) {
+      cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+    }
+
+    for (const listId of [1, 2, 3, 4]) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        await cardPropsById[listId].removeCard(listId);
+        await flushEffects();
+      });
+    }
+
+    expect(getImages).toHaveBeenCalled();
+    const natureForegroundCalls = getImages.mock.calls.filter(
+      ([, , params]) => params?.category_key === 'nature',
+    );
+    expect(natureForegroundCalls.length).toBeGreaterThan(0);
+  });
+
+  it('does not fire a foreground load when removeCard drops the deck from 4→3 (low but not empty)', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ]);
+    getLastImageId.mockResolvedValue(4);
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const first = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+    getImages.mockClear();
+
+    await act(async () => {
+      await first.removeCard(1);
+      await flushEffects();
+    });
+
+    expect(getImages).not.toHaveBeenCalled();
+    expect(prefetchIfLow).toHaveBeenCalled();
+  });
+
+  it('on mount, switches to the "all" deck without a foreground load when the category deck is empty but "all" has cards', async () => {
+    const allCard = { listId: 1, pictureId: 'all-1', imageFile: 'file:///a1.jpg' };
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') return Promise.resolve([]);
+      if (key === 'all') return Promise.resolve([allCard]);
+      return Promise.resolve(null);
+    });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    expect(getImages).not.toHaveBeenCalled();
+    expect(warmAllDeckIfNeeded).toHaveBeenCalled();
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).toContain('all-1');
+  });
+
+  it('on mount, fires the foreground cold-start load when the category deck AND "all" are both empty', async () => {
+    getLocalImages.mockResolvedValue(null);
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [{ pictureId: 'fresh-1', imageFile: 'file:///f1.jpg' }],
+    });
+    getLastImageId.mockResolvedValue(0);
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    expect(getImages).toHaveBeenCalled();
+  });
+
+  it('after falling back to "all", a subsequent removeCard removes from the "all" AsyncStorage key', async () => {
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    const allCard = { listId: 1, pictureId: 'all-1', imageFile: 'file:///a1.jpg' };
+
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        natureCallCount += 1;
+        return Promise.resolve(natureCallCount === 1 ? natureCards : []);
+      }
+      if (key === 'all') return Promise.resolve([allCard]);
+      return Promise.resolve(null);
+    });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const cardPropsById = {};
+    for (const listId of [1, 2, 3, 4]) {
+      cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+    }
+
+    for (const listId of [1, 2, 3, 4]) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        await cardPropsById[listId].removeCard(listId);
+        await flushEffects();
+      });
+    }
+
+    removeImageFromList.mockClear();
+
+    const allRemovable = mockSwipeableCard.mock.calls.find(([props]) => props.item.pictureId === 'all-1')[0];
+    await act(async () => {
+      await allRemovable.removeCard(allCard.listId);
+      await flushEffects();
+    });
+
+    expect(removeImageFromList).toHaveBeenCalledWith(allCard.listId, 'all', 'any');
+  });
+
+  it('private scope: fallback reads the groupFeedCache for "all" (categoryId undefined) when the group nature deck empties', async () => {
+    const scope = { kind: 'private', groupId: 'group-7' };
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    const allCard = { listId: 1, pictureId: 'all-1', imageFile: 'file:///a1.jpg' };
+
+    let natureCallCount = 0;
+    readGroupFeedCache.mockImplementation((groupId, { categoryId } = {}) => {
+      if (groupId !== 'group-7') return Promise.resolve(null);
+      if (categoryId === 'cat-nature') {
+        natureCallCount += 1;
+        return Promise.resolve({ images: natureCallCount === 1 ? natureCards : [], nextCursor: null });
+      }
+      if (categoryId === undefined) {
+        return Promise.resolve({ images: [allCard], nextCursor: null });
+      }
+      return Promise.resolve(null);
+    });
+
+    await renderSwipeImage(jest.fn(), {
+      category: { id: 'cat-nature', key: 'nature' },
+      language: 'fr',
+      scope,
+    });
+
+    expect(getImages).not.toHaveBeenCalled();
+
+    const cardPropsById = {};
+    for (const listId of [1, 2, 3, 4]) {
+      cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+    }
+
+    for (const listId of [1, 2, 3, 4]) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        await cardPropsById[listId].removeCard(listId);
+        await flushEffects();
+      });
+    }
+
+    expect(getImages).not.toHaveBeenCalled();
+    const allCacheReads = readGroupFeedCache.mock.calls.filter(
+      ([, params]) => params?.categoryId === undefined,
+    );
+    expect(allCacheReads.length).toBeGreaterThan(0);
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).toContain('all-1');
+  });
+
+  it('e2e mode: deck-empty fallback runs without crashing (warm/prefetch are no-ops; storage reads return null)', async () => {
+    isE2EMode.mockReturnValue(true);
+    getLocalImages.mockResolvedValue(null);
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const removable = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+
+    await act(async () => {
+      await removable.removeCard(1);
+      await flushEffects();
+    });
+
+    expect(prefetchIfLow).toHaveBeenCalled();
   });
 });

--- a/__tests__/SwipeImage.test.js
+++ b/__tests__/SwipeImage.test.js
@@ -236,21 +236,23 @@ describe('SwipeImage', () => {
     ], 'all', 'any');
   });
 
-  it('does not restart the synthetic all feed from head when the public exhausted sentinel is stored', async () => {
+  it('re-queries the server on cold mount when the exhausted sentinel is stored so new uploads surface', async () => {
+    // Regression: a stored PUBLIC_FEED_END_CURSOR used to short-circuit the
+    // cold-mount load, so once a category ever returned empty it never queried
+    // the server again — newly uploaded cards stayed invisible until reinstall.
     getLocalImages.mockResolvedValue(null);
     getLastImageUuid.mockResolvedValue(PUBLIC_FEED_END_CURSOR);
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [
+        { pictureId: 'fresh-after-exhaust', imageFile: 'file:///fresh.jpg' },
+      ],
+    });
 
-    const { renderer } = await renderSwipeImage();
+    await renderSwipeImage();
 
-    expect(getImages).not.toHaveBeenCalled();
-
-    const renderedText = renderer.root
-      .findAll((node) => node.type === 'Text')
-      .map((node) => node.props.children)
-      .flat()
-      .join(' ');
-
-    expect(renderedText).toContain('No more images to guess right now!');
+    expect(getImages).toHaveBeenCalledWith(null, contextValue, expect.objectContaining({}));
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).toContain('fresh-after-exhaust');
   });
 
   it('normalizes the synthetic all card so category_id stays undefined while category_key is threaded', async () => {

--- a/__tests__/SwipeImage.test.js
+++ b/__tests__/SwipeImage.test.js
@@ -990,19 +990,28 @@ describe('SwipeImage — deck-empty fallback to "all"', () => {
     expect(prefetchIfLow).toHaveBeenCalled();
   });
 
-  it('on mount, switches to the "all" deck without a foreground load when the category deck is empty but "all" has cards', async () => {
+  it('on mount, cold-starts the active category foreground load when the category deck is empty (no switch to "all")', async () => {
     const allCard = { listId: 1, pictureId: 'all-1', imageFile: 'file:///a1.jpg' };
     getLocalImages.mockImplementation((key) => {
       if (key === 'nature') return Promise.resolve([]);
       if (key === 'all') return Promise.resolve([allCard]);
       return Promise.resolve(null);
     });
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [{ pictureId: 'nat-fresh', imageFile: 'file:///nf.jpg' }],
+    });
 
     await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
 
-    expect(getImages).not.toHaveBeenCalled();
-    expect(warmAllDeckIfNeeded).toHaveBeenCalled();
-    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).toContain('all-1');
+    // No cross-category 'recent/all' fallback on mount — that refill only fires mid-play.
+    expect(warmAllDeckIfNeeded).not.toHaveBeenCalled();
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      expect.anything(),
+      expect.objectContaining({ category_key: 'nature', category_id: 'cat-nature' }),
+    );
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).not.toContain('all-1');
   });
 
   it('on mount, fires the foreground cold-start load when the category deck AND "all" are both empty', async () => {

--- a/__tests__/TableComponent.test.js
+++ b/__tests__/TableComponent.test.js
@@ -16,11 +16,19 @@ describe('TableComponent', () => {
     ],
   };
 
-  async function renderTable() {
+  const dataFiveCol = {
+    tableHeaders: ['Rank', 'Name', 'Score', 'Max Streak', 'Others'],
+    tableScores: [
+      { rank: 1, name: 'waldo', score: 25, maxStreak: 7, others: '' },
+      { rank: 2, name: 'odile', score: 14, maxStreak: 3, others: '' },
+    ],
+  };
+
+  async function renderTable(dataOverride) {
     let renderer;
 
     await act(async () => {
-      renderer = create(<TableComponent data={data} onPress={jest.fn()} />);
+      renderer = create(<TableComponent data={dataOverride ?? data} onPress={jest.fn()} />);
     });
 
     return renderer;
@@ -96,5 +104,40 @@ describe('TableComponent', () => {
     const container = renderer.root.findByProps({ testID: 'ranking.table' });
 
     expect(StyleSheet.flatten(container.props.style).backgroundColor).toBe(expectedTheme.screen);
+  });
+
+  it('renders one header cell per provided column', async () => {
+    const renderer = await renderTable();
+    const headerLabels = ['Rank', 'Name', 'Score', 'Others'];
+
+    headerLabels.forEach((label, index) => {
+      const headerCell = renderer.root.findByProps({ testID: `ranking.header.${index}` });
+      expect(headerCell.props.children).toBe(label);
+    });
+  });
+
+  describe('with five columns including Max Streak', () => {
+    it('renders the Max Streak header in the fourth position', async () => {
+      const renderer = await renderTable(dataFiveCol);
+      const maxStreakHeader = renderer.root.findByProps({ testID: 'ranking.header.3' });
+
+      expect(maxStreakHeader.props.children).toBe('Max Streak');
+    });
+
+    it('renders five cells per row including the maxStreak value and the Others button', async () => {
+      const renderer = await renderTable(dataFiveCol);
+
+      const rank = renderer.root.findByProps({ testID: 'ranking.row.1.rank' });
+      const name = renderer.root.findByProps({ testID: 'ranking.row.1.name' });
+      const score = renderer.root.findByProps({ testID: 'ranking.row.1.score' });
+      const maxStreak = renderer.root.findByProps({ testID: 'ranking.row.1.maxStreak' });
+      const more = renderer.root.findByProps({ testID: 'ranking.row.1.more' });
+
+      expect(rank.props.children).toBe(1);
+      expect(name.props.children).toBe('waldo');
+      expect(score.props.children).toBe(25);
+      expect(maxStreak.props.children).toBe(7);
+      expect(more).toBeDefined();
+    });
   });
 });

--- a/__tests__/cardDeck.test.js
+++ b/__tests__/cardDeck.test.js
@@ -1,0 +1,153 @@
+jest.mock('../utils/storageDatum', () => ({
+  getLastImageUuid: jest.fn(),
+  storeImageList: jest.fn(),
+  updateImageList: jest.fn(),
+}));
+
+jest.mock('../utils/imagesRequests', () => ({
+  getImages: jest.fn(),
+}));
+
+jest.mock('../services/groups/groupFeedCache', () => ({
+  readGroupFeedCache: jest.fn(),
+  writeGroupFeedCache: jest.fn(),
+}));
+
+import { updateImageList } from '../utils/storageDatum';
+import { readGroupFeedCache, writeGroupFeedCache } from '../services/groups/groupFeedCache';
+import { appendCardBatch } from '../services/cardDeck';
+
+describe('appendCardBatch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    updateImageList.mockResolvedValue([]);
+    writeGroupFeedCache.mockResolvedValue(undefined);
+    readGroupFeedCache.mockResolvedValue(null);
+  });
+
+  it('delegates to updateImageList on the public scope and skips the group feed cache', async () => {
+    const cards = [{ listId: 1 }, { listId: 2 }];
+
+    await appendCardBatch({ cards, categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' } });
+
+    expect(updateImageList).toHaveBeenCalledWith(cards, 'city', 'fr');
+    expect(writeGroupFeedCache).not.toHaveBeenCalled();
+    expect(readGroupFeedCache).not.toHaveBeenCalled();
+  });
+
+  it('reads, concatenates, and writes the merged deck on the private scope without calling updateImageList', async () => {
+    readGroupFeedCache.mockResolvedValueOnce({
+      images: [{ listId: 1 }, { listId: 2 }],
+      nextCursor: 'cursor-1',
+    });
+    const cards = [{ listId: 3 }, { listId: 4 }];
+
+    await appendCardBatch({
+      cards,
+      categoryKey: 'city',
+      categoryId: 7,
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-3' },
+    });
+
+    expect(readGroupFeedCache).toHaveBeenCalledWith('g-3', { categoryId: 7, language: 'fr' });
+    expect(writeGroupFeedCache).toHaveBeenCalledWith(
+      'g-3',
+      { categoryId: 7, language: 'fr' },
+      { images: [{ listId: 1 }, { listId: 2 }, { listId: 3 }, { listId: 4 }], nextCursor: 'cursor-1' },
+    );
+    expect(updateImageList).not.toHaveBeenCalled();
+  });
+
+  it('writes the incoming cards as-is when the private cache is empty or missing', async () => {
+    readGroupFeedCache.mockResolvedValueOnce(null);
+    const cards = [{ listId: 5 }];
+
+    await appendCardBatch({
+      cards,
+      categoryKey: 'all',
+      categoryId: 'all',
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-3' },
+    });
+
+    expect(writeGroupFeedCache).toHaveBeenCalledWith(
+      'g-3',
+      { categoryId: undefined, language: 'fr' },
+      { images: [{ listId: 5 }], nextCursor: null },
+    );
+  });
+
+  it('preserves the existing nextCursor when appending to a private cache', async () => {
+    readGroupFeedCache.mockResolvedValueOnce({
+      images: [{ listId: 1 }],
+      nextCursor: { page: 2 },
+    });
+
+    await appendCardBatch({
+      cards: [{ listId: 2 }],
+      categoryKey: 'city',
+      categoryId: 7,
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-3' },
+    });
+
+    expect(writeGroupFeedCache).toHaveBeenCalledWith(
+      'g-3',
+      { categoryId: 7, language: 'fr' },
+      { images: [{ listId: 1 }, { listId: 2 }], nextCursor: { page: 2 } },
+    );
+  });
+
+  it('returns null to match persistCardBatch', async () => {
+    await expect(
+      appendCardBatch({ cards: [], categoryKey: 'all', language: 'fr', scope: { kind: 'public' } }),
+    ).resolves.toBe(null);
+
+    readGroupFeedCache.mockResolvedValueOnce({ images: [], nextCursor: null });
+    await expect(
+      appendCardBatch({ cards: [], categoryKey: 'all', language: 'fr', scope: { kind: 'private', groupId: 'g-3' } }),
+    ).resolves.toBe(null);
+  });
+
+  it('normalizes an undefined language to "any" before forwarding to delegates', async () => {
+    const cards = [{ listId: 1 }];
+
+    await appendCardBatch({ cards, categoryKey: 'all', scope: { kind: 'public' } });
+
+    expect(updateImageList).toHaveBeenCalledWith(cards, 'all', 'any');
+
+    readGroupFeedCache.mockResolvedValueOnce({ images: [], nextCursor: null });
+    await appendCardBatch({
+      cards,
+      categoryKey: 'all',
+      scope: { kind: 'private', groupId: 'g-9' },
+    });
+
+    expect(readGroupFeedCache).toHaveBeenLastCalledWith('g-9', { categoryId: undefined, language: 'any' });
+    expect(writeGroupFeedCache).toHaveBeenLastCalledWith(
+      'g-9',
+      { categoryId: undefined, language: 'any' },
+      { images: cards, nextCursor: null },
+    );
+  });
+
+  it('resolves an "all" categoryId to undefined for both private and public scopes', async () => {
+    readGroupFeedCache.mockResolvedValueOnce({ images: [], nextCursor: null });
+
+    await appendCardBatch({
+      cards: [{ listId: 1 }],
+      categoryKey: 'all',
+      categoryId: 'all',
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-3' },
+    });
+
+    expect(readGroupFeedCache).toHaveBeenCalledWith('g-3', { categoryId: undefined, language: 'fr' });
+    expect(writeGroupFeedCache).toHaveBeenCalledWith(
+      'g-3',
+      { categoryId: undefined, language: 'fr' },
+      expect.objectContaining({ images: [{ listId: 1 }] }),
+    );
+  });
+});

--- a/__tests__/cardDeck.test.js
+++ b/__tests__/cardDeck.test.js
@@ -1,4 +1,5 @@
 jest.mock('../utils/storageDatum', () => ({
+  PUBLIC_FEED_END_CURSOR: '__public_feed_end__',
   getLastImageUuid: jest.fn(),
   storeImageList: jest.fn(),
   updateImageList: jest.fn(),
@@ -13,9 +14,10 @@ jest.mock('../services/groups/groupFeedCache', () => ({
   writeGroupFeedCache: jest.fn(),
 }));
 
-import { updateImageList } from '../utils/storageDatum';
+import { getLastImageUuid, updateImageList } from '../utils/storageDatum';
+import { getImages } from '../utils/imagesRequests';
 import { readGroupFeedCache, writeGroupFeedCache } from '../services/groups/groupFeedCache';
-import { appendCardBatch } from '../services/cardDeck';
+import { appendCardBatch, fetchCardBatch } from '../services/cardDeck';
 
 describe('appendCardBatch', () => {
   beforeEach(() => {
@@ -148,6 +150,95 @@ describe('appendCardBatch', () => {
       'g-3',
       { categoryId: undefined, language: 'fr' },
       expect.objectContaining({ images: [{ listId: 1 }] }),
+    );
+  });
+});
+
+describe('fetchCardBatch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getLastImageUuid.mockResolvedValue(null);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+  });
+
+  it('normalizes a synthetic "any" language to undefined so the backend does not filter by a non-existent language code', async () => {
+    // Regression: GuessPathScreen passes navigationLanguage='any' when the user
+    // never opened the language filter. That literal flowed all the way to the
+    // backend as ?language=any, and Image.batch_with_existing_storage applied
+    // WHERE language='any' — matching zero rows (no image has language='any').
+    // Categories with otherwise-matching cards appeared permanently empty.
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'any',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ language: undefined, category_key: 'nature', category_id: 'cat-nature' }),
+    );
+    expect(getImages.mock.calls[0][2].language).not.toBe('any');
+  });
+
+  it('forwards a real language code untouched', async () => {
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ language: 'fr' }),
+    );
+  });
+
+  it('normalizes an undefined language to undefined on the server (parity with the any/undefined branch)', async () => {
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: undefined,
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ language: undefined }),
+    );
+    expect(getImages.mock.calls[0][2].language).not.toBe('any');
+  });
+
+  it('treats a legacy stored exhausted sentinel as a fresh cursor so pictureIdOverride===undefined paths self-heal', async () => {
+    // Regression: prior app versions persisted PUBLIC_FEED_END_CURSOR to mark a
+    // category exhausted. After the brick fix, the cold-mount path bypasses the
+    // cursor (always passes null), but refillOrFallback's foreground load and
+    // the background prefetcher still call fetchCardBatch with no override —
+    // which used to read the stale sentinel and POST {name:'__public_feed_end__'}
+    // to the backend every session. Treat the sentinel as null so those paths
+    // also re-query from head and overwrite the stale key with a real cursor.
+    getLastImageUuid.mockResolvedValue('__public_feed_end__');
+
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+      // pictureIdOverride intentionally omitted (refillOrFallback / prefetcher shape)
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ category_key: 'nature' }),
     );
   });
 });

--- a/__tests__/cardPrefetcher.test.ts
+++ b/__tests__/cardPrefetcher.test.ts
@@ -1,0 +1,256 @@
+jest.mock('../services/cardDeck', () => ({
+  fetchCardBatch: jest.fn(),
+  appendCardBatch: jest.fn(),
+}));
+jest.mock('../utils/storageDatum', () => ({
+  getDeckCountForScope: jest.fn(),
+}));
+jest.mock('../utils/e2eMode', () => ({ isE2EMode: jest.fn(() => false) }));
+
+import { fetchCardBatch, appendCardBatch } from '../services/cardDeck';
+import { getDeckCountForScope } from '../utils/storageDatum';
+import { isE2EMode } from '../utils/e2eMode';
+import {
+  LOW_CARD_THRESHOLD,
+  ALL_WARM_THRESHOLD,
+  prefetchIfLow,
+  warmAllDeckIfNeeded,
+  __resetForTests,
+} from '../services/cardPrefetcher';
+
+const fetchMock = fetchCardBatch as jest.MockedFunction<typeof fetchCardBatch>;
+const appendMock = appendCardBatch as jest.MockedFunction<typeof appendCardBatch>;
+const countMock = getDeckCountForScope as jest.MockedFunction<typeof getDeckCountForScope>;
+const e2eMock = isE2EMode as jest.MockedFunction<typeof isE2EMode>;
+
+const IMAGES = [{ listId: 1 }, { listId: 2 }, { listId: 3 }];
+
+function okResponse(images = IMAGES) {
+  return Promise.resolve({ isError: false, images });
+}
+
+describe('cardPrefetcher', () => {
+  beforeEach(() => {
+    __resetForTests();
+    jest.clearAllMocks();
+    e2eMock.mockReturnValue(false);
+    countMock.mockResolvedValue(0);
+    fetchMock.mockResolvedValue({ isError: false, images: IMAGES } as never);
+    appendMock.mockResolvedValue(null as never);
+  });
+
+  it('exports thresholds equal to 5', () => {
+    expect(LOW_CARD_THRESHOLD).toBe(5);
+    expect(ALL_WARM_THRESHOLD).toBe(5);
+  });
+
+  it('does not fetch when count >= LOW_CARD_THRESHOLD', async () => {
+    countMock.mockResolvedValue(7);
+
+    await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(appendMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches and appends when count < LOW_CARD_THRESHOLD', async () => {
+    countMock.mockResolvedValue(3);
+
+    await prefetchIfLow({ categoryKey: 'all', language: 'fr', scope: { kind: 'public' }, authContext: { token: 'x' } });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith({
+      categoryKey: 'all',
+      categoryId: undefined,
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 'x' },
+    });
+    expect(appendMock).toHaveBeenCalledTimes(1);
+    expect(appendMock).toHaveBeenCalledWith({
+      cards: IMAGES,
+      categoryKey: 'all',
+      categoryId: undefined,
+      language: 'fr',
+      scope: { kind: 'public' },
+    });
+  });
+
+  it('skips append when fetchCardBatch returns isError', async () => {
+    countMock.mockResolvedValue(3);
+    fetchMock.mockResolvedValue({ isError: true } as never);
+
+    await expect(
+      prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} }),
+    ).resolves.toBeUndefined();
+
+    expect(appendMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors from fetchCardBatch', async () => {
+    countMock.mockResolvedValue(3);
+    fetchMock.mockRejectedValue(new Error('network down') as never);
+
+    await expect(
+      prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} }),
+    ).resolves.toBeUndefined();
+
+    expect(appendMock).not.toHaveBeenCalled();
+  });
+
+  it('dedups concurrent calls for the same deck key (one fetchCardBatch total)', async () => {
+    countMock.mockResolvedValue(3);
+    fetchMock.mockImplementation(okResponse);
+
+    const a = prefetchIfLow({ categoryKey: 'all', language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    const b = prefetchIfLow({ categoryKey: 'all', language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+    await Promise.all([a, b]);
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a new prefetch after the in-flight promise resolves (dedup cleared)', async () => {
+    countMock.mockResolvedValue(3);
+    fetchMock.mockImplementation(okResponse);
+
+    await prefetchIfLow({ categoryKey: 'all', language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+    await prefetchIfLow({ categoryKey: 'all', language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('warms the "all" deck in addition to the category fetch when categoryKey !== "all" and count is low', async () => {
+    countMock.mockResolvedValueOnce(3).mockResolvedValueOnce(0);
+    fetchMock.mockImplementation((params) =>
+      okResponse((params as { categoryKey: string }).categoryKey === 'all' ? [{ listId: 100 }] : IMAGES),
+    );
+
+    await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const allCall = fetchMock.mock.calls.find((c) => c[0]?.categoryKey === 'all');
+    expect(allCall).toBeDefined();
+    expect(allCall![0]).toMatchObject({ categoryKey: 'all', language: 'fr' });
+
+    const allAppend = appendMock.mock.calls.find((c) => c[0]?.categoryKey === 'all');
+    expect(allAppend).toBeDefined();
+    expect(allAppend![0]).toMatchObject({ cards: [{ listId: 100 }], categoryKey: 'all' });
+  });
+
+  it('does not re-warm while the persisted "all" deck still has cards', async () => {
+    countMock.mockResolvedValueOnce(0).mockResolvedValueOnce(2);
+    fetchMock.mockImplementation(() => okResponse());
+
+    await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+    const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+    expect(allCalls).toHaveLength(1);
+    expect(appendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('cold-starts the all-deck warm from the head when the persisted all deck is empty', async () => {
+    countMock.mockResolvedValueOnce(0);
+    fetchMock.mockImplementation(() => okResponse());
+
+    await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+    expect(fetchMock).toHaveBeenCalledWith({
+      categoryKey: 'all',
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: {},
+      pictureIdOverride: null,
+    });
+  });
+
+  it('does not warm when categoryKey === "all"', async () => {
+    countMock.mockResolvedValue(3);
+    fetchMock.mockImplementation(okResponse);
+
+    await prefetchIfLow({ categoryKey: 'all', language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toMatchObject({ categoryKey: 'all' });
+  });
+
+  it('is a no-op in e2e mode (prefetchIfLow)', async () => {
+    e2eMock.mockReturnValue(true);
+
+    await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+    expect(countMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(appendMock).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op in e2e mode (warmAllDeckIfNeeded)', async () => {
+    e2eMock.mockReturnValue(true);
+
+    await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(appendMock).not.toHaveBeenCalled();
+  });
+
+  it('warm-all retries on failure', async () => {
+    fetchMock.mockImplementation(() => Promise.reject(new Error('net down') as never));
+
+    await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+    fetchMock.mockImplementation(() => okResponse());
+
+    await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+    const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+    expect(allCalls).toHaveLength(2);
+    expect(appendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('warm-all is awaitable and shares in-flight promise across concurrent callers', async () => {
+    fetchMock.mockImplementation(() => okResponse());
+
+    const p = warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    expect(p).toBeInstanceOf(Promise);
+
+    const p2 = warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+    await Promise.all([p, p2]);
+
+    const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+    expect(allCalls).toHaveLength(1);
+  });
+
+  it('warm-all fetches again when the persisted all deck drains back to zero', async () => {
+    countMock.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    fetchMock.mockImplementation(() => okResponse());
+
+    await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    expect(appendMock).toHaveBeenCalledTimes(1);
+
+    await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+    const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+    expect(allCalls).toHaveLength(2);
+    expect(appendMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('warm-all with empty result retries on the next call', async () => {
+    fetchMock.mockResolvedValue({ isError: false, images: [] } as never);
+
+    await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+    const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+    expect(allCalls).toHaveLength(2);
+    expect(appendMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/frontend-smoke.test.js
+++ b/__tests__/frontend-smoke.test.js
@@ -29,6 +29,7 @@ describe('frontend smoke invariants', () => {
       'Rank',
       'Name',
       'Score',
+      'Max Streak',
       'Guess Score',
       'Guess Count',
       'Hide Score',

--- a/__tests__/handleGuessOutcome.test.js
+++ b/__tests__/handleGuessOutcome.test.js
@@ -60,4 +60,27 @@ describe('applySuccessSideEffects', () => {
     expect(bufferScore).toHaveBeenCalledTimes(1);
     expect(deleteImageFromStorage).not.toHaveBeenCalled();
   });
+
+  it('defaults streak to 0 and omits streakMultiplier when not passed', async () => {
+    await applySuccessSideEffects(baseArgs);
+
+    const arg = bufferScore.mock.calls[0][0];
+    expect(arg).toEqual(expect.objectContaining({ streak: 0 }));
+    expect('streakMultiplier' in arg).toBe(false);
+  });
+
+  it('threads streak and streakMultiplier into the buffered item', async () => {
+    await applySuccessSideEffects({ ...baseArgs, streak: 5, streakMultiplier: 1.5 });
+
+    const arg = bufferScore.mock.calls[0][0];
+    expect(arg).toEqual(expect.objectContaining({ streak: 5, streakMultiplier: 1.5 }));
+  });
+
+  it('threads streak without streakMultiplier when only streak is passed', async () => {
+    await applySuccessSideEffects({ ...baseArgs, streak: 5 });
+
+    const arg = bufferScore.mock.calls[0][0];
+    expect(arg).toEqual(expect.objectContaining({ streak: 5 }));
+    expect('streakMultiplier' in arg).toBe(false);
+  });
 });

--- a/__tests__/hooks/useGroupsHub.test.js
+++ b/__tests__/hooks/useGroupsHub.test.js
@@ -28,6 +28,18 @@ describe('useGroupsHub', () => {
     jest.clearAllMocks();
   });
 
+  it('does not fetch private groups when disabled explicitly', async () => {
+    const { result } = renderHook(() => useGroupsHub({ enabled: false }), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(fetchGroups).not.toHaveBeenCalled();
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
   it('populates data.owned and data.joined and flips isLoading to false once fetchGroups resolves', async () => {
     fetchGroups.mockResolvedValue({
       status: 200,

--- a/__tests__/imagesRequests.test.js
+++ b/__tests__/imagesRequests.test.js
@@ -15,7 +15,6 @@ jest.mock('../utils/auth', () => ({
 }));
 
 jest.mock('../utils/storageDatum', () => ({
-  PUBLIC_FEED_END_CURSOR: '__public_feed_end__',
   saveLastImageUuid: jest.fn(),
 }));
 
@@ -43,7 +42,7 @@ import { File, Paths } from 'expo-file-system';
 
 import { getBackendHeaders, setHeaders } from '../utils/auth';
 import { getImages, performImageUpload, prepareImageUpload, saveImageInfos, buildImageObject } from '../utils/imagesRequests';
-import { PUBLIC_FEED_END_CURSOR, saveLastImageUuid } from '../utils/storageDatum';
+import { saveLastImageUuid } from '../utils/storageDatum';
 
 describe('imagesRequests utilities', () => {
   beforeEach(() => {
@@ -152,15 +151,11 @@ describe('imagesRequests utilities', () => {
 
     expect(response).toEqual({ isError: false, images: [] });
     expect(axios.get).toHaveBeenCalledTimes(1);
-    expect(saveLastImageUuid).toHaveBeenCalledWith(PUBLIC_FEED_END_CURSOR, undefined, undefined);
-  });
-
-  it('short-circuits the public exhausted sentinel without hitting the network', async () => {
-    const response = await getImages(PUBLIC_FEED_END_CURSOR, { token: 'Bearer token' }, { language: 'fr' });
-
-    expect(response).toEqual({ isError: false, images: [] });
-    expect(axios.get).not.toHaveBeenCalled();
-    expect(axios.post).not.toHaveBeenCalled();
+    // Regression: an empty batch must NOT persist the exhausted sentinel.
+    // Saving it bricked the category forever (no new uploads ever surfaced).
+    // The caller decides exhaustion via the empty images array; the cursor
+    // stays on the last successfully fetched image so a later retry can page.
+    expect(saveLastImageUuid).not.toHaveBeenCalled();
   });
 
   it('downloads backend-hosted images with auth headers', async () => {

--- a/__tests__/imagesRequests.test.js
+++ b/__tests__/imagesRequests.test.js
@@ -15,6 +15,7 @@ jest.mock('../utils/auth', () => ({
 }));
 
 jest.mock('../utils/storageDatum', () => ({
+  PUBLIC_FEED_END_CURSOR: '__public_feed_end__',
   saveLastImageUuid: jest.fn(),
 }));
 
@@ -42,7 +43,7 @@ import { File, Paths } from 'expo-file-system';
 
 import { getBackendHeaders, setHeaders } from '../utils/auth';
 import { getImages, performImageUpload, prepareImageUpload, saveImageInfos, buildImageObject } from '../utils/imagesRequests';
-import { saveLastImageUuid } from '../utils/storageDatum';
+import { PUBLIC_FEED_END_CURSOR, saveLastImageUuid } from '../utils/storageDatum';
 
 describe('imagesRequests utilities', () => {
   beforeEach(() => {
@@ -151,6 +152,15 @@ describe('imagesRequests utilities', () => {
 
     expect(response).toEqual({ isError: false, images: [] });
     expect(axios.get).toHaveBeenCalledTimes(1);
+    expect(saveLastImageUuid).toHaveBeenCalledWith(PUBLIC_FEED_END_CURSOR, undefined, undefined);
+  });
+
+  it('short-circuits the public exhausted sentinel without hitting the network', async () => {
+    const response = await getImages(PUBLIC_FEED_END_CURSOR, { token: 'Bearer token' }, { language: 'fr' });
+
+    expect(response).toEqual({ isError: false, images: [] });
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(axios.post).not.toHaveBeenCalled();
   });
 
   it('downloads backend-hosted images with auth headers', async () => {

--- a/__tests__/scoreRequests.test.js
+++ b/__tests__/scoreRequests.test.js
@@ -70,8 +70,8 @@ describe('scoreRequests utilities', () => {
         {
           batch: {
             results: [
-              { guess_id: 'g-1', image_name: 'img-1', points: 10 },
-              { guess_id: 'g-2', image_name: 'img-2', points: 5 },
+              { guess_id: 'g-1', image_name: 'img-1', points: 10, streak: 0 },
+              { guess_id: 'g-2', image_name: 'img-2', points: 5, streak: 0 },
             ],
           },
         },
@@ -79,6 +79,69 @@ describe('scoreRequests utilities', () => {
       );
       expect(result).toBe(true);
       expect(setHeaders).toHaveBeenCalledWith({ token: 'Bearer token' });
+    });
+
+    it('includes the streak value on the public batch payload when provided', async () => {
+      axios.post.mockResolvedValue({ status: 200, data: { ok: true } });
+
+      await submitScoreBatch({
+        items: [{ guessId: 'g-1', pictureId: 'img-1', points: 10, streak: 5 }],
+        context: { token: 'Bearer token' },
+      });
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'https://backend.example/api/v1/users/42/scores/batch',
+        {
+          batch: {
+            results: [
+              { guess_id: 'g-1', image_name: 'img-1', points: 10, streak: 5 },
+            ],
+          },
+        },
+        { headers: { Authorization: 'Bearer token' } }
+      );
+    });
+
+    it('defaults streak to 0 on the public batch payload when the item omits it', async () => {
+      axios.post.mockResolvedValue({ status: 200, data: { ok: true } });
+
+      await submitScoreBatch({
+        items: [{ guessId: 'g-1', pictureId: 'img-1', points: 10 }],
+        context: { token: 'Bearer token' },
+      });
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'https://backend.example/api/v1/users/42/scores/batch',
+        {
+          batch: {
+            results: [
+              { guess_id: 'g-1', image_name: 'img-1', points: 10, streak: 0 },
+            ],
+          },
+        },
+        { headers: { Authorization: 'Bearer token' } }
+      );
+    });
+
+    it('passes an explicit streak of 0 through to the public batch payload', async () => {
+      axios.post.mockResolvedValue({ status: 200, data: { ok: true } });
+
+      await submitScoreBatch({
+        items: [{ guessId: 'g-1', pictureId: 'img-1', points: 10, streak: 0 }],
+        context: { token: 'Bearer token' },
+      });
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'https://backend.example/api/v1/users/42/scores/batch',
+        {
+          batch: {
+            results: [
+              { guess_id: 'g-1', image_name: 'img-1', points: 10, streak: 0 },
+            ],
+          },
+        },
+        { headers: { Authorization: 'Bearer token' } }
+      );
     });
 
     it('posts private items to the group batch endpoint with the expected payload', async () => {
@@ -104,6 +167,27 @@ describe('scoreRequests utilities', () => {
       );
       expect(result).toBe(true);
       expect(setHeaders).toHaveBeenCalledWith({ token: 'Bearer token' });
+    });
+
+    it('does not include streak on the private batch payload', async () => {
+      axios.post.mockResolvedValue({ status: 200, data: { ok: true } });
+
+      await submitScoreBatch({
+        items: [
+          { guessId: 'g-1', pictureId: 'img-1', points: 7, streak: 5, scope: { kind: 'private', groupId: 'g-9' } },
+        ],
+        context: { token: 'Bearer token' },
+      });
+
+      const call = axios.post.mock.calls[0];
+      const [url, body] = call;
+      expect(url).toBe('https://backend.example/api/v1/private_groups/g-9/game_complete/batch');
+      expect(body.batch.results[0]).toEqual({
+        guess_id: 'g-1',
+        image_id: 'img-1',
+        earned_points: 7,
+      });
+      expect(body.batch.results[0]).not.toHaveProperty('streak');
     });
 
     it('calls setHeaders with only the token and no uid/expiry/access_token/client', async () => {

--- a/__tests__/scoreRequests.test.js
+++ b/__tests__/scoreRequests.test.js
@@ -149,7 +149,7 @@ describe('scoreRequests utilities', () => {
 
       const result = await submitScoreBatch({
         items: [
-          { guessId: 'g-1', pictureId: 'img-1', points: 7, scope: { kind: 'private', groupId: 'g-9' } },
+          { guessId: 'g-1', pictureId: 'img-1', points: 7, streak: 5, scope: { kind: 'private', groupId: 'g-9' } },
         ],
         context: { token: 'Bearer token' },
       });
@@ -159,7 +159,7 @@ describe('scoreRequests utilities', () => {
         {
           batch: {
             results: [
-              { guess_id: 'g-1', image_id: 'img-1', earned_points: 7 },
+              { guess_id: 'g-1', image_id: 'img-1', earned_points: 7, streak: 5 },
             ],
           },
         },
@@ -169,12 +169,12 @@ describe('scoreRequests utilities', () => {
       expect(setHeaders).toHaveBeenCalledWith({ token: 'Bearer token' });
     });
 
-    it('does not include streak on the private batch payload', async () => {
+    it('defaults streak to 0 on the private batch payload when the item omits it', async () => {
       axios.post.mockResolvedValue({ status: 200, data: { ok: true } });
 
       await submitScoreBatch({
         items: [
-          { guessId: 'g-1', pictureId: 'img-1', points: 7, streak: 5, scope: { kind: 'private', groupId: 'g-9' } },
+          { guessId: 'g-1', pictureId: 'img-1', points: 7, scope: { kind: 'private', groupId: 'g-9' } },
         ],
         context: { token: 'Bearer token' },
       });
@@ -186,8 +186,8 @@ describe('scoreRequests utilities', () => {
         guess_id: 'g-1',
         image_id: 'img-1',
         earned_points: 7,
+        streak: 0,
       });
-      expect(body.batch.results[0]).not.toHaveProperty('streak');
     });
 
     it('calls setHeaders with only the token and no uid/expiry/access_token/client', async () => {

--- a/__tests__/sessionScoreStore.test.js
+++ b/__tests__/sessionScoreStore.test.js
@@ -387,4 +387,62 @@ describe('sessionScoreStore', () => {
       expect(aItem.userId).toBe('user-A');
     });
   });
+
+  describe('streak passthrough', () => {
+    it('passes streak through unchanged to submitScoreBatch on flush', async () => {
+      bufferScore(item({ guessId: 'g-streak', streak: 5 }));
+      await drain();
+
+      const result = await flush({ authContext: { token: 'Bearer token' } });
+
+      expect(result).toEqual({ ok: true, sent: 1, retained: 0 });
+      expect(submitScoreBatch).toHaveBeenCalledTimes(1);
+      const callItems = submitScoreBatch.mock.calls[0][0].items;
+      expect(callItems).toHaveLength(1);
+      expect(callItems[0].guessId).toBe('g-streak');
+      expect(callItems[0].streak).toBe(5);
+    });
+
+    it('survives a serialize/deserialize round-trip via AsyncStorage', async () => {
+      bufferScore(item({ guessId: 'g-rt', streak: 7 }));
+      await drain();
+
+      expect(mockStorage[PENDING_KEY]).toContain('"streak":7');
+
+      const storedAfterBuffer = await getPending();
+      expect(storedAfterBuffer).toHaveLength(1);
+      expect(storedAfterBuffer[0].streak).toBe(7);
+
+      const reloaded = JSON.parse(mockStorage[PENDING_KEY]);
+      expect(reloaded[0].streak).toBe(7);
+
+      const result = await flush({ authContext: { token: 'Bearer token' } });
+      expect(result).toEqual({ ok: true, sent: 1, retained: 0 });
+      const callItems = submitScoreBatch.mock.calls[0][0].items;
+      expect(callItems[0].streak).toBe(7);
+    });
+
+    it('leaves streak undefined when bufferScore receives no streak', async () => {
+      bufferScore(item({ guessId: 'g-no-streak' }));
+      await drain();
+
+      const result = await flush({ authContext: { token: 'Bearer token' } });
+
+      expect(result).toEqual({ ok: true, sent: 1, retained: 0 });
+      const callItems = submitScoreBatch.mock.calls[0][0].items;
+      expect(callItems[0].guessId).toBe('g-no-streak');
+      expect(callItems[0].streak).toBeUndefined();
+    });
+
+    it('passes streakMultiplier through unchanged for display-only consumers', async () => {
+      bufferScore(item({ guessId: 'g-sm', streak: 3, streakMultiplier: 1.5 }));
+      await drain();
+
+      await flush({ authContext: { token: 'Bearer token' } });
+
+      const callItems = submitScoreBatch.mock.calls[0][0].items;
+      expect(callItems[0].streak).toBe(3);
+      expect(callItems[0].streakMultiplier).toBe(1.5);
+    });
+  });
 });

--- a/__tests__/storageDatum.test.js
+++ b/__tests__/storageDatum.test.js
@@ -112,7 +112,7 @@ describe('storageDatum utilities', () => {
     expect(await getLastImageUuid()).toBe('uuid-1');
   });
 
-  it('round-trips the session language filter and defaults to en when unset', async () => {
+  it('round-trips the session language filter and returns null when unset', async () => {
     await saveSessionLanguageFilter('fr');
     expect(AsyncStorage.setItem).toHaveBeenCalledWith('sessionLanguageFilter', 'fr');
 
@@ -120,7 +120,7 @@ describe('storageDatum utilities', () => {
     expect(await getSessionLanguageFilter()).toBe('fr');
 
     AsyncStorage.getItem.mockResolvedValueOnce(null);
-    expect(await getSessionLanguageFilter()).toBe('en');
+    expect(await getSessionLanguageFilter()).toBeNull();
   });
 
   it('round-trips the preferred language and returns null when unset', async () => {

--- a/__tests__/storageDatum.test.js
+++ b/__tests__/storageDatum.test.js
@@ -38,6 +38,7 @@ import {
   clearE2EHiddenGuessCard,
   deleteImageFromStorage,
   emptyImageList,
+  getDeckCountForScope,
   getE2EHiddenGuessCard,
   getLastImageId,
   getLastImageUuid,
@@ -376,6 +377,152 @@ describe('storageDatum utilities', () => {
       });
 
       expect(card).toEqual({ listId: 7, imageFile: 'file:///cache/p7.jpg' });
+    });
+  });
+
+  describe('getDeckCountForScope', () => {
+    it('returns the getLocalImages array length for the public scope', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([
+        { listId: 1, imageFile: 'file:///cache/1.jpg' },
+        { listId: 2, imageFile: 'file:///cache/2.jpg' },
+        { listId: 3, imageFile: 'file:///cache/3.jpg' },
+      ]));
+
+      const count = await getDeckCountForScope({
+        category: { key: 'all' },
+        language: 'any',
+        scope: { kind: 'public' },
+      });
+
+      expect(count).toBe(3);
+      expect(readGroupFeedCache).not.toHaveBeenCalled();
+    });
+
+    it('returns 0 for the public scope when the deck is missing', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(null);
+
+      const count = await getDeckCountForScope({
+        category: { key: 'all' },
+        language: 'any',
+        scope: { kind: 'public' },
+      });
+
+      expect(count).toBe(0);
+    });
+
+    it('returns 0 for the public scope when the deck is an empty array', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([]));
+
+      const count = await getDeckCountForScope({
+        category: { key: 'all' },
+        language: 'any',
+        scope: { kind: 'public' },
+      });
+
+      expect(count).toBe(0);
+    });
+
+    it('uses category.key for the public scope lookup', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([
+        { listId: 1, imageFile: 'file:///cache/1.jpg' },
+      ]));
+
+      await getDeckCountForScope({
+        category: { key: 'city', id: 7 },
+        language: 'fr',
+        scope: { kind: 'public' },
+      });
+
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith('imageList:city:fr');
+    });
+
+    it('falls back to the "all" category key when category is missing', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([
+        { listId: 1, imageFile: 'file:///cache/1.jpg' },
+      ]));
+
+      await getDeckCountForScope({
+        category: null,
+        language: 'fr',
+        scope: { kind: 'public' },
+      });
+
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith('imageList:all:fr');
+    });
+
+    it('returns the readGroupFeedCache images length for a private scope', async () => {
+      readGroupFeedCache.mockResolvedValueOnce({
+        images: [{ listId: 1, imageFile: 'file:///cache/p1.jpg' }],
+        nextCursor: 'x',
+      });
+
+      const count = await getDeckCountForScope({
+        category: { key: 'city', id: 7 },
+        language: 'fr',
+        scope: { kind: 'private', groupId: 'g-3' },
+      });
+
+      expect(count).toBe(1);
+    });
+
+    it('returns 0 for a private scope when the cache is missing', async () => {
+      readGroupFeedCache.mockResolvedValueOnce(null);
+
+      const count = await getDeckCountForScope({
+        category: { key: 'city', id: 7 },
+        language: 'fr',
+        scope: { kind: 'private', groupId: 'g-3' },
+      });
+
+      expect(count).toBe(0);
+    });
+
+    it('resolves category.key === "all" to categoryId undefined for a private scope', async () => {
+      readGroupFeedCache.mockResolvedValueOnce({ images: [], nextCursor: null });
+
+      await getDeckCountForScope({
+        category: { key: 'all' },
+        language: 'fr',
+        scope: { kind: 'private', groupId: 'g-3' },
+      });
+
+      expect(readGroupFeedCache).toHaveBeenCalledWith('g-3', { categoryId: undefined, language: 'fr' });
+    });
+
+    it('passes category.id as categoryId for a private scope with a real category', async () => {
+      readGroupFeedCache.mockResolvedValueOnce({ images: [], nextCursor: null });
+
+      await getDeckCountForScope({
+        category: { key: 'city', id: 42 },
+        language: 'de',
+        scope: { kind: 'private', groupId: 'g-9' },
+      });
+
+      expect(readGroupFeedCache).toHaveBeenCalledWith('g-9', { categoryId: 42, language: 'de' });
+    });
+
+    it('passes language through unchanged to both readers', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([
+        { listId: 1, imageFile: 'file:///cache/1.jpg' },
+      ]));
+
+      await getDeckCountForScope({
+        category: { key: 'all' },
+        language: 'fr',
+        scope: { kind: 'public' },
+      });
+
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith('imageList:all:fr');
+
+      readGroupFeedCache.mockResolvedValueOnce({ images: [], nextCursor: null });
+
+      await getDeckCountForScope({
+        category: { key: 'all' },
+        language: undefined,
+        scope: { kind: 'private', groupId: 'g-1' },
+      });
+
+      expect(readGroupFeedCache).toHaveBeenCalledWith('g-1', { categoryId: undefined, language: undefined });
     });
   });
 });

--- a/__tests__/streakTiers.test.js
+++ b/__tests__/streakTiers.test.js
@@ -1,0 +1,88 @@
+import {
+  STREAK_TIERS,
+  NEUTRAL_TIER,
+  STREAK_MULTIPLIER_BASE,
+  resolveStreakTier,
+} from '../constants/streakTiers';
+
+describe('streakTiers', () => {
+  describe('constants', () => {
+    it('exports STREAK_MULTIPLIER_BASE === 1.0', () => {
+      expect(STREAK_MULTIPLIER_BASE).toBe(1.0);
+    });
+
+    it('exposes a neutral tier 0 fallback', () => {
+      expect(NEUTRAL_TIER).toEqual({
+        tier: 0,
+        threshold: 0,
+        multiplier: 1.0,
+        label: '',
+        colorKey: 'neutral',
+      });
+    });
+
+    it('keeps thresholds strictly descending across STREAK_TIERS', () => {
+      for (let i = 0; i < STREAK_TIERS.length - 1; i += 1) {
+        expect(STREAK_TIERS[i].threshold).toBeGreaterThan(STREAK_TIERS[i + 1].threshold);
+      }
+    });
+  });
+
+  describe('resolveStreakTier — neutral input', () => {
+    it('returns neutral tier for streak 0', () => {
+      const result = resolveStreakTier(0);
+      expect(result.tier).toBe(0);
+      expect(result.multiplier).toBe(1.0);
+      expect(result.label).toBe('');
+      expect(result.colorKey).toBe('neutral');
+    });
+  });
+
+  describe('resolveStreakTier — boundaries', () => {
+    it.each([
+      [2, 0, 1.0, '', 'neutral'],
+      [3, 1, 1.5, 'Focused', 'blue'],
+      [6, 1, 1.5, 'Focused', 'blue'],
+      [7, 2, 2.0, 'In the Zone', 'orange'],
+      [12, 3, 3.0, 'On Fire', 'red'],
+      [20, 4, 5.0, 'Legendary', 'purple'],
+      [50, 5, 10.0, "Waldo's Nemesis", 'white'],
+    ])(
+      'streak %p -> tier %p, multiplier %p, label %p, colorKey %p',
+      (streak, tier, multiplier, label, colorKey) => {
+        const result = resolveStreakTier(streak);
+        expect(result.tier).toBe(tier);
+        expect(result.multiplier).toBe(multiplier);
+        expect(result.label).toBe(label);
+        expect(result.colorKey).toBe(colorKey);
+      },
+    );
+  });
+
+  describe('resolveStreakTier — high values', () => {
+    it('returns the top tier for streak 999', () => {
+      expect(resolveStreakTier(999).tier).toBe(5);
+    });
+  });
+
+  describe('resolveStreakTier — clamping', () => {
+    it('clamps negative streak to tier 0', () => {
+      expect(resolveStreakTier(-5).tier).toBe(0);
+    });
+
+    it('floors 2.9 to tier 0 (floor = 2, below threshold 3)', () => {
+      expect(resolveStreakTier(2.9).tier).toBe(0);
+    });
+  });
+
+  describe('resolveStreakTier — contract', () => {
+    it.each([-5, 0, 1, 2, 3, 6, 7, 12, 20, 50, 999])(
+      'guarantees multiplier >= 1.0 and tier >= 0 for streak %p',
+      (streak) => {
+        const { tier, multiplier } = resolveStreakTier(streak);
+        expect(multiplier).toBeGreaterThanOrEqual(1.0);
+        expect(tier).toBeGreaterThanOrEqual(0);
+      },
+    );
+  });
+});

--- a/__tests__/useStreak.test.js
+++ b/__tests__/useStreak.test.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import { useStreak } from '../hooks/useStreak';
+
+let captured;
+function Probe({ initial }) {
+  captured = useStreak(initial);
+  return null;
+}
+
+describe('useStreak', () => {
+  let renderer;
+
+  beforeEach(() => {
+    captured = undefined;
+    renderer = undefined;
+  });
+
+  afterEach(() => {
+    if (renderer) {
+      act(() => {
+        renderer.unmount();
+      });
+      renderer = undefined;
+    }
+  });
+
+  it('starts at streak 0 by default and increments on each onWin', () => {
+    act(() => {
+      renderer = create(<Probe />);
+    });
+
+    expect(captured.streak).toBe(0);
+
+    act(() => {
+      captured.onWin();
+    });
+    expect(captured.streak).toBe(1);
+
+    act(() => {
+      captured.onWin();
+    });
+    expect(captured.streak).toBe(2);
+  });
+
+  it('resets to 0 on onLose and resumes from 1 on the next win', () => {
+    act(() => {
+      renderer = create(<Probe />);
+    });
+
+    act(() => {
+      captured.onWin();
+      captured.onWin();
+    });
+    expect(captured.streak).toBe(2);
+
+    act(() => {
+      captured.onLose();
+    });
+    expect(captured.streak).toBe(0);
+
+    act(() => {
+      captured.onWin();
+    });
+    expect(captured.streak).toBe(1);
+  });
+
+  it('derives multiplier from the tier at each step', () => {
+    act(() => {
+      renderer = create(<Probe />);
+    });
+
+    expect(captured.multiplier).toBe(1.0);
+    expect(captured.tier.tier).toBe(0);
+
+    act(() => {
+      captured.onWin();
+      captured.onWin();
+      captured.onWin();
+    });
+    expect(captured.streak).toBe(3);
+    expect(captured.tier.tier).toBe(1);
+    expect(captured.tier.label).toBe('Focused');
+    expect(captured.multiplier).toBe(1.5);
+
+    act(() => {
+      captured.onWin();
+      captured.onWin();
+      captured.onWin();
+      captured.onWin();
+    });
+    expect(captured.streak).toBe(7);
+    expect(captured.tier.tier).toBe(2);
+    expect(captured.multiplier).toBe(2.0);
+  });
+
+  it('reset() returns streak to 0 and clears the tier', () => {
+    act(() => {
+      renderer = create(<Probe />);
+    });
+
+    act(() => {
+      captured.onWin();
+      captured.onWin();
+      captured.onWin();
+    });
+    expect(captured.streak).toBe(3);
+
+    act(() => {
+      captured.reset();
+    });
+    expect(captured.streak).toBe(0);
+    expect(captured.tier.tier).toBe(0);
+    expect(captured.multiplier).toBe(1.0);
+  });
+
+  it('keeps onWin/onLose/reset referentially stable across re-renders', () => {
+    act(() => {
+      renderer = create(<Probe />);
+    });
+
+    const firstOnWin = captured.onWin;
+    const firstOnLose = captured.onLose;
+    const firstReset = captured.reset;
+
+    act(() => {
+      captured.onWin();
+    });
+
+    expect(captured.onWin).toBe(firstOnWin);
+    expect(captured.onLose).toBe(firstOnLose);
+    expect(captured.reset).toBe(firstReset);
+  });
+
+  it('honours an initial streak argument and derives its tier', () => {
+    act(() => {
+      renderer = create(<Probe initial={5} />);
+    });
+
+    expect(captured.streak).toBe(5);
+    expect(captured.tier.tier).toBe(1);
+    expect(captured.multiplier).toBe(1.5);
+  });
+});

--- a/app.json
+++ b/app.json
@@ -27,9 +27,6 @@
         "backgroundColor": "#ffffff"
       },
       "permissions": [
-        "android.permission.RECORD_AUDIO",
-        "android.permission.READ_EXTERNAL_STORAGE",
-        "android.permission.WRITE_EXTERNAL_STORAGE",
         "android.permission.ACCESS_MEDIA_LOCATION"
       ],
       "package": "com.alegarn.WoIstWaldoProject"

--- a/components/Guess/SuccessOverlay.js
+++ b/components/Guess/SuccessOverlay.js
@@ -3,6 +3,7 @@ import { Animated, Easing, StyleSheet, View, Text } from 'react-native';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
 
 import { GlobalStyle } from '../../constants/theme';
+import { NEUTRAL_TIER } from '../../constants/streakTiers';
 
 // Single source of truth for the speed-bonus color (spokes, chrono, pill).
 const SPEED_COLOR = GlobalStyle.color.win;
@@ -22,8 +23,29 @@ const BADGE_DELAY_MS = 120;
 const BURST_SPIN_DEG = 45;
 const CHRONO_ICON = 'timer-outline';
 const CHRONO_SIZE = 22;
+const STREAK_PULSE_MS = 600;
+const STREAK_PULSE_OPACITY_MAX = 1.0;
+const STREAK_PULSE_OPACITY_MIN = 0.6;
+const STREAK_PULSE_SCALE_MAX = 1.0;
+const STREAK_PULSE_SCALE_MIN = 0.97;
+const STREAK_RING_MS = 1400;
+const STREAK_RING_STAGGER_MS = 700;
+const STREAK_RING_SCALE_MAX = 1.4;
+const STREAK_RING_OPACITY_START = 0.5;
+const STREAK_RING_OPACITY_END = 0;
+const STREAK_RING_SCALE_START = 1.0;
+const STREAK_RING_BORDER_WIDTH = 2;
+const STREAK_RING_RADIUS = 36;
+const STREAK_RING_SIZE = (STREAK_RING_RADIUS + STREAK_RING_BORDER_WIDTH) * 2;
 
-export default function SuccessOverlay({ visible, onDone, multiplier = 1, points = 1 }) {
+function breathe(value, high, low, durationMs) {
+  return Animated.sequence([
+    Animated.timing(value, { toValue: low, duration: durationMs, useNativeDriver: true }),
+    Animated.timing(value, { toValue: high, duration: durationMs, useNativeDriver: true }),
+  ]);
+}
+
+export default function SuccessOverlay({ visible, onDone, multiplier = 1, points = 1, streakTier = NEUTRAL_TIER }) {
   const isSpeedBonus = multiplier > 1;
   const scale = useRef(new Animated.Value(0)).current;
   const opacity = useRef(new Animated.Value(0)).current;
@@ -42,6 +64,38 @@ export default function SuccessOverlay({ visible, onDone, multiplier = 1, points
   const onDoneRef = useRef(onDone);
   onDoneRef.current = onDone;
   const animRef = useRef(null);
+
+  const isStreak = streakTier.tier > 0;
+  const flameColor = GlobalStyle.color.streak[streakTier.colorKey];
+  const pulseOpacity = useRef(new Animated.Value(STREAK_PULSE_OPACITY_MAX)).current;
+  const pulseScale = useRef(new Animated.Value(STREAK_PULSE_SCALE_MAX)).current;
+  const ringA = useRef({ scale: new Animated.Value(STREAK_RING_SCALE_START), opacity: new Animated.Value(STREAK_RING_OPACITY_START) }).current;
+  const ringB = useRef({ scale: new Animated.Value(STREAK_RING_SCALE_START), opacity: new Animated.Value(STREAK_RING_OPACITY_START) }).current;
+
+  useEffect(() => {
+    if (!visible || streakTier.tier !== 1) return undefined;
+    const loop = Animated.loop(Animated.parallel([
+      breathe(pulseOpacity, STREAK_PULSE_OPACITY_MAX, STREAK_PULSE_OPACITY_MIN, STREAK_PULSE_MS),
+      breathe(pulseScale, STREAK_PULSE_SCALE_MAX, STREAK_PULSE_SCALE_MIN, STREAK_PULSE_MS),
+    ]));
+    loop.start();
+    return () => loop.stop();
+  }, [visible, streakTier.tier, pulseOpacity, pulseScale]);
+
+  useEffect(() => {
+    if (!visible || streakTier.tier < 2) return undefined;
+    const ripple = (ring) => Animated.loop(Animated.parallel([
+      Animated.timing(ring.scale, { toValue: STREAK_RING_SCALE_MAX, duration: STREAK_RING_MS, useNativeDriver: true }),
+      Animated.timing(ring.opacity, { toValue: STREAK_RING_OPACITY_END, duration: STREAK_RING_MS, useNativeDriver: true }),
+    ]));
+    const loopA = ripple(ringA);
+    loopA.start();
+    const loopBHandle = setTimeout(() => ripple(ringB).start(), STREAK_RING_STAGGER_MS);
+    return () => {
+      loopA.stop();
+      clearTimeout(loopBHandle);
+    };
+  }, [visible, streakTier.tier, flameColor, ringA, ringB]);
 
   useEffect(() => {
     if (!visible) return undefined;
@@ -152,6 +206,53 @@ export default function SuccessOverlay({ visible, onDone, multiplier = 1, points
             </View>
           </Animated.View>
         )}
+        {isStreak && (
+          <View style={styles.streakBadge}>
+            {streakTier.tier >= 2 && (
+              <>
+                <Animated.View
+                  testID="guess.success.streak.ring"
+                  pointerEvents="none"
+                  style={[
+                    styles.glowRing,
+                    {
+                      borderColor: flameColor,
+                      opacity: ringA.opacity,
+                      transform: [{ scale: ringA.scale }],
+                    },
+                  ]}
+                />
+                <Animated.View
+                  testID="guess.success.streak.ring"
+                  pointerEvents="none"
+                  style={[
+                    styles.glowRing,
+                    {
+                      borderColor: flameColor,
+                      opacity: ringB.opacity,
+                      transform: [{ scale: ringB.scale }],
+                    },
+                  ]}
+                />
+              </>
+            )}
+            <Animated.View
+              testID="guess.success.streak.pill"
+              style={[
+                styles.streakPill,
+                {
+                  borderColor: flameColor,
+                  opacity: streakTier.tier === 1 ? pulseOpacity : STREAK_PULSE_OPACITY_MAX,
+                  transform: [{ scale: streakTier.tier === 1 ? pulseScale : STREAK_PULSE_SCALE_MAX }],
+                },
+              ]}
+            >
+              <Text style={[styles.streakPillText, { color: flameColor }]}>
+                {`🔥 ${streakTier.label} ×${streakTier.multiplier}`}
+              </Text>
+            </Animated.View>
+          </View>
+        )}
       </Animated.View>
     </View>
   );
@@ -192,4 +293,20 @@ const styles = StyleSheet.create({
   chrono: { marginRight: 6 },
   multiplierPill: { borderWidth: 2, borderColor: SPEED_COLOR, borderRadius: 10, paddingHorizontal: 8, paddingVertical: 2, backgroundColor: 'transparent' },
   multiplierText: { fontSize: 20, fontWeight: 'bold', color: SPEED_COLOR },
+  streakBadge: { marginTop: 8, alignItems: 'center', justifyContent: 'center' },
+  streakPill: {
+    borderWidth: 2,
+    borderRadius: 10,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    backgroundColor: 'transparent',
+  },
+  streakPillText: { fontSize: 16, fontWeight: 'bold' },
+  glowRing: {
+    position: 'absolute',
+    width: STREAK_RING_SIZE,
+    height: STREAK_RING_SIZE,
+    borderRadius: STREAK_RING_SIZE / 2,
+    borderWidth: STREAK_RING_BORDER_WIDTH,
+  },
 });

--- a/components/Guess/SwipeHaloHint.js
+++ b/components/Guess/SwipeHaloHint.js
@@ -22,6 +22,7 @@ const RING_SIZE_STEP_PX = 40;
 const RING_BORDER_WIDTH_PX = 3;
 const RING_RADIUS_DIVISOR = 2;
 const RING_CENTER_OFFSET_PERCENT = 50;
+const BOTTOM_EDGE_INSET_PX = 28;
 const RING_COLOR_PRIMARY = GlobalStyle.color.primaryColor;
 const RING_COLOR_SECONDARY = GlobalStyle.color.secondaryColor;
 const RING_KEY_PREFIX = 'swipe-halo-ring-';
@@ -50,7 +51,7 @@ function ringLayout(edge, size) {
   }
 
   return {
-    bottom: centerOffset,
+    bottom: BOTTOM_EDGE_INSET_PX + centerOffset,
     left: `${RING_CENTER_OFFSET_PERCENT}%`,
     marginLeft: centerOffset,
   };

--- a/components/Picture/Descriptions/EnigmaOverlay.js
+++ b/components/Picture/Descriptions/EnigmaOverlay.js
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, PanResponder, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import IconButton from '../../UI/IconButton';
@@ -20,6 +20,24 @@ export default function EnigmaOverlay({ description, screenHeight, defaultOpen, 
   const panelHeight = buildPanelHeight(screenHeight);
   const [isOpen, setIsOpen] = useState(!!defaultOpen);
   const translateY = useRef(new Animated.Value(defaultOpen ? 0 : panelHeight)).current;
+  const previousDefaultOpenRef = useRef(!!defaultOpen);
+
+  useEffect(() => {
+    const previousDefaultOpen = previousDefaultOpenRef.current;
+    if (previousDefaultOpen === !!defaultOpen) {
+      return;
+    }
+
+    previousDefaultOpenRef.current = !!defaultOpen;
+    if (defaultOpen) {
+      setIsOpen(true);
+      translateY.setValue(0);
+      return;
+    }
+
+    translateY.setValue(panelHeight);
+    setIsOpen(false);
+  }, [defaultOpen, panelHeight, translateY]);
 
   const openPanel = useCallback(() => {
     setIsOpen(true);

--- a/components/UI/CategoryChips.js
+++ b/components/UI/CategoryChips.js
@@ -1,5 +1,6 @@
 import { Pressable, Text, View, Image, StyleSheet } from 'react-native';
 
+import { getCategoryAssetSource } from '../../utils/categoryAssets';
 import { GlobalStyle } from '../../constants/theme';
 
 const OTHER_CATEGORY = {
@@ -20,8 +21,9 @@ export default function CategoryChips({ selected, onSelect, categories = [], tes
       {visibleCategories.map((category) => {
         const chipValue = category.key === OTHER_CATEGORY.key ? null : category.key;
         const isSelected = category.key === OTHER_CATEGORY.key ? selected == null : selected === category.key;
-        const hasThumbnail = Boolean(category.thumbnailUrl);
-        // TODO: backend serves placeholder thumbnail_url (seeds set nil); fallback renders until real assets are uploaded.
+        const thumbnailSource = typeof category?.thumbnailUrl === 'string' && category.thumbnailUrl.length > 0
+          ? { uri: category.thumbnailUrl }
+          : getCategoryAssetSource(category);
         return (
           <Pressable
             key={category.key}
@@ -33,8 +35,8 @@ export default function CategoryChips({ selected, onSelect, categories = [], tes
               isSelected && styles.chipSelected,
               isSelected && isOverlay && styles.chipSelectedOverlay,
             ]}>
-            {hasThumbnail ? (
-              <Image source={{ uri: category.thumbnailUrl }} style={styles.thumbnail} />
+            {thumbnailSource ? (
+              <Image source={thumbnailSource} style={styles.thumbnail} />
             ) : (
               <View
                 testID={`${testIDPrefix}.chip.${category.key}.fallback`}

--- a/components/UI/GuessCategoryCard.js
+++ b/components/UI/GuessCategoryCard.js
@@ -1,6 +1,6 @@
 import { Pressable, View, Text, ImageBackground, StyleSheet } from 'react-native';
 
-import { getCategoryAsset } from '../../utils/categoryAssets';
+import { getCategoryAssetSource } from '../../utils/categoryAssets';
 import { GlobalStyle } from '../../constants/theme';
 
 function isRemoteThumbnail(value) {
@@ -10,7 +10,7 @@ function isRemoteThumbnail(value) {
 export default function GuessCategoryCard({ category, thumbnailUrl, count, onPress, testIDPrefix }) {
   const cardTestID = `${testIDPrefix}.card.${category.id}`;
   const useRemote = isRemoteThumbnail(thumbnailUrl);
-  const source = useRemote ? { uri: thumbnailUrl } : getCategoryAsset(category?.key);
+  const source = useRemote ? { uri: thumbnailUrl } : getCategoryAssetSource(category);
 
   return (
     <Pressable onPress={onPress} testID={cardTestID} style={styles.card}>

--- a/components/UI/SwipeImage.js
+++ b/components/UI/SwipeImage.js
@@ -7,7 +7,7 @@ import SwipeableCard from './SwipeableCard';
 import LoadingOverlay from './LoadingOverlay';
 import useBadgeDetail from './useBadgeDetail';
 
-import { getE2EHiddenGuessCard, getLocalImages, getLastImageId, removeImageFromList, deleteImageFromStorage } from '../../utils/storageDatum';
+import { PUBLIC_FEED_END_CURSOR, getE2EHiddenGuessCard, getLocalImages, getLastImageId, getLastImageUuid, removeImageFromList, deleteImageFromStorage } from '../../utils/storageDatum';
 import { AuthContext } from '../../store/auth-context';
 import { buildE2EGuessCardFromPayload, buildE2EGuessCards, isE2EMode } from '../../utils/e2eMode';
 import { GlobalStyle } from '../../constants/theme';
@@ -187,7 +187,8 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
           return;
         }
       }
-      await handleImagesLoading(null);
+      const lastCursor = await getLastImageUuid(categoryKey, lang);
+      await handleImagesLoading(lastCursor === PUBLIC_FEED_END_CURSOR ? undefined : null);
     } else {
       setImageList(localImageList);
       await handleImagesLoading();

--- a/components/UI/SwipeImage.js
+++ b/components/UI/SwipeImage.js
@@ -7,12 +7,14 @@ import SwipeableCard from './SwipeableCard';
 import LoadingOverlay from './LoadingOverlay';
 import useBadgeDetail from './useBadgeDetail';
 
-import { getE2EHiddenGuessCard, getLocalImages, getLastImageId, emptyImageList, removeImageFromList, updateImageList, saveLastImageUuid, deleteImageFromStorage } from '../../utils/storageDatum';
+import { getE2EHiddenGuessCard, getLocalImages, getLastImageId, removeImageFromList, deleteImageFromStorage } from '../../utils/storageDatum';
 import { AuthContext } from '../../store/auth-context';
 import { buildE2EGuessCardFromPayload, buildE2EGuessCards, isE2EMode } from '../../utils/e2eMode';
 import { GlobalStyle } from '../../constants/theme';
 import { readGroupFeedCache, writeGroupFeedCache } from '../../services/groups/groupFeedCache';
-import { fetchCardBatch, persistCardBatch } from '../../services/cardDeck';
+import { fetchCardBatch, persistCardBatch, appendCardBatch } from '../../services/cardDeck';
+import { prefetchIfLow, warmAllDeckIfNeeded } from '../../services/cardPrefetcher';
+import { RECENT_ALL_CATEGORY } from '../../constants/categories';
 /* https://snack.expo.dev/embedded/@aboutreact/tinder-like-swipeable-card-example?preview=true&platform=ios&iframeId=0kofaqg0vl&theme=dark */
 
 export default function SwipeImage({ screenWidth, screenHeight, startGuessing, category, language, onOpenFilter, scope }) {
@@ -25,6 +27,8 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
   const [imageList, setImageList] = useState(null);
   const [asyncImagesAreLoading, setAsyncImagesAreLoading] = useState(false);
   const [noMoreCard, setNoMoreCard] = useState(null);
+  const [activeCategoryKey, setActiveCategoryKey] = useState(categoryKey);
+  const [activeCategory, setActiveCategory] = useState(category);
 
   const context = useContext(AuthContext);
   const { detailImage, detailTags, detailRating, detailVisible, openDetail, closeDetail } = useBadgeDetail(context);
@@ -35,7 +39,10 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
   const asyncImagesAreLoadingRef = useRef(false);
   asyncImagesAreLoadingRef.current = asyncImagesAreLoading;
 
-  const allDeckWarmedRef = useRef(false);
+  const activeCategoryKeyRef = useRef(categoryKey);
+  activeCategoryKeyRef.current = activeCategoryKey;
+  const activeCategoryRef = useRef(category);
+  activeCategoryRef.current = activeCategory;
 
   // Functions __________________________________________________________________
 
@@ -48,10 +55,12 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
   const handleData = useCallback(async (data) => {
     console.log("handleData");
 
+    const aKey = activeCategoryKeyRef.current;
+    const aCat = activeCategoryRef.current;
     const currentImageList = imageListRef.current;
     const lastId = currentImageList?.length
       ? currentImageList.reduce((maxId, image) => Math.max(maxId, image?.listId ?? 0), 0)
-      : await getLastImageId(categoryKey, lang);
+      : await getLastImageId(aKey, lang);
     // This is done to add a unique identifier to each object in 'data', which will be used to keep track of the order in which images are displayed.
     const updatedImageList = data?.map((image, index) => ({
      ...image,
@@ -62,8 +71,8 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       console.log("updatedImageList handleData imageList null");
       await persistCardBatch({
         cards: updatedImageList,
-        categoryKey,
-        categoryId: category?.id,
+        categoryKey: aKey,
+        categoryId: aCat?.id,
         language: lang,
         scope,
       });
@@ -82,32 +91,27 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       console.log("updatedImageList handleData imageList !== null");
 
       if (updatedImageList?.length > 0) {
-        let newImageList;
-        if (isPrivateScope) {
-          newImageList = [...currentImageList, ...updatedImageList];
-          await persistCardBatch({
-            cards: newImageList,
-            categoryKey,
-            categoryId: category?.id,
-            language: lang,
-            scope,
-          });
-        } else {
-          newImageList = await updateImageList(updatedImageList, categoryKey, lang);
-        }
+        await appendCardBatch({
+          cards: updatedImageList,
+          categoryKey: aKey,
+          categoryId: aCat?.id,
+          language: lang,
+          scope,
+        });
+        const newImageList = [...currentImageList, ...updatedImageList];
         setImageList(newImageList);
-        return true
-      };
+        return true;
+      }
 
-      return false
+      return false;
     };
-  }, [category?.id, categoryKey, isPrivateScope, lang, scope]);
+  }, [lang, scope]);
 
   const loadNewImages = useCallback(async (pictureIdOverride) => {
     console.log("loadNewImages");
     const response = await fetchCardBatch({
-      categoryKey,
-      categoryId: category?.id,
+      categoryKey: activeCategoryKeyRef.current,
+      categoryId: activeCategoryRef.current?.id,
       language,
       scope,
       authContext: context,
@@ -123,7 +127,7 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       const isCardLeft = await handleData(response.images);
       return isCardLeft;
     };
-  }, [context, handleData, category, language, categoryKey]);
+  }, [context, handleData, language, scope]);
 
   /* centralized function for loading images / set when imgs are loading */
   const handleImagesLoading = useCallback(async (pictureIdOverride) => {
@@ -170,22 +174,95 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
     if (localImageList !== null && (localImageList?.length >= 4)) {
       setImageList(localImageList);
     } else if (localImageList === null || localImageList?.length === 0) {
+      // Category deck empty on mount — try 'all' fallback before blocking foreground load.
+      if (categoryKey !== 'all') {
+        await warmAllDeckIfNeeded({ language, scope, authContext: context }).catch(() => {});
+        const allDeck = isPrivateScope
+          ? (await readGroupFeedCache(privateGroupId, { categoryId: undefined, language: lang }))?.images ?? null
+          : await getLocalImages('all', lang);
+        if (allDeck && allDeck.length > 0) {
+          setActiveCategoryKey('all');
+          setActiveCategory(RECENT_ALL_CATEGORY);
+          setImageList(allDeck);
+          return;
+        }
+      }
       await handleImagesLoading(null);
     } else {
       setImageList(localImageList);
       await handleImagesLoading();
     };
-  }, [category?.id, categoryKey, handleImagesLoading, isPrivateScope, lang, privateGroupId]);
+  }, [category?.id, categoryKey, context, handleImagesLoading, isPrivateScope, lang, language, privateGroupId, scope]);
 
 
   const deleteImage = useCallback(async (id, imageFilePath) => {
     // delete image
     if (!isPrivateScope) {
-      await removeImageFromList(id, categoryKey, lang);
+      await removeImageFromList(id, activeCategoryKeyRef.current, lang);
     }
     await deleteImageFromStorage(imageFilePath);
     return null;
-  }, [categoryKey, isPrivateScope, lang]);
+  }, [isPrivateScope, lang]);
+
+  /*
+   * Deck-empty fallback. Prefers background-prefetched cards (re-read the active
+   * deck — the prefetcher may have appended to AsyncStorage since mount), then
+   * the warmed 'all' deck (awaiting any in-flight warm), then a foreground load
+   * as a last resort. Avoids the "Load new images..." overlay whenever the
+   * background prefetcher has done its job.
+   */
+  const refillOrFallback = useCallback(async (categoryPrefetchPromise) => {
+    const aKey = activeCategoryKeyRef.current;
+    const aCat = activeCategoryRef.current;
+
+    const readDeck = async (deckKey, deckCategory) => (
+      isPrivateScope
+        ? (await readGroupFeedCache(privateGroupId, { categoryId: deckCategory?.id === 'all' ? undefined : deckCategory?.id, language: lang }))?.images ?? []
+        : (await getLocalImages(deckKey, lang)) ?? []
+    );
+
+    // 1. Re-read the active deck — the background prefetcher may have appended
+    //    cards to AsyncStorage that local state hasn't picked up yet.
+    let catDeck = await readDeck(aKey, aCat);
+    if (catDeck.length > 0) {
+      setImageList(catDeck);
+      return;
+    }
+
+    // 2. Join any in-flight category prefetch (or start one at deck 0) before
+    //    declaring the category exhausted. This covers the last-card race where
+    //    the background top-up lands just after the first storage read.
+    await (categoryPrefetchPromise ?? prefetchIfLow({
+      categoryKey: aKey,
+      categoryId: aCat?.id,
+      language,
+      scope,
+      authContext: context,
+    }).catch(() => {}));
+
+    catDeck = await readDeck(aKey, aCat);
+    if (catDeck.length > 0) {
+      setImageList(catDeck);
+      return;
+    }
+
+    // 3. Active deck empty and not already on 'all' → fall back to the 'all' deck.
+    //    Await the warm so we don't bounce when the warm is mid-flight.
+    if (aKey !== 'all') {
+      await warmAllDeckIfNeeded({ language, scope, authContext: context }).catch(() => {});
+      const allDeck = await readDeck('all', RECENT_ALL_CATEGORY);
+      if (allDeck.length > 0) {
+        setActiveCategoryKey('all');
+        setActiveCategory(RECENT_ALL_CATEGORY);
+        setImageList(allDeck);
+        return;
+      }
+    }
+
+    // 4. Both empty — last-resort foreground load (will show the overlay, but
+    //    only when truly out of cards). Keep on the active category/scope.
+    await handleImagesLoading();
+  }, [context, handleImagesLoading, isPrivateScope, lang, language, privateGroupId, scope]);
 
   /*
    * Asynchronously removes a card from the image list based on the provided id.
@@ -198,6 +275,7 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       const currentList = imageListRef.current ?? [];
       const updatedImageList = currentList.filter((item) => item.listId !== id);
       const image = currentList.find((item) => item.listId === id);
+      const aCat = activeCategoryRef.current;
 
       if (image?.imageFile) {
         await deleteImage(id, image.imageFile);
@@ -206,29 +284,29 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       if (isPrivateScope) {
         await writeGroupFeedCache(
           privateGroupId,
-          { categoryId: category?.id === 'all' ? undefined : category?.id, language: lang },
+          { categoryId: aCat?.id === 'all' ? undefined : aCat?.id, language: lang },
           { images: updatedImageList, nextCursor: null },
         );
       }
 
-      if (updatedImageList?.length < 4 && !asyncImagesAreLoadingRef.current) {
-        await handleImagesLoading();
+      const prefetchPromise = prefetchIfLow({
+        categoryKey: activeCategoryKeyRef.current,
+        categoryId: aCat?.id,
+        language,
+        scope,
+        authContext: context,
+      }).catch(() => {});
+
+      // Deck-empty fallback: prefer background-prefetched cards, then 'all' deck,
+      // then a foreground load as last resort. Avoids the "Load new images..."
+      // blocking overlay whenever the background prefetcher has done its job.
+      if (updatedImageList?.length === 0 && !asyncImagesAreLoadingRef.current) {
+        await refillOrFallback(prefetchPromise);
       }
 
-      if (updatedImageList?.length < 4
-        && !asyncImagesAreLoadingRef.current
-        && !isE2EMode()
-        && !allDeckWarmedRef.current) {
-        allDeckWarmedRef.current = true;
-        fetchCardBatch({ categoryKey: 'all', language, scope, authContext: context })
-          .then((r) => (r && !r.isError && r.images?.length
-            ? persistCardBatch({ cards: r.images, categoryKey: 'all', language, scope })
-            : null))
-          .catch(() => {});
-      }
       return null;
     },
-    [category?.id, context, deleteImage, handleImagesLoading, isPrivateScope, lang, language, privateGroupId, scope]
+    [context, deleteImage, isPrivateScope, lang, language, privateGroupId, refillOrFallback, scope]
   );
 
   // Effects __________________________________________________________________

--- a/components/UI/SwipeImage.js
+++ b/components/UI/SwipeImage.js
@@ -17,6 +17,24 @@ import { prefetchIfLow, warmAllDeckIfNeeded } from '../../services/cardPrefetche
 import { RECENT_ALL_CATEGORY } from '../../constants/categories';
 /* https://snack.expo.dev/embedded/@aboutreact/tinder-like-swipeable-card-example?preview=true&platform=ios&iframeId=0kofaqg0vl&theme=dark */
 
+/**
+ * Guarantee every card has a finite, unique listId. Background-prefetched cards
+ * are persisted with listId === null (buildImageObject hardcodes it and the
+ * prefetcher bypasses handleData, the only path that assigns listIds). Loading
+ * those back would render multiple <SwipeableCard key={null}> (React "two
+ * children with the same key" warning) and would also break removeCard, which
+ * matches/removes by listId. Assign sequential ids continuing from the deck's
+ * current max so this is a stable no-op for already-healthy decks and a
+ * one-time self-heal for legacy null-listId cards.
+ */
+function normalizeListIds(cards) {
+  if (!Array.isArray(cards) || cards.length === 0) return cards;
+  const hasMissing = cards.some((c) => c?.listId == null || !Number.isFinite(c.listId));
+  if (!hasMissing) return cards;
+  let next = cards.reduce((max, c) => (Number.isFinite(c?.listId) && c.listId > max ? c.listId : max), 0);
+  return cards.map((c) => (Number.isFinite(c?.listId) ? c : { ...c, listId: (next += 1) }));
+}
+
 export default function SwipeImage({ screenWidth, screenHeight, startGuessing, category, language, onOpenFilter, scope }) {
 
   const categoryKey = category?.key || 'all';
@@ -172,21 +190,12 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
 
     // if localImageList [] or null, get Images() / show loadingOverlay
     if (localImageList !== null && (localImageList?.length >= 4)) {
-      setImageList(localImageList);
+      setImageList(normalizeListIds(localImageList));
     } else if (localImageList === null || localImageList?.length === 0) {
-      // Category deck empty on mount — try 'all' fallback before blocking foreground load.
-      if (categoryKey !== 'all') {
-        await warmAllDeckIfNeeded({ language, scope, authContext: context }).catch(() => {});
-        const allDeck = isPrivateScope
-          ? (await readGroupFeedCache(privateGroupId, { categoryId: undefined, language: lang }))?.images ?? null
-          : await getLocalImages('all', lang);
-        if (allDeck && allDeck.length > 0) {
-          setActiveCategoryKey('all');
-          setActiveCategory(RECENT_ALL_CATEGORY);
-          setImageList(allDeck);
-          return;
-        }
-      }
+      // Empty category deck on mount — cold-start the ACTIVE category. Do NOT
+      // cross-fall back to 'recent/all' here; that refill belongs to mid-play
+      // (refillOrFallback), once the user is actually swiping and the deck
+      // empties. Loading recent/all on a cold mount is the reported bug.
       const lastCursor = await getLastImageUuid(categoryKey, lang);
       await handleImagesLoading(lastCursor === PUBLIC_FEED_END_CURSOR ? undefined : null);
     } else {
@@ -216,10 +225,10 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
     const aKey = activeCategoryKeyRef.current;
     const aCat = activeCategoryRef.current;
 
-    const readDeck = async (deckKey, deckCategory) => (
+    const readDeck = async (deckKey, deckCategory) => normalizeListIds(
       isPrivateScope
         ? (await readGroupFeedCache(privateGroupId, { categoryId: deckCategory?.id === 'all' ? undefined : deckCategory?.id, language: lang }))?.images ?? []
-        : (await getLocalImages(deckKey, lang)) ?? []
+        : await getLocalImages(deckKey, lang) ?? [],
     );
 
     // 1. Re-read the active deck — the background prefetcher may have appended
@@ -398,7 +407,7 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
                 <>
                   {reversedImageList.map((item) => (
                     <SwipeableCard
-                      key={item.listId}
+                      key={item.listId ?? item.name}
                       item={item}
                       onBadgePress={openDetail}
                       removeCard={removeCard}

--- a/components/UI/SwipeImage.js
+++ b/components/UI/SwipeImage.js
@@ -7,7 +7,7 @@ import SwipeableCard from './SwipeableCard';
 import LoadingOverlay from './LoadingOverlay';
 import useBadgeDetail from './useBadgeDetail';
 
-import { PUBLIC_FEED_END_CURSOR, getE2EHiddenGuessCard, getLocalImages, getLastImageId, getLastImageUuid, removeImageFromList, deleteImageFromStorage } from '../../utils/storageDatum';
+import { getE2EHiddenGuessCard, getLocalImages, getLastImageId, removeImageFromList, deleteImageFromStorage } from '../../utils/storageDatum';
 import { AuthContext } from '../../store/auth-context';
 import { buildE2EGuessCardFromPayload, buildE2EGuessCards, isE2EMode } from '../../utils/e2eMode';
 import { GlobalStyle } from '../../constants/theme';
@@ -192,12 +192,12 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
     if (localImageList !== null && (localImageList?.length >= 4)) {
       setImageList(normalizeListIds(localImageList));
     } else if (localImageList === null || localImageList?.length === 0) {
-      // Empty category deck on mount — cold-start the ACTIVE category. Do NOT
-      // cross-fall back to 'recent/all' here; that refill belongs to mid-play
-      // (refillOrFallback), once the user is actually swiping and the deck
-      // empties. Loading recent/all on a cold mount is the reported bug.
-      const lastCursor = await getLastImageUuid(categoryKey, lang);
-      await handleImagesLoading(lastCursor === PUBLIC_FEED_END_CURSOR ? undefined : null);
+      // Empty category deck on mount — cold-start the ACTIVE category with a
+      // fresh server query (pictureId=null). Do NOT consult the stored cursor:
+      // it may be a stale exhausted marker, and we want new uploads to surface.
+      // Cross-fallback to 'recent/all' belongs to mid-play (refillOrFallback),
+      // once the user is actually swiping and the deck empties.
+      await handleImagesLoading(null);
     } else {
       setImageList(localImageList);
       await handleImagesLoading();

--- a/components/UI/TableComponent.js
+++ b/components/UI/TableComponent.js
@@ -5,6 +5,18 @@ import TableButton from './TableButton';
 import { GlobalStyle } from '../../constants/theme';
 import { usePrivateGroupTheme } from '../../store/privateGroupTheme-context';
 
+const COLUMNS = [
+  { header: 'Rank',       field: 'rank',      flex: 0.7, kind: 'rank' },
+  { header: 'Name',       field: 'name',      flex: 1.6, kind: 'name' },
+  { header: 'Score',      field: 'score',     flex: 1,   kind: 'score' },
+  { header: 'Max Streak', field: 'maxStreak', flex: 1,   kind: 'text' },
+  { header: 'Others',     field: 'others',    flex: 0.9, kind: 'button' },
+];
+
+function getColumnDescriptor(header) {
+  return COLUMNS.find((column) => column.header === header);
+}
+
 function buildRankingMetrics(width, height) {
   return {
     containerPaddingHorizontal: width * 0.04,
@@ -17,8 +29,6 @@ function buildRankingMetrics(width, height) {
     headerFontSize: height * 0.022,
 
     rowHeight: height * 0.07,
-
-    cellWidth: width * 0.23,
     cellHeight: height * 0.07,
 
     textMargin: width * 0.02,
@@ -44,36 +54,47 @@ function getRowBackground(rank) {
   return rank % 2 === 0 ? 'rgba(255, 255, 255, 0.04)' : 'transparent';
 }
 
-const RowItem = React.memo(function RowItem({ row, onPressMore, metrics, styles }) {
+function cellTextStyle(kind, styles, rankColor) {
+  if (kind === 'rank') return [styles.text, styles.big, { color: rankColor, fontWeight: 'bold' }];
+  if (kind === 'name') return [styles.text, styles.name];
+  if (kind === 'score') return [styles.text, styles.big, styles.score];
+  return [styles.text];
+}
+
+const RowItem = React.memo(function RowItem({ row, headers, onPressMore, metrics, styles }) {
   const rankColor = getRankColor(row.rank);
   const rowBackground = getRowBackground(row.rank);
   return (
     <View style={[styles.row, { backgroundColor: rowBackground }]} testID={`ranking.row.${row.rank}`}>
-      <View style={styles.cell}>
-        <Text style={[styles.text, styles.big, { color: rankColor, fontWeight: 'bold' }]} numberOfLines={1} testID={`ranking.row.${row.rank}.rank`}>
-          {row.rank}
-        </Text>
-      </View>
-      <View style={styles.cell}>
-        <Text style={[styles.text, styles.name]} numberOfLines={1} testID={`ranking.row.${row.rank}.name`}>
-          {row.name}
-        </Text>
-      </View>
-      <View style={styles.cell}>
-        <Text style={[styles.text, styles.big, styles.score]} numberOfLines={1} testID={`ranking.row.${row.rank}.score`}>
-          {row.score}
-        </Text>
-      </View>
-      <View style={styles.cell}>
-        <TableButton
-          accessibilityLabel={`Show more scores for ${row.name}`}
-          onPress={() => onPressMore(row.name)}
-          testID={`ranking.row.${row.rank}.more`}
-          buttonWidth={metrics.buttonWidth}
-          buttonHeight={metrics.buttonHeight}
-          buttonBorderRadius={metrics.buttonBorderRadius}
-        />
-      </View>
+      {headers.map((header, index) => {
+        const column = getColumnDescriptor(header);
+        const key = `${header}-${index}`;
+        if (column?.kind === 'button') {
+          return (
+            <View key={key} style={[styles.cell, { flex: column.flex }]}>
+              <TableButton
+                accessibilityLabel={`Show more scores for ${row.name}`}
+                onPress={() => onPressMore(row.name)}
+                testID={`ranking.row.${row.rank}.more`}
+                buttonWidth={metrics.buttonWidth}
+                buttonHeight={metrics.buttonHeight}
+                buttonBorderRadius={metrics.buttonBorderRadius}
+              />
+            </View>
+          );
+        }
+        return (
+          <View key={key} style={[styles.cell, { flex: column?.flex ?? 1 }]}>
+            <Text
+              style={cellTextStyle(column?.kind, styles, rankColor)}
+              numberOfLines={1}
+              testID={`ranking.row.${row.rank}.${column?.field ?? header}`}
+            >
+              {row[column?.field]}
+            </Text>
+          </View>
+        );
+      })}
     </View>
   );
 });
@@ -127,7 +148,6 @@ export default function TableComponent({ data, onPress, onEndReached }) {
       flexDirection: 'row',
     },
     cell: {
-      width: metrics.cellWidth,
       height: metrics.cellHeight,
       borderBottomWidth: 0.5,
       borderBottomColor: 'rgba(255, 255, 255, 0.08)',
@@ -157,22 +177,25 @@ export default function TableComponent({ data, onPress, onEndReached }) {
   const renderHeader = useCallback(() => {
     return (
       <View style={styles.head} testID="ranking.header">
-        {headers.map((header, index) => (
-          <View key={`${header}-${index}`} style={styles.cell}>
-            <Text style={[styles.text, styles.headText]} numberOfLines={1} testID={`ranking.header.${index}`}>
-              {header}
-            </Text>
-          </View>
-        ))}
+        {headers.map((header, index) => {
+          const column = getColumnDescriptor(header);
+          return (
+            <View key={`${header}-${index}`} style={[styles.cell, { flex: column?.flex ?? 1 }]}>
+              <Text style={[styles.text, styles.headText]} numberOfLines={1} testID={`ranking.header.${index}`}>
+                {header}
+              </Text>
+            </View>
+          );
+        })}
       </View>
     );
   }, [headers, styles]);
 
   const renderItem = useCallback(
     ({ item }) => {
-      return <RowItem row={item} onPressMore={onPressMore} metrics={metrics} styles={styles} />;
+      return <RowItem row={item} headers={headers} onPressMore={onPressMore} metrics={metrics} styles={styles} />;
     },
-    [onPressMore, metrics, styles]
+    [headers, onPressMore, metrics, styles]
   );
 
   return (

--- a/constants/ranking.js
+++ b/constants/ranking.js
@@ -1,3 +1,6 @@
+// Single source of truth for the leaderboard column contract.
+// RankingScreen slices a subset for the live header; TableComponent
+// maps each header to its cell descriptor (see COLUMNS).
 export const RANKING = {
-  tableHeaders: ["Rank", "Name", "Score", "Guess Score", "Guess Count", "Hide Score", "Hide Count"],
+  tableHeaders: ["Rank", "Name", "Score", "Max Streak", "Guess Score", "Guess Count", "Hide Score", "Hide Count"],
 };

--- a/constants/streakTiers.js
+++ b/constants/streakTiers.js
@@ -5,10 +5,10 @@
 
 export const STREAK_TIERS = [
   { tier: 5, threshold: 50, multiplier: 10.0, label: "Waldo's Nemesis", colorKey: 'white'  },
-  { tier: 4, threshold: 20, multiplier: 5.0,  label: 'Legendary',       colorKey: 'purple' },
-  { tier: 3, threshold: 12, multiplier: 3.0,  label: 'On Fire',         colorKey: 'red'    },
-  { tier: 2, threshold: 7,  multiplier: 2.0,  label: 'In the Zone',     colorKey: 'orange' },
-  { tier: 1, threshold: 3,  multiplier: 1.5,  label: 'Focused',         colorKey: 'blue'   },
+  { tier: 4, threshold: 20, multiplier: 7.0,  label: 'Legendary',       colorKey: 'purple' },
+  { tier: 3, threshold: 12, multiplier: 5.0,  label: 'On Fire',         colorKey: 'red'    },
+  { tier: 2, threshold: 7,  multiplier: 3.0,  label: 'In the Zone',     colorKey: 'orange' },
+  { tier: 1, threshold: 3,  multiplier: 2.0,  label: 'Focused',         colorKey: 'blue'   },
 ];
 
 export const NEUTRAL_TIER = { tier: 0, threshold: 0, multiplier: 1.0, label: '', colorKey: 'neutral' };

--- a/constants/streakTiers.js
+++ b/constants/streakTiers.js
@@ -1,0 +1,22 @@
+// Streak Tier Policy: longer correct-find streaks unlock higher score multipliers and display tiers.
+// Tier table: thresholds 3/7/12/20/50 -> multipliers 1.5/2.0/3.0/5.0/10.0 (highest threshold first).
+// Add a tier by appending one object to STREAK_TIERS (OCP); keep highest threshold first.
+// Contract: input streak >= 0 (clamped); output always { tier>=0, multiplier>=1.0, label, colorKey }.
+
+export const STREAK_TIERS = [
+  { tier: 5, threshold: 50, multiplier: 10.0, label: "Waldo's Nemesis", colorKey: 'white'  },
+  { tier: 4, threshold: 20, multiplier: 5.0,  label: 'Legendary',       colorKey: 'purple' },
+  { tier: 3, threshold: 12, multiplier: 3.0,  label: 'On Fire',         colorKey: 'red'    },
+  { tier: 2, threshold: 7,  multiplier: 2.0,  label: 'In the Zone',     colorKey: 'orange' },
+  { tier: 1, threshold: 3,  multiplier: 1.5,  label: 'Focused',         colorKey: 'blue'   },
+];
+
+export const NEUTRAL_TIER = { tier: 0, threshold: 0, multiplier: 1.0, label: '', colorKey: 'neutral' };
+
+export const STREAK_MULTIPLIER_BASE = NEUTRAL_TIER.multiplier;
+
+export function resolveStreakTier(streak) {
+  const s = Math.max(0, Math.floor(Number(streak) || 0));
+  const match = STREAK_TIERS.find(t => s >= t.threshold);
+  return match ?? NEUTRAL_TIER;
+}

--- a/constants/theme.js
+++ b/constants/theme.js
@@ -46,6 +46,17 @@ export const GlobalStyle = {
     warning: '#FFCC00',
     info: '#17a2b8',
     win: '#FFD700',
+    danger: '#FF3B30',
+    onSurface: '#FFFFFF',
+    // streak hex values mirror sibling tokens above (DIP fallback: GlobalStyle is in TDZ while its initializer evaluates).
+    streak: {
+      neutral: '#7895CB',
+      blue:    '#17a2b8',
+      orange:  '#f37c13',
+      red:     '#FF3B30',
+      purple:  '#6528F7',
+      white:   '#FFFFFF',
+    },
   },
 };
 

--- a/hooks/useGroupsHub.js
+++ b/hooks/useGroupsHub.js
@@ -2,7 +2,7 @@ import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { fetchGroups } from '../services/groups/groupApi';
 import { AuthContext } from '../store/auth-context';
 
-export function useGroupsHub() {
+export function useGroupsHub({ enabled = true } = {}) {
   const { token, userId } = useContext(AuthContext);
   const [data, setData] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -16,9 +16,10 @@ export function useGroupsHub() {
   }, []);
 
   const refresh = useCallback(async () => {
-    if (!token || !userId) {
+    if (!enabled || !token || !userId) {
       if (mounted.current) {
         setData(null);
+        setError(null);
         setIsLoading(false);
       }
       return;
@@ -40,7 +41,7 @@ export function useGroupsHub() {
     }
 
     if (mounted.current) setIsLoading(false);
-  }, [token, userId]);
+  }, [enabled, token, userId]);
 
   useEffect(() => {
     refresh();

--- a/hooks/useStreak.js
+++ b/hooks/useStreak.js
@@ -1,0 +1,14 @@
+import { useCallback, useState } from 'react';
+
+import { resolveStreakTier } from '../constants/streakTiers';
+
+// useStreak: tracks consecutive wins for the current sitting.
+// Pure state machine — no UI, no network, no tier table literal (DIP via constants/streakTiers).
+export function useStreak(initial = 0) {
+  const [streak, setStreak] = useState(initial);
+  const onWin = useCallback(() => setStreak(s => s + 1), []);
+  const onLose = useCallback(() => setStreak(0), []);
+  const reset = useCallback(() => setStreak(0), []);
+  const tier = resolveStreakTier(streak);
+  return { streak, tier, multiplier: tier.multiplier, onWin, onLose, reset };
+}

--- a/screens/GuessScreens/GuessPathScreen.js
+++ b/screens/GuessScreens/GuessPathScreen.js
@@ -21,6 +21,7 @@ import CenteredModal from '../../components/UI/CenteredModal';
 import { LANGUAGES } from '../../constants/languages';
 import { getCategories } from '../../utils/categoryRequests';
 import {
+  getPreferredLanguage,
   getSessionLanguageFilter,
   saveSessionLanguageFilter,
 } from '../../utils/storageDatum';
@@ -123,11 +124,14 @@ export default function GuessPathScreen({ navigation, route }) {
     let cancelled = false;
 
     async function loadLanguage() {
-      const stored = await getSessionLanguageFilter();
+      const [stored, preferred] = await Promise.all([
+        getSessionLanguageFilter(),
+        getPreferredLanguage(),
+      ]);
       if (cancelled) {
         return;
       }
-      setSessionLanguage(stored);
+      setSessionLanguage(stored ?? preferred ?? null);
     }
 
     loadLanguage();

--- a/screens/GuessScreens/GuessPathScreen.js
+++ b/screens/GuessScreens/GuessPathScreen.js
@@ -49,7 +49,6 @@ const NAVIGATION_ANY_LANGUAGE = 'any';
 
 export default function GuessPathScreen({ navigation, route }) {
   const context = useContext(AuthContext);
-  const { data: groupsHubData } = useGroupsHub();
   const [categories, setCategories] = useState([]);
   const [sessionLanguage, setSessionLanguage] = useState(null);
   const [isFilterModalVisible, setIsFilterModalVisible] = useState(false);
@@ -67,6 +66,7 @@ export default function GuessPathScreen({ navigation, route }) {
   const { scope: activeScope } = useActiveGroup();
   const scope = routeScope ?? activeScope;
   const isPrivateScope = scope?.kind === 'private' && !!scope?.groupId;
+  const { data: groupsHubData } = useGroupsHub({ enabled: isPrivateScope });
   const isOwner = isPrivateScope && (groupsHubData?.owned ?? []).some(
     (g) => g.id === scope.groupId
   );

--- a/screens/GuessScreens/GuessScreen.js
+++ b/screens/GuessScreens/GuessScreen.js
@@ -11,6 +11,7 @@ import { isOnTarget } from "../../utils/targetLocation";
 import { applySuccessSideEffects, resolveNextGuessParams } from '../../utils/handleGuessOutcome';
 import { navigateToNextGuess } from '../../utils/guessNavigation';
 import { isE2EMode } from '../../utils/e2eMode';
+import { prefetchIfLow, warmAllDeckIfNeeded } from '../../services/cardPrefetcher';
 import { computeMultiplier, isSpeedBonus, SPEED_MULTIPLIER_BASE } from '../../utils/speedMultiplier';
 import { useStreak } from '../../hooks/useStreak';
 import { resolveStreakTier } from '../../constants/streakTiers';
@@ -29,7 +30,8 @@ export default function GuessScreen({ navigation, route }) {
   const [hintsActive, setHintsActive] = useState(!isE2EMode());
   const dismissHints = useCallback(() => setHintsActive(false), []);
 
-  const { userId } = useContext(AuthContext);
+  const authContext = useContext(AuthContext);
+  const { userId } = authContext;
 
   const { group, theme } = useScopedPrivateGroupTheme(scope);
 
@@ -40,6 +42,20 @@ export default function GuessScreen({ navigation, route }) {
       headerTintColor: theme.headerTintColor,
     });
   }, [navigation, theme?.primaryColor, theme?.headerTintColor]);
+
+  // Eagerly warm the 'all' deck on entering a real-category streak so the
+  // category→all fallback is instant when the category exhausts. Fire-and-forget;
+  // the prefetcher dedupes + shares the in-flight promise across this and the
+  // per-win prefetch. No-op for 'all' itself (no fallback needed) and in e2e.
+  useEffect(() => {
+    if (category?.key === 'all') return;
+    warmAllDeckIfNeeded({
+      language,
+      scope,
+      authContext,
+    }).catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only warm
+  }, []);
 
   const screenWidth = Dimensions.get('window').width;
   const screenHeight = Dimensions.get('window').height;
@@ -83,6 +99,16 @@ export default function GuessScreen({ navigation, route }) {
       onWin();
       const finalPoints = Math.round(1 * multiplier * nextTier.multiplier);
       await applySuccessSideEffects({ listId, categoryKey: category?.key, language, imageFile: uri, pictureId, scope, userId, points: finalPoints, multiplier, streak: nextStreak, streakMultiplier: nextTier.multiplier });
+      // Background prefetch (fire-and-forget). Keeps the deck warm for long streaks
+      // without blocking the success animation or the setParams advance. Dedup +
+      // warm-all handled by the prefetcher module (SRP).
+      prefetchIfLow({
+        categoryKey: category?.key || 'all',
+        categoryId: category?.id,
+        language,
+        scope,
+        authContext,
+      }).catch(() => {});
       setSuccessMultiplier(multiplier);
       setShowSuccess(true);
       return;
@@ -93,7 +119,18 @@ export default function GuessScreen({ navigation, route }) {
   };
 
   async function handleOverlayDone() {
-    const next = await resolveNextGuessParams({ category, language, currentListId: listId, isTutorial, scope });
+    let next = await resolveNextGuessParams({ category, language, currentListId: listId, isTutorial, scope });
+
+    // Streak-preservation: if the deck exhausted while in a real category, the
+    // 'all' fallback inside resolveNextCard may have found an empty 'all' deck
+    // because the background warm hasn't completed yet. Wait for the warm, then
+    // retry once. Only bounce to the feed if 'all' is truly empty. No-op for
+    // 'all' itself (no warmer deck to fall back to).
+    if (!next && category?.key !== 'all') {
+      await warmAllDeckIfNeeded({ language, scope, authContext }).catch(() => {});
+      next = await resolveNextGuessParams({ category, language, currentListId: listId, isTutorial, scope });
+    }
+
     setShowSuccess(false);
     if (!next) {
       navigateToNextGuess(navigation, { category, language, currentListId: listId, isTutorial, scope: isPrivate ? scope : undefined });

--- a/screens/GuessScreens/GuessScreen.js
+++ b/screens/GuessScreens/GuessScreen.js
@@ -11,7 +11,9 @@ import { isOnTarget } from "../../utils/targetLocation";
 import { applySuccessSideEffects, resolveNextGuessParams } from '../../utils/handleGuessOutcome';
 import { navigateToNextGuess } from '../../utils/guessNavigation';
 import { isE2EMode } from '../../utils/e2eMode';
-import { computeMultiplier, isSpeedBonus, computeSpeedPoints, SPEED_MULTIPLIER_BASE } from '../../utils/speedMultiplier';
+import { computeMultiplier, isSpeedBonus, SPEED_MULTIPLIER_BASE } from '../../utils/speedMultiplier';
+import { useStreak } from '../../hooks/useStreak';
+import { resolveStreakTier } from '../../constants/streakTiers';
 
 export default function GuessScreen({ navigation, route }) {
 
@@ -20,6 +22,7 @@ export default function GuessScreen({ navigation, route }) {
 
   const [showSuccess, setShowSuccess] = useState(false);
   const [successMultiplier, setSuccessMultiplier] = useState(SPEED_MULTIPLIER_BASE);
+  const { streak, tier, multiplier: streakMultiplier, onWin, onLose, reset } = useStreak();
   // Hints show on the first card of each game series (every fresh mount of
   // GuessScreen). Advancing to later cards uses setParams (no remount), so the
   // dismissed state persists for the rest of the series. Suppressed in e2e mode.
@@ -75,12 +78,17 @@ export default function GuessScreen({ navigation, route }) {
     };
 
     if (onTarget) {
-      await applySuccessSideEffects({ listId, categoryKey: category?.key, language, imageFile: uri, pictureId, scope, userId, points: computeSpeedPoints(1, multiplier), multiplier });
+      const nextStreak = streak + 1;
+      const nextTier = resolveStreakTier(nextStreak);
+      onWin();
+      const finalPoints = Math.round(1 * multiplier * nextTier.multiplier);
+      await applySuccessSideEffects({ listId, categoryKey: category?.key, language, imageFile: uri, pictureId, scope, userId, points: finalPoints, multiplier, streak: nextStreak, streakMultiplier: nextTier.multiplier });
       setSuccessMultiplier(multiplier);
       setShowSuccess(true);
       return;
     }
 
+    onLose();
     navigation.replace('ResultScreen', sharedParams);
   };
 
@@ -120,7 +128,7 @@ export default function GuessScreen({ navigation, route }) {
       pulseTarget={hintsActive}
       onInteract={dismissHints}
     />
-    <SuccessOverlay visible={showSuccess} multiplier={successMultiplier} points={computeSpeedPoints(1, successMultiplier)} onDone={handleOverlayDone} />
+    <SuccessOverlay visible={showSuccess} multiplier={successMultiplier} points={Math.round(1 * successMultiplier * streakMultiplier)} streakTier={tier} onDone={handleOverlayDone} />
     {
       isTutorial && 
         <TutorialOverlay

--- a/screens/RankingScreen.js
+++ b/screens/RankingScreen.js
@@ -35,7 +35,7 @@ export default function RankingScreen({ route, navigation }) {
   const displayRows = slices.flat();
 
   const rankingDatum = displayRows.length > 0 ? {
-    tableHeaders: tableHeaders.slice(0, 3).concat(["Others"]),
+    tableHeaders: tableHeaders.slice(0, 4).concat(["Others"]),
     tableScores: displayRows,
   } : null;
 
@@ -108,6 +108,7 @@ export default function RankingScreen({ route, navigation }) {
       rank: Number(row.rank),
       name: row.username,
       score: row.total_score,
+      maxStreak: Number(row.max_streak || 0),
       others: "",
       userId: row.user_id,
     }));
@@ -142,6 +143,7 @@ export default function RankingScreen({ route, navigation }) {
       rank: baseRank + index + 1,
       name: row.username,
       score: row.total_score || row.totalScore,
+      maxStreak: Number(row.max_streak || 0),
       others: "",
       userId: row.user_id,
     }));

--- a/screens/SetInstructionScreen.js
+++ b/screens/SetInstructionScreen.js
@@ -43,7 +43,9 @@ export default function SetInstructionsScreen({ navigation, route }) {
   const [categories, setCategories] = useState([]);
   const [categoriesError, setCategoriesError] = useState(null);
   const [selectedCategory, setSelectedCategory] = useState(null);
-  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions();
+  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions({
+    granularPermissions: ['photo'],
+  });
   const [isLoading, setIsLoading] = useState(false);
   const isSubmittingRef = useRef(false);
   const languageTouchedRef = useRef(false);
@@ -146,7 +148,7 @@ export default function SetInstructionsScreen({ navigation, route }) {
       currentPermission = await requestPermission();
     };
     if (!currentPermission?.canAskAgain || currentPermission?.status === "denied") {
-      Alert.alert("Insufficient Permissions", 'Access to  Photos and Videos / audio is denied');
+      Alert.alert("Insufficient Permissions", 'Access to  Photos and Videos is denied');
       Linking.openSettings();
     } else {
       if (currentPermission?.status === "granted") {

--- a/screens/SetInstructionScreen.js
+++ b/screens/SetInstructionScreen.js
@@ -23,7 +23,7 @@ import LoadingOverlay from '../components/UI/LoadingOverlay';
 import { checkSecureStoreItem } from '../utils/auth';
 import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../store/privateGroupTheme-context';
 
-const NON_UPLOAD_CATEGORY_KEYS = new Set(['all', 'other']);
+const NON_UPLOAD_CATEGORY_KEYS = new Set(['all']);
 const DEFAULT_CATEGORY_LOAD_ERROR_MESSAGE = 'Unable to load categories. Please try again.';
 
 function isUploadableCategoryKey(categoryKey) {

--- a/services/cardDeck.js
+++ b/services/cardDeck.js
@@ -1,6 +1,6 @@
 import { getImages } from '../utils/imagesRequests';
-import { getLastImageUuid, storeImageList } from '../utils/storageDatum';
-import { writeGroupFeedCache } from './groups/groupFeedCache';
+import { getLastImageUuid, storeImageList, updateImageList } from '../utils/storageDatum';
+import { readGroupFeedCache, writeGroupFeedCache } from './groups/groupFeedCache';
 
 function normalizeLanguage(language) {
   return language || 'any';
@@ -40,5 +40,33 @@ export async function persistCardBatch({ cards, categoryKey, categoryId, languag
   }
 
   await storeImageList(cards, categoryKey, lang);
+  return null;
+}
+
+/**
+ * Append a card batch to the persisted deck (scope-aware). Mirrors persistCardBatch
+ * scope branching but appends instead of overwriting. Used by background prefetch
+ * (cardPrefetcher) to grow the deck without losing existing cards.
+ * - Public scope: reuses updateImageList (already appends to AsyncStorage).
+ * - Private scope: reads the group feed cache, concatenates, writes back.
+ * Returns null (matches persistCardBatch return contract).
+ */
+export async function appendCardBatch({ cards, categoryKey, categoryId, language, scope } = {}) {
+  const lang = normalizeLanguage(language);
+
+  if (isPrivateScope(scope)) {
+    const cid = resolveCategoryId(categoryId);
+    const existing = await readGroupFeedCache(scope.groupId, { categoryId: cid, language: lang });
+    const prior = existing?.images ?? [];
+    const merged = [...prior, ...cards];
+    await writeGroupFeedCache(
+      scope.groupId,
+      { categoryId: cid, language: lang },
+      { images: merged, nextCursor: existing?.nextCursor ?? null },
+    );
+    return null;
+  }
+
+  await updateImageList(cards, categoryKey, lang);
   return null;
 }

--- a/services/cardDeck.js
+++ b/services/cardDeck.js
@@ -1,5 +1,5 @@
 import { getImages } from '../utils/imagesRequests';
-import { getLastImageUuid, storeImageList, updateImageList } from '../utils/storageDatum';
+import { PUBLIC_FEED_END_CURSOR, getLastImageUuid, storeImageList, updateImageList } from '../utils/storageDatum';
 import { readGroupFeedCache, writeGroupFeedCache } from './groups/groupFeedCache';
 
 function normalizeLanguage(language) {
@@ -18,6 +18,10 @@ export async function fetchCardBatch({ categoryKey, categoryId, language, scope,
   const lang = normalizeLanguage(language);
   const lastImageUuid = await getLastImageUuid(categoryKey, lang);
   const pictureId = pictureIdOverride !== undefined ? pictureIdOverride : lastImageUuid;
+
+  if (!isPrivateScope(scope) && pictureId === PUBLIC_FEED_END_CURSOR) {
+    return { isError: false, images: [] };
+  }
 
   return getImages(pictureId, authContext, {
     category_id: resolveCategoryId(categoryId),

--- a/services/cardDeck.js
+++ b/services/cardDeck.js
@@ -6,6 +6,18 @@ function normalizeLanguage(language) {
   return language || 'any';
 }
 
+/**
+ * Server-side language filter. AsyncStorage uses 'any' as the canonical
+ * "no language filter" namespace (see normalizeLanguage), but the backend's
+ * Image.batch_with_existing_storage applies WHERE language = params[:language]
+ * verbatim — and no image row has language='any'. So 'any' must be stripped at
+ * the server boundary, or every card query under a no-filter session returns
+ * empty. Real codes ('en', 'fr', …) pass through untouched.
+ */
+function resolveServerLanguage(language) {
+  return language && language !== 'any' ? language : undefined;
+}
+
 function resolveCategoryId(categoryId) {
   return categoryId === 'all' ? undefined : categoryId;
 }
@@ -19,14 +31,18 @@ export async function fetchCardBatch({ categoryKey, categoryId, language, scope,
   const lastImageUuid = await getLastImageUuid(categoryKey, lang);
   const pictureId = pictureIdOverride !== undefined ? pictureIdOverride : lastImageUuid;
 
-  if (!isPrivateScope(scope) && pictureId === PUBLIC_FEED_END_CURSOR) {
-    return { isError: false, images: [] };
-  }
+  // Legacy self-heal: prior app versions persisted PUBLIC_FEED_END_CURSOR to
+  // mark a category exhausted. The cold-mount path now bypasses the cursor
+  // (always passes null), but refillOrFallback's foreground load and the
+  // background prefetcher still call fetchCardBatch with no override. Treat
+  // the stale sentinel as a fresh cursor so those paths also re-query from
+  // head; the next non-empty batch overwrites the stale key with a real uuid.
+  const effectivePictureId = pictureId === PUBLIC_FEED_END_CURSOR ? null : pictureId;
 
-  return getImages(pictureId, authContext, {
+  return getImages(effectivePictureId, authContext, {
     category_id: resolveCategoryId(categoryId),
     category_key: categoryKey || 'all',
-    language,
+    language: resolveServerLanguage(language),
     scope,
   });
 }

--- a/services/cardPrefetcher.ts
+++ b/services/cardPrefetcher.ts
@@ -1,0 +1,178 @@
+import { fetchCardBatch, appendCardBatch } from './cardDeck';
+import { getDeckCountForScope } from '../utils/storageDatum';
+import { isE2EMode } from '../utils/e2eMode';
+
+export const LOW_CARD_THRESHOLD = 5;
+export const ALL_WARM_THRESHOLD = 5;
+
+export interface PrefetchParams {
+  categoryKey: string;
+  categoryId?: string | number | null;
+  language?: string | null;
+  scope?: unknown;
+  authContext: unknown;
+}
+
+export type WarmAllParams = Omit<PrefetchParams, 'categoryKey' | 'categoryId'>;
+
+const inFlight = new Map<string, Promise<void>>();
+const allWarming = new Map<string, Promise<void>>();
+
+function scopeGroupId(scope: unknown): string | undefined {
+  if (scope && typeof scope === 'object' && 'groupId' in scope) {
+    const gid = (scope as { groupId?: unknown }).groupId;
+    return typeof gid === 'string' ? gid : undefined;
+  }
+  return undefined;
+}
+
+function dedupKey(categoryKey: string, language: string | null | undefined, scope: unknown): string {
+  return `${categoryKey}:${language ?? 'any'}:${scopeGroupId(scope) ?? 'public'}`;
+}
+
+function warmKey(language: string | null | undefined, scope: unknown): string {
+  return `${language ?? 'any'}:${scopeGroupId(scope) ?? 'public'}`;
+}
+
+export async function prefetchIfLow({
+  categoryKey,
+  categoryId,
+  language,
+  scope,
+  authContext,
+}: PrefetchParams): Promise<void> {
+  if (isE2EMode()) {
+    return;
+  }
+
+  const dk = dedupKey(categoryKey, language, scope);
+  const existing = inFlight.get(dk);
+  if (existing) {
+    return existing;
+  }
+
+  const count = await getDeckCountForScope({
+    category: {
+      key: categoryKey,
+      ...(categoryId != null ? { id: categoryId } : {}),
+    },
+    language,
+    scope,
+  });
+
+  if (count >= LOW_CARD_THRESHOLD) {
+    return;
+  }
+
+  const raced = inFlight.get(dk);
+  if (raced) {
+    return raced;
+  }
+
+  const p = (async () => {
+    try {
+      const r = await fetchCardBatch({
+        categoryKey,
+        categoryId,
+        language,
+        scope,
+        authContext,
+      });
+      if (r && !r.isError && r.images?.length) {
+        await appendCardBatch({
+          cards: r.images,
+          categoryKey,
+          categoryId,
+          language,
+          scope,
+        });
+      }
+    } catch (e) {
+      if (__DEV__) {
+        console.warn('[cardPrefetcher] prefetch failed', dk, e);
+      }
+    }
+  })();
+
+  inFlight.set(dk, p);
+  p.finally(() => {
+    if (inFlight.get(dk) === p) {
+      inFlight.delete(dk);
+    }
+  });
+
+  if (categoryKey !== 'all' && count < ALL_WARM_THRESHOLD) {
+    warmAllDeckIfNeeded({ language, scope, authContext });
+  }
+
+  return p;
+}
+
+/**
+ * Warm the 'all' deck in the background. Concurrent callers share the in-flight
+ * promise, and callers re-check the persisted 'all' deck on each attempt so a
+ * drained fallback deck can be warmed again later in the session.
+ */
+export async function warmAllDeckIfNeeded({
+  language,
+  scope,
+  authContext,
+}: WarmAllParams): Promise<void> {
+  if (isE2EMode()) {
+    return;
+  }
+
+  const wk = warmKey(language, scope);
+  const existing = allWarming.get(wk);
+  if (existing) {
+    return existing;
+  }
+
+  const count = await getDeckCountForScope({
+    category: { key: 'all' },
+    language,
+    scope,
+  });
+  if (count > 0) {
+    return;
+  }
+
+  const raced = allWarming.get(wk);
+  if (raced) {
+    return raced;
+  }
+
+  const p = (async () => {
+    try {
+      const r = await fetchCardBatch({
+        categoryKey: 'all',
+        language,
+        scope,
+        authContext,
+        pictureIdOverride: null,
+      });
+      if (r && !r.isError && r.images?.length) {
+        await appendCardBatch({
+          cards: r.images,
+          categoryKey: 'all',
+          language,
+          scope,
+        });
+      }
+    } catch (e) {
+      if (__DEV__) {
+        console.warn('[cardPrefetcher] warm-all failed', wk, e);
+      }
+    } finally {
+      allWarming.delete(wk);
+    }
+  })();
+
+  allWarming.set(wk, p);
+  return p;
+}
+
+export function __resetForTests(): void {
+  inFlight.clear();
+  allWarming.clear();
+}

--- a/store/privateGroupTheme-context.js
+++ b/store/privateGroupTheme-context.js
@@ -39,9 +39,9 @@ export function useGroupSurfaceColor() {
 
 export function useScopedPrivateGroupTheme(routeScopeOverride) {
   const { scope: activeScope } = useActiveGroup();
-  const { data } = useGroupsHub();
   const scope = routeScopeOverride ?? activeScope;
   const isPrivate = !!(scope?.kind === 'private' && scope?.groupId);
+  const { data } = useGroupsHub({ enabled: isPrivate });
   const group = useMemo(() => {
     if (!isPrivate) return null;
     const all = [...(data?.owned ?? []), ...(data?.joined ?? [])];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": {},
+  "extends": "expo/tsconfig.base"
+}

--- a/utils/categoryAssets.js
+++ b/utils/categoryAssets.js
@@ -11,8 +11,43 @@ const CATEGORY_ASSETS = {
   abstract: require('../assets/categories/abstract-image-cat.webp'),
 };
 
+const CATEGORY_NAME_TO_ASSET_KEY = {
+  all: 'all',
+  'recent/all': 'all',
+  other: 'other',
+  nature: 'nature',
+  city: 'city',
+  animals: 'animals',
+  food: 'food',
+  vehicles: 'vehicles',
+  interiors: 'interiors',
+  landmarks: 'landmarks',
+  abstract: 'abstract',
+};
+
+function normalizeAssetLookupToken(value) {
+  return typeof value === 'string'
+    ? value.trim().toLowerCase().replace(/\s*\/\s*/g, '/').replace(/\s+/g, ' ')
+    : null;
+}
+
 export function getCategoryAsset(key) {
   return CATEGORY_ASSETS[key];
+}
+
+export function resolveCategoryAssetKey(category) {
+  const explicitKey = normalizeAssetLookupToken(category?.key);
+  if (explicitKey && CATEGORY_ASSETS[explicitKey]) {
+    return explicitKey;
+  }
+
+  const normalizedName = normalizeAssetLookupToken(category?.name);
+  return normalizedName ? CATEGORY_NAME_TO_ASSET_KEY[normalizedName] : undefined;
+}
+
+export function getCategoryAssetSource(category) {
+  const assetKey = resolveCategoryAssetKey(category);
+  return assetKey ? CATEGORY_ASSETS[assetKey] : undefined;
 }
 
 export { CATEGORY_ASSETS };

--- a/utils/handleGuessOutcome.js
+++ b/utils/handleGuessOutcome.js
@@ -3,7 +3,7 @@ import { removeImageFromList, deleteImageFromStorage } from './storageDatum';
 import { resolveNextCard } from './nextCardResolver';
 import { SPEED_MULTIPLIER_BASE } from './speedMultiplier';
 
-export async function applySuccessSideEffects({ listId, categoryKey, language, imageFile, pictureId, scope, userId, points = SPEED_MULTIPLIER_BASE, multiplier }) {
+export async function applySuccessSideEffects({ listId, categoryKey, language, imageFile, pictureId, scope, userId, points = SPEED_MULTIPLIER_BASE, multiplier, streak = 0, streakMultiplier }) {
   await bufferScore({
     guessId: mintGuessId(),
     imageName: pictureId,
@@ -12,6 +12,8 @@ export async function applySuccessSideEffects({ listId, categoryKey, language, i
     scope,
     points,
     ...(multiplier !== undefined ? { multiplier } : {}),
+    streak,
+    ...(streakMultiplier !== undefined ? { streakMultiplier } : {}),
     ts: Date.now(),
     userId,
   });

--- a/utils/imagesRequests.js
+++ b/utils/imagesRequests.js
@@ -4,7 +4,7 @@ import Image from "../models/image";
 import { setHeaders, getBackendHeaders } from "./auth";
 
 export { getBackendHeaders };
-import { saveLastImageUuid } from "./storageDatum";
+import { PUBLIC_FEED_END_CURSOR, saveLastImageUuid } from "./storageDatum";
 import { fetchPrivateFeedPageForGame } from "../services/groups/groupFeedApi";
 
 function isPrivateScope(scope) {
@@ -263,6 +263,10 @@ export async function getImages(pictureId, context, filters = {}) {
     });
   }
 
+  if (pictureId === PUBLIC_FEED_END_CURSOR) {
+    return { isError: false, images: [] };
+  }
+
   const { token, userId } = await getBackendHeaders(context);
   const headers = setHeaders({ token });
 
@@ -290,9 +294,7 @@ export async function getImages(pictureId, context, filters = {}) {
     const imagesInfosData = imagesInfos?.data?.data ?? [];
 
     if (imagesInfosData.length === 0) {
-      if (lastSkippedPictureId !== null) {
-        await saveLastImageUuid(lastSkippedPictureId, filters?.category_key, filters?.language);
-      }
+      await saveLastImageUuid(PUBLIC_FEED_END_CURSOR, filters?.category_key, filters?.language);
 
       return { isError: false, images: [] };
     };

--- a/utils/imagesRequests.js
+++ b/utils/imagesRequests.js
@@ -4,7 +4,7 @@ import Image from "../models/image";
 import { setHeaders, getBackendHeaders } from "./auth";
 
 export { getBackendHeaders };
-import { PUBLIC_FEED_END_CURSOR, saveLastImageUuid } from "./storageDatum";
+import { saveLastImageUuid } from "./storageDatum";
 import { fetchPrivateFeedPageForGame } from "../services/groups/groupFeedApi";
 
 function isPrivateScope(scope) {
@@ -263,10 +263,6 @@ export async function getImages(pictureId, context, filters = {}) {
     });
   }
 
-  if (pictureId === PUBLIC_FEED_END_CURSOR) {
-    return { isError: false, images: [] };
-  }
-
   const { token, userId } = await getBackendHeaders(context);
   const headers = setHeaders({ token });
 
@@ -294,7 +290,7 @@ export async function getImages(pictureId, context, filters = {}) {
     const imagesInfosData = imagesInfos?.data?.data ?? [];
 
     if (imagesInfosData.length === 0) {
-      await saveLastImageUuid(PUBLIC_FEED_END_CURSOR, filters?.category_key, filters?.language);
+      await saveLastImageUuid(filters?.category_key, filters?.language);
 
       return { isError: false, images: [] };
     };

--- a/utils/scoreRequests.js
+++ b/utils/scoreRequests.js
@@ -90,6 +90,7 @@ export async function submitScoreBatch({ items, context }) {
       guess_id: item.guessId,
       image_id: item.pictureId,
       earned_points: item.points,
+      streak: item.streak ?? 0,
     }));
 
     return axios

--- a/utils/scoreRequests.js
+++ b/utils/scoreRequests.js
@@ -103,6 +103,7 @@ export async function submitScoreBatch({ items, context }) {
     guess_id: item.guessId,
     image_name: item.pictureId,
     points: item.points,
+    streak: item.streak ?? 0,
   }));
 
   return axios

--- a/utils/storageDatum.js
+++ b/utils/storageDatum.js
@@ -93,6 +93,27 @@ export async function getNextImageForScope({ category, language, currentListId, 
   return images[0];
 };
 
+/**
+ * Return the TOTAL number of cards persisted for a given scope (category+language).
+ * Used by the prefetcher as a low-water trigger (count < threshold → fetch more).
+ * Returns the TOTAL deck size (NOT cursor-filtered) — prefetch triggering only
+ * needs a proxy, and cursor-filtering is the resolver's responsibility (SRP).
+ * - Public scope: count getLocalImages(category?.key || 'all', language).
+ * - Private scope: count readGroupFeedCache(scope.groupId, {categoryId, language}).images.
+ * Returns 0 for missing/empty decks. Never throws.
+ */
+export async function getDeckCountForScope({ category, language, scope }) {
+  const isPrivate = scope?.kind === 'private' && scope?.groupId;
+  if (!isPrivate) {
+    const images = await getLocalImages(category?.key || 'all', language);
+    return Array.isArray(images) ? images.length : 0;
+  }
+
+  const categoryId = category?.key === 'all' ? undefined : category?.id;
+  const cache = await readGroupFeedCache(scope.groupId, { categoryId, language });
+  return Array.isArray(cache?.images) ? cache.images.length : 0;
+};
+
 function getLastListId(list) {
   const lastListId = list.reduce((maxId, image) => {
     const imageId = image.listId;

--- a/utils/storageDatum.js
+++ b/utils/storageDatum.js
@@ -8,6 +8,7 @@ const PREFERRED_LANGUAGE_KEY = 'preferredLanguage';
 const ONBOARDING_COMPLETED_KEY = 'onboardingCompleted';
 const USER_TAGS_KEY = 'userTags';
 const DEFAULT_LANGUAGE = 'en';
+export const PUBLIC_FEED_END_CURSOR = '__public_feed_end__';
 
 function imageListKey(categoryKey, language) {
   return `imageList:${categoryKey || 'all'}:${language || 'any'}`;

--- a/utils/storageDatum.js
+++ b/utils/storageDatum.js
@@ -150,7 +150,11 @@ export async function getLastImageUuid(categoryKey, language) {
 
 export async function getSessionLanguageFilter() {
   const stored = await AsyncStorage.getItem(SESSION_LANGUAGE_FILTER_KEY);
-  return stored || DEFAULT_LANGUAGE;
+
+  // Keep "unset" distinct from an explicit language choice.
+  // GuessPath/GuessFeed use this to send "any" (no server filter) while still
+  // rendering the UI sentinel as English until the user picks a filter.
+  return stored || null;
 };
 
 export async function saveSessionLanguageFilter(code) {


### PR DESCRIPTION
This pull request adds and improves test coverage for several components, focusing on category asset fallback logic, language selection behavior, ranking table structure, and streak tier display. It also introduces new tests for private group handling and ensures that UI components correctly handle new or updated data structures.

**Category and Group Behavior**

* Added tests to ensure that category chips and cards use local assets as a fallback when a private default category has no remote thumbnail, and that this logic works for both public and private groups. [[1]](diffhunk://#diff-ca536fe7e8a980b5df51fddd86a4dbc6eff6b94bc2061ce808cdbd4b650bf9c2L84-R107) [[2]](diffhunk://#diff-ddd333f313ddc60dad22cf6c288315cce88ff652366ab18778e514e9c28045c6R87-R101) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R32)
* Added a test to verify that the app does not opt into private group loading when rendering the public guess path flow, and updated mocks to allow argument passing. [[1]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfR210-R216) [[2]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfL47-R55)

**Language Selection Logic**

* Added tests to confirm that the preferred language is used as a fallback when the session language filter is unset, and updated mocks to support this logic. [[1]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfR329-R350) [[2]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfR163) [[3]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfR96)

**Ranking Table Enhancements**

* Updated ranking table tests to expect and verify a new "Max Streak" column, including mapping, defaulting, and correct header/cell rendering in both the ranking screen and the table component. [[1]](diffhunk://#diff-a06705e74126f7f671d0928ddfcf8c169f77e28ecfe173d8731b8780a11941fbL135-R195) [[2]](diffhunk://#diff-a06705e74126f7f671d0928ddfcf8c169f77e28ecfe173d8731b8780a11941fbL340-R393) [[3]](diffhunk://#diff-a06705e74126f7f671d0928ddfcf8c169f77e28ecfe173d8731b8780a11941fbL382-R436) [[4]](diffhunk://#diff-a06705e74126f7f671d0928ddfcf8c169f77e28ecfe173d8731b8780a11941fbL422-R474) [[5]](diffhunk://#diff-dc4f783b2fe4638e1e4caa13586e99c447dacc77d9c5e37ed8ab44e3ed895b88L19-R31) [[6]](diffhunk://#diff-dc4f783b2fe4638e1e4caa13586e99c447dacc77d9c5e37ed8ab44e3ed895b88R108-R142)

**Streak Tier Display**

* Added comprehensive tests for the `SuccessOverlay` component to cover all streak tiers, their colors, and animation logic, including the default/neutral tier and the interaction with speed multipliers. [[1]](diffhunk://#diff-41c470994cb1c7092568bc1848127d07cf3d34a3b52c66a83e1aefb91340a00aR11-R12) [[2]](diffhunk://#diff-41c470994cb1c7092568bc1848127d07cf3d34a3b52c66a83e1aefb91340a00aR22-R43) [[3]](diffhunk://#diff-41c470994cb1c7092568bc1848127d07cf3d34a3b52c66a83e1aefb91340a00aR109-R203)

**Other Improvements**

* Added a test for the `EnigmaOverlay` component to verify that it opens when the `defaultOpen` prop changes from false to true.