### PR TITLE
Fix/guess bugs remove adscreen

### DIFF
--- a/__tests__/GuessScreen.test.tsx
+++ b/__tests__/GuessScreen.test.tsx
@@ -233,7 +233,7 @@ jest.mock('../hooks/useStreak', () => {
   return { useStreak: useStreakMock };
 });
 
-import { act, create } from 'react-test-renderer';
+import { act, create as reactCreate } from 'react-test-renderer';
 import type { FC } from 'react';
 import { AppState } from 'react-native';
 
@@ -260,6 +260,14 @@ const consumeAdSlot = consumeAdSlotImpl as jest.MockedFunction<typeof consumeAdS
 const shouldSuppressAds = shouldSuppressAdsImpl as jest.MockedFunction<typeof shouldSuppressAdsImpl>;
 const resolveNextCardWithServerFallback = resolveNextCardWithServerFallbackImpl as jest.MockedFunction<typeof resolveNextCardWithServerFallbackImpl>;
 const getNextImagesForScope = getNextImagesForScopeImpl as jest.MockedFunction<typeof getNextImagesForScopeImpl>;
+
+const mountedRenderers: Array<ReturnType<typeof reactCreate>> = [];
+
+function create(...args: Parameters<typeof reactCreate>): ReturnType<typeof reactCreate> {
+  const renderer = reactCreate(...args);
+  mountedRenderers.push(renderer);
+  return renderer;
+}
 const advanceModuleActual = jest.requireActual('../utils/nextCardAdvancer') as typeof import('../utils/nextCardAdvancer');
 
 // reason: source's GuessNavigation requires navigate/setOptions, but several test fixtures only supply replace/setParams/popToTop; loosen prop types to keep fixtures byte-identical to the .js baseline.
@@ -307,7 +315,13 @@ describe('GuessScreen', () => {
     jest.spyOn(AppState, 'addEventListener').mockImplementation(() => ({ remove: jest.fn() }) as any);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await act(async () => {
+      while (mountedRenderers.length > 0) {
+        mountedRenderers.pop()?.unmount();
+      }
+      await Promise.resolve();
+    });
     jest.restoreAllMocks();
   });
 
@@ -1927,6 +1941,42 @@ describe('GuessScreen', () => {
       jest.useRealTimers();
     });
 
+    it('R4: retry recovery credits the success-time multiplier through the retry loop (not the latest state)', async () => {
+      // §2.4 contract: the multiplier used at retry time MUST equal the value
+      // at the moment of the success that triggered the cycle. Fast tap
+      // (elapsedMs=1000) → multiplier=2 (above SPEED_MULTIPLIER_BASE=1, so a
+      // stale-state read or a ref-mirror regression that falls back to the
+      // initial state would surface as multiplier=1). Threading is via an
+      // explicit arg through runResolveCycle → onAdvanceResolved →
+      // scheduleRetry → runResolveCycle (no mirror ref).
+      jest.useFakeTimers();
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+      const nextParams = { listId: 4, imageFile: 'file:///next.jpg', pictureId: 'p-2' };
+      resolveNextCardWithServerFallback
+        .mockResolvedValueOnce({ next: null, reason: 'network' })
+        .mockResolvedValueOnce({ next: { params: nextParams }, reason: 'ok' });
+
+      const navigation = makeNav();
+      await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+      // Fast tap → multiplier=2 (under the speed bonus threshold).
+      await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 }, elapsedMs: 1000 }); });
+      await act(async () => { lastOverlayProps().onDone(); });
+
+      expect(mockGuessAdvanceLoader).toHaveBeenCalled();
+
+      // Fire retry 1 at 1s — second resolve succeeds → RESOLVED with multiplier=2
+      // threaded from the original success, not a fresh read of state.
+      await act(async () => { jest.advanceTimersByTime(1000); });
+
+      expect(applySuccessSideEffects).toHaveBeenCalledTimes(1);
+      expect(applySuccessSideEffects).toHaveBeenLastCalledWith(expect.objectContaining({
+        multiplier: 2,
+      }));
+
+      jest.useRealTimers();
+    });
+
     it('win → next card resolved → setParams called (no remount), useStreak preserved', async () => {
       const nextParams = { listId: 4, imageFile: 'file:///next.jpg', pictureId: 'p-2' };
       resolveNextCardWithServerFallback.mockResolvedValue({ next: { params: nextParams }, reason: 'ok' });
@@ -2336,6 +2386,56 @@ describe('GuessScreen', () => {
       await act(async () => { await Promise.resolve(); });
 
       expect(applySuccessSideEffects).not.toHaveBeenCalled();
+    });
+
+    it('swipe-home while success side effects await → cadence and ad state do not update after unmount', async () => {
+      jest.clearAllMocks();
+      shouldSuppressAds.mockReturnValue(false);
+      isOnTarget.mockReturnValue(true);
+      consumeAdSlot.mockReturnValue({ showAd: true, nextCount: 0 });
+
+      let finishSuccessSideEffects!: () => void;
+      applySuccessSideEffects.mockImplementation(
+        () => new Promise<void>((resolve) => {
+          finishSuccessSideEffects = resolve;
+        }),
+      );
+
+      let resolveAdvance!: (v: { next: { params: Record<string, unknown> }; reason: 'ok' }) => void;
+      resolveNextCardWithServerFallback.mockReturnValue(
+        new Promise<{ next: { params: Record<string, unknown> }; reason: 'ok' }>((resolve) => {
+          resolveAdvance = resolve;
+        }),
+      );
+
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const navigation = makeNav();
+      let renderer: ReturnType<typeof create>;
+      await act(async () => { renderer = create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+      await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+
+      await act(async () => {
+        resolveAdvance({ next: { params: { listId: 4 } }, reason: 'ok' });
+        await Promise.resolve();
+      });
+
+      expect(applySuccessSideEffects).toHaveBeenCalledTimes(1);
+
+      await act(async () => { renderer.unmount(); });
+
+      await act(async () => {
+        finishSuccessSideEffects();
+        await Promise.resolve();
+      });
+
+      expect(consumeAdSlot).not.toHaveBeenCalled();
+      expect(mockAdInterstitial).not.toHaveBeenCalled();
+      const setStateWarning = consoleErrorSpy.mock.calls.find((c: unknown[]) =>
+        /setState after unmount|state update on an unmounted|Can't perform a React state update/i.test(String(c[0] ?? '')),
+      );
+      expect(setStateWarning).toBeUndefined();
+
+      consoleErrorSpy.mockRestore();
     });
   });
 

--- a/__tests__/GuessScreen.test.tsx
+++ b/__tests__/GuessScreen.test.tsx
@@ -506,6 +506,7 @@ describe('GuessScreen', () => {
       category: { id: 'cat-1', key: 'nature' },
       language: 'fr',
       currentListId: 3,
+      currentPictureId: 'image-1',
       isTutorial: false,
       scope: undefined,
     });
@@ -1960,8 +1961,10 @@ describe('GuessScreen', () => {
       expect(lastPictureProps().disabled).toBe(true);
       // Overlay hidden — does not double as a loading spinner (R1).
       expect(lastOverlayProps().visible).toBe(false);
-      // Spinner+loader UI not yet warming (still advancing, resolve pending).
-      expect(mockGuessAdvanceLoader).not.toHaveBeenCalled();
+      // Loader now shown during `advancing && !showSuccess` to cover the
+      // foreground-fetch gap after the success animation dismisses; deliberate
+      // fix for the "frozen screen after animation" symptom.
+      expect(mockGuessAdvanceLoader).toHaveBeenCalled();
     });
 
     it('PT2: warming → app backgrounded → state=exhausted on foreground', async () => {

--- a/__tests__/imagesRequests.test.js
+++ b/__tests__/imagesRequests.test.js
@@ -236,6 +236,7 @@ describe('imagesRequests utilities', () => {
           Authorization: 'Bearer token',
           HTTP_AUTHORIZATION: 'Bearer token',
         },
+        timeout: 15000,
       }
     );
     expect(File).toHaveBeenCalledWith(
@@ -301,7 +302,7 @@ describe('imagesRequests utilities', () => {
     expect(axios.post).toHaveBeenCalledWith(
       'https://backend.example/api/v1/users/42/next_image_batch',
       { image: { name: 'broken-img' } },
-      { headers: { Authorization: 'Bearer token' } }
+      { headers: { Authorization: 'Bearer token' }, timeout: 15000 }
     );
     expect(response).toEqual({
       isError: false,
@@ -325,6 +326,7 @@ describe('imagesRequests utilities', () => {
       {
         headers: { Authorization: 'Bearer token' },
         params: { category_id: 'X', language: 'fr' },
+        timeout: 15000,
       }
     );
   });
@@ -337,7 +339,7 @@ describe('imagesRequests utilities', () => {
     expect(axios.post).toHaveBeenCalledWith(
       'https://backend.example/api/v1/users/42/next_image_batch',
       { image: { name: 'first-img', category_id: 'X', language: 'fr' } },
-      { headers: { Authorization: 'Bearer token' } }
+      { headers: { Authorization: 'Bearer token' }, timeout: 15000 }
     );
   });
 
@@ -379,7 +381,7 @@ describe('imagesRequests utilities', () => {
 
     expect(axios.get).toHaveBeenCalledWith(
       'https://backend.example/api/v1/users/42/get_image_batch',
-      { headers: { Authorization: 'Bearer token' } }
+      { headers: { Authorization: 'Bearer token' }, timeout: 15000 }
     );
   });
 

--- a/components/Guess/GuessExhaustedPanel.tsx
+++ b/components/Guess/GuessExhaustedPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   StyleSheet,
   Text,
@@ -7,6 +6,7 @@ import {
 } from 'react-native';
 
 import { GlobalStyle } from '../../constants/theme';
+import { OverlayZIndex } from '../../constants/overlayZIndex';
 
 type Props = {
   onSwitch: () => void;
@@ -59,7 +59,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 0, 0, 0.55)',
     justifyContent: 'center',
     alignItems: 'center',
-    zIndex: 9999,
+    zIndex: OverlayZIndex.EXHAUSTED_PANEL,
   },
   card: {
     width: '85%',

--- a/components/Guess/GuessExitSwipeMenu.js
+++ b/components/Guess/GuessExitSwipeMenu.js
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { Animated, PanResponder, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { GlobalStyle } from '../../constants/theme';
+import { OverlayZIndex } from '../../constants/overlayZIndex';
 import SwipeHaloHint from './SwipeHaloHint';
 
 const EDGE_WIDTH = 36;
@@ -87,7 +88,7 @@ export default function GuessExitSwipeMenu({ onHome, showHints = false, onIntera
   );
 
   return (
-    <View pointerEvents="box-none" style={[StyleSheet.absoluteFill, { zIndex: 9000, elevation: 9000 }]}>
+    <View pointerEvents="box-none" style={[StyleSheet.absoluteFill, { zIndex: OverlayZIndex.EXIT_MENU_ROOT, elevation: OverlayZIndex.EXIT_MENU_ROOT }]}>
       <View
         testID="guess.exit.edge"
         {...edgePanResponder.panHandlers}
@@ -144,14 +145,14 @@ const styles = StyleSheet.create({
     left: 0,
     width: EDGE_WIDTH,
     backgroundColor: 'transparent',
-    zIndex: 9001,
-    elevation: 9001,
+    zIndex: OverlayZIndex.EXIT_MENU_EDGE,
+    elevation: OverlayZIndex.EXIT_MENU_EDGE,
   },
   scrim: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.28)',
-    zIndex: 9002,
-    elevation: 9002,
+    zIndex: OverlayZIndex.EXIT_MENU_SCRIM,
+    elevation: OverlayZIndex.EXIT_MENU_SCRIM,
   },
   panel: {
     position: 'absolute',
@@ -162,8 +163,8 @@ const styles = StyleSheet.create({
     backgroundColor: GlobalStyle.color.primaryColor900,
     paddingTop: 64,
     paddingHorizontal: 16,
-    zIndex: 9003,
-    elevation: 9003,
+    zIndex: OverlayZIndex.EXIT_MENU_PANEL,
+    elevation: OverlayZIndex.EXIT_MENU_PANEL,
   },
   panelHeader: {
     flexDirection: 'row',

--- a/components/Guess/SuccessOverlay.js
+++ b/components/Guess/SuccessOverlay.js
@@ -1,8 +1,9 @@
-import React, { useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 import { Animated, Easing, StyleSheet, View, Text } from 'react-native';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
 
 import { GlobalStyle } from '../../constants/theme';
+import { OverlayZIndex } from '../../constants/overlayZIndex';
 import { NEUTRAL_TIER } from '../../constants/streakTiers';
 
 // Single source of truth for the speed-bonus color (spokes, chrono, pill).
@@ -259,7 +260,7 @@ export default function SuccessOverlay({ visible, onDone, multiplier = 1, points
 }
 
 const styles = StyleSheet.create({
-  overlay: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, justifyContent: 'center', alignItems: 'center', zIndex: 9999 },
+  overlay: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, justifyContent: 'center', alignItems: 'center', zIndex: OverlayZIndex.SUCCESS_OVERLAY },
   panel: {
     alignItems: 'center',
     backgroundColor: 'rgba(0, 0, 0, 0.45)',

--- a/components/Picture/Descriptions/EnigmaOverlay.js
+++ b/components/Picture/Descriptions/EnigmaOverlay.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, PanResponder, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import IconButton from '../../UI/IconButton';
+import { OverlayZIndex } from '../../../constants/overlayZIndex';
 import { GlobalStyle } from '../../../constants/theme';
 
 const SWIPE_THRESHOLD_PX = 40;
@@ -99,7 +100,7 @@ export default function EnigmaOverlay({ description, screenHeight, defaultOpen, 
   const text = description && description !== '' ? description : 'No description';
 
   return (
-    <View pointerEvents="box-none" style={[StyleSheet.absoluteFill, { zIndex: 9000, elevation: 9000 }]}>
+    <View pointerEvents="box-none" style={[StyleSheet.absoluteFill, { zIndex: OverlayZIndex.ENIGMA_ROOT, elevation: OverlayZIndex.ENIGMA_ROOT }]}>
       {!isOpen ? (
         <View
           {...handlePanResponder.panHandlers}
@@ -153,14 +154,14 @@ const styles = StyleSheet.create({
     backgroundColor: GlobalStyle.color.primaryColor900,
     borderTopLeftRadius: 12,
     borderTopRightRadius: 12,
-    zIndex: 9001,
-    elevation: 9001,
+    zIndex: OverlayZIndex.ENIGMA_HANDLE,
+    elevation: OverlayZIndex.ENIGMA_HANDLE,
   },
   scrim: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.28)',
-    zIndex: 9002,
-    elevation: 9002,
+    zIndex: OverlayZIndex.ENIGMA_SCRIM,
+    elevation: OverlayZIndex.ENIGMA_SCRIM,
   },
   panel: {
     position: 'absolute',
@@ -171,8 +172,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 8,
     paddingBottom: 16,
-    zIndex: 9003,
-    elevation: 9003,
+    zIndex: OverlayZIndex.ENIGMA_PANEL,
+    elevation: OverlayZIndex.ENIGMA_PANEL,
   },
   panelHeader: {
     flexDirection: 'row',

--- a/components/UI/SwipeImage.js
+++ b/components/UI/SwipeImage.js
@@ -107,6 +107,16 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
     };
   }, [lang, scope]);
 
+  /**
+   * Fetch+append path: call `fetchCardBatch` with the active category/language/
+   * scope, then hand the response to `handleData`. Translates the fetch outcome
+   * into the same result contract as `handleImagesLoading`.
+   * @param {string|null|undefined} [pictureIdOverride] - When provided, sent as
+   *   the server cursor; `undefined` → caller-side persisted cursor, `null` →
+   *   fresh head query.
+   * @returns {Promise<boolean|'error'|void>} `true`/`false` from handleData,
+   *   `'error'` when the fetch errored (alert already shown).
+   */
   const loadNewImages = useCallback(async (pictureIdOverride) => {
     console.log("loadNewImages");
     const response = await fetchCardBatch({
@@ -129,6 +139,23 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
     };
   }, [context, handleData, language, scope]);
 
+  /**
+   * Centralized image-loading entry. Drives the `asyncImagesAreLoading` and
+   * `noMoreCard` flags around `loadNewImages`, and RETURNS its result so the
+   * caller can branch on the fetch outcome.
+   *
+   * `pictureIdOverride`:
+   * - `undefined` (omitted) → `loadNewImages` reads the persisted feed cursor.
+   * - `null` → fresh head query (no cursor).
+   *
+   * Result semantics:
+   * - truthy / `true` → cards arrived; `noMoreCard` cleared.
+   * - `false` → server returned an empty batch; `noMoreCard` set to 'exhausted'.
+   * - `'error'` → fetch failed; alert already shown, `noMoreCard` set to 'error'.
+   *
+   * @param {string|null|undefined} [pictureIdOverride] - Cursor override; see above.
+   * @returns {Promise<boolean|'error'|void>} The `loadNewImages` result.
+   */
   /* centralized function for loading images / set when imgs are loading */
   const handleImagesLoading = useCallback(async (pictureIdOverride) => {
     console.log("handleImagesLoading");
@@ -146,11 +173,20 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
     return result;
   }, [loadNewImages]);
 
-  /*
-  * Handles the retrieval of the list of images.
-  *
-  * @return {null} Returns null if the localImageList is not null and has a length of at least 4.
-  */
+  /**
+   * Mount loader. Reads the local deck for the active (category, language) and
+   * branches by deck size (e2e mode short-circuits to a fixture/saved card):
+   * - cold (null / length 0) → `handleImagesLoading(null)` (fresh head query,
+   *   bypassing any stale cursor so newly-uploaded images can surface).
+   * - full (length ≥ 4) → use the local deck directly (no fetch).
+   * - partial (1–3) → cursor-based `handleImagesLoading()` (no override → reads
+   *   the persisted cursor); if it returns `false` (cursor exhausted), write the
+   *   `PUBLIC_FEED_END_CURSOR` sentinel and do ONE fresh
+   *   `handleImagesLoading(null)` so newly-available server images can be
+   *   reached. The cached deck is NOT wiped — only the cursor is replaced.
+   *
+   * @returns {Promise<void>}
+   */
   const handleGetImagesList = useCallback(async () => {
     console.log("handleGetImagesList");
 

--- a/components/UI/SwipeImage.js
+++ b/components/UI/SwipeImage.js
@@ -7,7 +7,7 @@ import SwipeableCard from './SwipeableCard';
 import LoadingOverlay from './LoadingOverlay';
 import useBadgeDetail from './useBadgeDetail';
 
-import { getE2EHiddenGuessCard, getLocalImages, getLastImageId, normalizeListIds, removeImageFromList, deleteImageFromStorage } from '../../utils/storageDatum';
+import { getE2EHiddenGuessCard, getLocalImages, getLastImageId, normalizeListIds, removeImageFromList, deleteImageFromStorage, saveLastImageUuid, PUBLIC_FEED_END_CURSOR } from '../../utils/storageDatum';
 import { AuthContext } from '../../store/auth-context';
 import { buildE2EGuessCardFromPayload, buildE2EGuessCards, isE2EMode } from '../../utils/e2eMode';
 import { GlobalStyle } from '../../constants/theme';
@@ -139,8 +139,11 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       setNoMoreCard('error');
     } else if (result === false) {
       setNoMoreCard('exhausted');
+    } else if (result === true) {
+      setNoMoreCard(null);
     }
     setAsyncImagesAreLoading(false);
+    return result;
   }, [loadNewImages]);
 
   /*
@@ -182,7 +185,11 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       await handleImagesLoading(null);
     } else {
       setImageList(normalizeListIds(localImageList));
-      await handleImagesLoading();
+      const cursorResult = await handleImagesLoading();
+      if (cursorResult === false) {
+        await saveLastImageUuid(PUBLIC_FEED_END_CURSOR, categoryKey, lang);
+        await handleImagesLoading(null);
+      }
     };
   }, [category?.id, categoryKey, context, handleImagesLoading, isPrivateScope, lang, language, privateGroupId, scope]);
 

--- a/constants/overlayZIndex.ts
+++ b/constants/overlayZIndex.ts
@@ -1,0 +1,58 @@
+/**
+ * ADR: Overlay z-index stacking order
+ * ===================================
+ *
+ * Single source of truth for z-index (and matching Android `elevation`) of
+ * global full-screen / modal overlay layers across the app. Replaces the
+ * magic literals (9000–9999) that were duplicated across components.
+ *
+ * Stack intent (low → high), values preserved exactly from pre-refactor code:
+ *
+ *   EnigmaOverlay / GuessExitSwipeMenu root container .... 9000
+ *   handle / edge tab .................................... 9001
+ *   dismiss scrim ........................................ 9002
+ *   sliding panel ........................................ 9003
+ *   AdInterstitial wrapper ............................... 9998
+ *   SuccessOverlay / GuessExhaustedPanel ................. 9999
+ *
+ * Why AdInterstitial (9998) sits BELOW SuccessOverlay / GuessExhaustedPanel
+ * (9999):
+ *   - SuccessOverlay animates over the picture right after a correct guess;
+ *     the interstitial only mounts later (advance state 'showing'). The +1
+ *     margin guarantees a still-visible success burst is never obscured if
+ *     both ever overlap during the brief swap window.
+ *   - GuessExhaustedPanel is the terminal "no more cards" gate; it must sit
+ *     above every gameplay layer (including any lingering ad) so the user
+ *     always sees the exit CTA.
+ *
+ * EnigmaOverlay / GuessExitSwipeMenu 9000→9003 progression:
+ *   root scrim container (9000) < handle/edge tab (9001) < dismiss scrim
+ *   (9002) < sliding panel (9003). Higher sibling wins pointer precedence
+ *   when the panel is open.
+ *
+ * zIndex ↔ elevation pairing (Android):
+ *   React Native's `zIndex` has no effect on Android; `elevation` does.
+ *   Where both appear, keep them numerically equal so iOS and Android agree
+ *   on ordering. Each member below is reused for both style props.
+ *
+ * LOCAL-STACK NOTE — intentionally excluded:
+ *   Intra-component sibling stacking (GuessPathScreen z=10, SwipeableCard
+ *   z=2, Instructions z=1) has no cross-file meaning; pulling it in would
+ *   bloat this enum and dilute its purpose (global overlay ordering only).
+ *   Those literals stay local to their components.
+ */
+export const OverlayZIndex = {
+  ENIGMA_ROOT: 9000,
+  ENIGMA_HANDLE: 9001,
+  ENIGMA_SCRIM: 9002,
+  ENIGMA_PANEL: 9003,
+  EXIT_MENU_ROOT: 9000,
+  EXIT_MENU_EDGE: 9001,
+  EXIT_MENU_SCRIM: 9002,
+  EXIT_MENU_PANEL: 9003,
+  AD_INTERSTITIAL: 9998,
+  SUCCESS_OVERLAY: 9999,
+  EXHAUSTED_PANEL: 9999,
+} as const;
+
+export type OverlayZIndexKey = keyof typeof OverlayZIndex;

--- a/hooks/useAdCadence.ts
+++ b/hooks/useAdCadence.ts
@@ -1,0 +1,53 @@
+import { useCallback, useRef, useState } from 'react';
+import { Platform } from 'react-native';
+
+import { consumeAdSlot as resolveAdSlot } from '../utils/adCadence';
+import type { AdScope, ConsumeAdSlotResult } from '../utils/adCadence';
+import { shouldSuppressAds } from '../services/billing/entitlements';
+import type { AuthContextLike } from '../services/billing/entitlements';
+import { isE2EMode } from '../utils/e2eMode';
+import type { AdSource } from '../services/ads/AdSource';
+
+const IS_ANDROID = Platform.OS === 'android';
+
+type UseAdCadenceArgs = {
+  scope?: AdScope;
+  authContext: AuthContextLike;
+  adSource: AdSource;
+};
+
+type UseAdCadenceResult = {
+  consumeAdSlot: () => ConsumeAdSlotResult;
+  resetSuccessesSinceLastAd: () => void;
+};
+
+// §2.3 (3): owns the ad-cadence counter state and its two state transitions:
+// consume one success slot after a committed win, or reset the counter after a
+// miss. Callers do not thread the current count around manually anymore.
+export function useAdCadence({ scope, authContext, adSource }: UseAdCadenceArgs): UseAdCadenceResult {
+  const [successesSinceLastAd, setSuccessesSinceLastAd] = useState(0);
+  const successesSinceLastAdRef = useRef(successesSinceLastAd);
+  successesSinceLastAdRef.current = successesSinceLastAd;
+  const isAdFree = shouldSuppressAds(authContext);
+  const isE2E = isE2EMode();
+
+  const consumeCurrentAdSlot = useCallback((): ConsumeAdSlotResult => {
+    const result = resolveAdSlot({
+      successesSinceLastAd: successesSinceLastAdRef.current,
+      scope,
+      isAdFree,
+      isE2E,
+      isSourceReady: IS_ANDROID && adSource.isReady(),
+    });
+    successesSinceLastAdRef.current = result.nextCount;
+    setSuccessesSinceLastAd(result.nextCount);
+    return result;
+  }, [adSource, isAdFree, isE2E, scope]);
+
+  const resetSuccessesSinceLastAd = useCallback(() => {
+    successesSinceLastAdRef.current = 0;
+    setSuccessesSinceLastAd(0);
+  }, []);
+
+  return { consumeAdSlot: consumeCurrentAdSlot, resetSuccessesSinceLastAd };
+}

--- a/hooks/useAdSource.ts
+++ b/hooks/useAdSource.ts
@@ -6,9 +6,8 @@ import { createInternalProAdSource } from '../services/ads/InternalProAdSource';
 import type { AdSource } from '../services/ads/AdSource';
 
 // On iOS the whole ad feature is a no-op (Q1): the AdMob source is never ready, and
-// the InternalProAdSource is suppressed via consumeAdSlot by a platform gate in
-// GuessScreen. We still construct the composite for shape parity; the platform gate
-// is enforced in decideAdSlot via Platform.OS !== 'android' (no overlay shown).
+// the InternalProAdSource is suppressed by useAdCadence's platform gate before
+// any overlay is shown. We still construct the composite for shape parity.
 //
 // NOTE (F2/F3): GuessScreen deliberately constructs AdMob WITHOUT a hookSnapshot —
 // GuessScreen never reads AdMob readiness at runtime; it only checks the composite's

--- a/hooks/useAdvanceStateMachine.ts
+++ b/hooks/useAdvanceStateMachine.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import type { RefObject } from 'react';
+
+import { advanceReducer, initialAdvance } from '../utils/advanceState';
+import type { AdvanceEvent, AdvanceSnapshot, AdvanceState } from '../utils/advanceState';
+
+type AdvanceStateMachineNavigation = {
+  setParams(params: Record<string, unknown>): void;
+};
+
+type UseAdvanceStateMachineArgs = {
+  navigation: AdvanceStateMachineNavigation;
+};
+
+type UseAdvanceStateMachineResult = {
+  advance: AdvanceSnapshot;
+  dispatch: (event: AdvanceEvent) => void;
+  advanceStateRef: RefObject<AdvanceState>;
+};
+
+// Owns the pure advance reducer + its dispatch wrapper + the synchronous
+// snapshot refs the AppState listener and onAdvanceResolved read, plus the
+// idle-entry setParams side effect. Navigation is injected so the hook stays
+// free of RN/router coupling beyond the single setParams seam.
+export function useAdvanceStateMachine({
+  navigation,
+}: UseAdvanceStateMachineArgs): UseAdvanceStateMachineResult {
+  const [advance, dispatchAdvance] = useReducer(
+    (prev: AdvanceSnapshot, event: AdvanceEvent) => advanceReducer(prev, event),
+    initialAdvance,
+  );
+
+  // Mirror advance.state into a ref so the AppState listener (mounted once) can
+  // read the latest state without re-subscribing on every transition.
+  const advanceStateRef = useRef<AdvanceState>(advance.state);
+  // Snapshot ref used by `dispatch` to compute the next state synchronously.
+  // useEffect([advance.state]) updates advanceStateRef AFTER commit, but an
+  // awaited async chain (e.g. runResolveCycle → onAdvanceResolved) continues
+  // on the microtask queue before passive effects run, leaving the ref stale.
+  // dispatch updates both refs synchronously so the A7 guard inside
+  // onAdvanceResolved and the AppState listener see the post-event state
+  // immediately. The useEffect below is defense-in-depth (re-syncs from the
+  // committed advance in case the optimistic update diverged).
+  const advanceSnapRef = useRef<AdvanceSnapshot>(advance);
+  const dispatch = useCallback((event: AdvanceEvent) => {
+    const next = advanceReducer(advanceSnapRef.current, event);
+    advanceSnapRef.current = next;
+    advanceStateRef.current = next.state;
+    dispatchAdvance(event);
+  }, [dispatchAdvance]);
+
+  useEffect(() => {
+    advanceSnapRef.current = advance;
+    advanceStateRef.current = advance.state;
+  }, [advance]);
+
+  // PB1: the advance reducer is the single source of truth for advance. The reducer
+  // itself is pure (no navigation); this idle-entry side-effect consumes a staged
+  // `advance.next` via setParams whenever the machine lands in `idle` with a non-null
+  // payload. Identity-tracked (single-apply-per-resolve latch) so a re-dispatch with
+  // the same `next` reference (e.g. test mocks returning a shared object, or any
+  // future code path that re-stages without a new reference) does not double-apply
+  // setParams. The latch's premise is now the in-overlay RESOLVED dispatch — the
+  // AdScreen round-trip is gone, but the single-apply invariant still holds.
+  const appliedNextRef = useRef<Record<string, unknown> | null>(null);
+
+  useEffect(() => {
+    if (advance.state === 'idle' && advance.next && appliedNextRef.current !== advance.next) {
+      appliedNextRef.current = advance.next;
+      navigation.setParams(advance.next);
+    }
+  }, [advance.state, advance.next, navigation]);
+
+  return { advance, dispatch, advanceStateRef };
+}

--- a/hooks/useResolveLifecycle.ts
+++ b/hooks/useResolveLifecycle.ts
@@ -1,0 +1,280 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+
+import { applySuccessSideEffects } from '../utils/handleGuessOutcome';
+import { resolveNextCardWithServerFallback } from '../utils/nextCardAdvancer';
+import type { NextGuessResult } from '../utils/nextCardAdvancer';
+import { DEFAULT_RETRY_BUDGET } from '../utils/advanceState';
+import type { AdvanceEvent, AdvanceState } from '../utils/advanceState';
+import type { AdScope, ConsumeAdSlotResult } from '../utils/adCadence';
+import { resolveCorrectGuessOutcome } from '../utils/guessPoints';
+import type { AuthContextLike } from '../services/billing/entitlements';
+
+// Exponential retry cadence for the `warming` state (§5.3 + §8 risk row).
+// 3 attempts total, 1s/2s/4s. After the budget is consumed the reducer
+// transitions to `exhausted` via the final RETRY_TICK (no further resolve).
+const RETRY_DELAYS_MS = [1000, 2000, 4000];
+
+type GuessCategory = { id?: string; key?: string };
+
+type ResolveArgs = {
+  category?: GuessCategory;
+  language?: string;
+  currentListId?: number;
+  currentPictureId?: string;
+  isTutorial?: boolean;
+  scope?: AdScope;
+  authContext: AuthContextLike;
+};
+
+type SideEffectArgs = {
+  listId?: number;
+  categoryKey?: string;
+  language?: string;
+  imageFile?: string;
+  pictureId?: string;
+  scope?: AdScope;
+  userId: string;
+};
+
+type AdPhase = 'idle' | 'showing';
+
+export type UseResolveLifecycleArgs = {
+  dispatch: (event: AdvanceEvent) => void;
+  advanceStateRef: RefObject<AdvanceState>;
+  setAdPhase: (phase: AdPhase) => void;
+  currentStreak: number;
+  onWin: () => void;
+  resolveArgs: ResolveArgs;
+  sideEffectArgs: SideEffectArgs;
+  // Cadence state stays owned by useAdCadence; the lifecycle only asks it to
+  // consume the current slot after success side effects commit.
+  consumeAdSlot: () => ConsumeAdSlotResult;
+};
+
+export type UseResolveLifecycleResult = {
+  kickoffResolve: (multiplier: number) => void;
+  awaitResolve: () => Promise<void>;
+  consumePendingNext: () => NonNullable<NextGuessResult> | null;
+  handleAdDone: () => void;
+  clearRetryTimer: () => void;
+};
+
+// Owns the resolve-lifecycle machinery: the in-flight next-card Promise ref,
+// the staged pending-next ref consumed by both ad/non-ad RESOLVED dispatch
+// paths, the warming-retry timer + count, and the mountedRef abort guard.
+// `multiplier` is threaded explicitly through runResolveCycle → onAdvanceResolved
+// → scheduleRetry → runResolveCycle so the success-time value survives the
+// retry loop without a parallel multiplier mirror ref (§2.4 option c).
+export function useResolveLifecycle({
+  dispatch,
+  advanceStateRef,
+  setAdPhase,
+  currentStreak,
+  onWin,
+  resolveArgs,
+  sideEffectArgs,
+  consumeAdSlot,
+}: UseResolveLifecycleArgs): UseResolveLifecycleResult {
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryCountRef = useRef<number>(0);
+  // Holds the in-flight next-card resolve Promise kicked off in
+  // applySuccessPath so handleOverlayDone can await it instead of re-entering
+  // the cascade at dismiss. Discarded on unmount so a swipe-home during the
+  // overlay never lands a setState-after-unmount when the trailing resolve
+  // settles.
+  const nextCardResolveRef = useRef<Promise<void> | null>(null);
+  // CONCERN #1 (post-implementation verification pass): PT6 cleanup nulls
+  // nextCardResolveRef but cannot cancel the in-flight runResolveCycle()
+  // Promise. When it settles post-unmount, onAdvanceResolved would fire
+  // applySuccessSideEffects → bufferScore (AsyncStorage) + removeImageFromList
+  // (deck mutation) + deleteImageFromStorage (file delete). User decision:
+  // ABORT the win-credit on swipe-home. Flipped to false in the PT6 cleanup
+  // below; checked at the top of onAdvanceResolved.
+  const mountedRef = useRef(true);
+  // C2 (ad-in-screen-overlay §4.4): holds the resolved next card so the
+  // post-ad RESOLVED dispatch can fire from handleAdDone — the advance state
+  // machine stays in `advancing` during the ad (no premature setParams), then
+  // lands in `idle` on dismiss. The same ref is borrowed by the non-ad path's
+  // deferred RESOLVED (staged in onAdvanceResolved, consumed by
+  // handleOverlayDone via consumePendingNext).
+  const pendingNextRef = useRef<NonNullable<NextGuessResult> | null>(null);
+
+  // PT6: clear any pending retry timer on unmount so we never setState after
+  // unmount (Leave tap during warming, navigation.popToTop, etc.). C1: also
+  // discard the in-flight next-card resolve ref so a swipe-home during the
+  // SuccessOverlay does not land a setState-after-unmount when the trailing
+  // resolve settles.
+  useEffect(() => {
+    return () => {
+      if (retryTimerRef.current !== null) {
+        clearTimeout(retryTimerRef.current);
+        retryTimerRef.current = null;
+      }
+      nextCardResolveRef.current = null;
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const clearRetryTimer = useCallback(() => {
+    if (retryTimerRef.current !== null) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
+
+  // Drives the advance state machine from a single resolve attempt. Called
+  // initially by handleOverlayDone (state=advancing) and re-entered on each
+  // scheduled retry tick (state=warming). Side effects (streak commit, score
+  // buffer, ad cadence, setParams/navigation) fire ONLY on a successful
+  // resolve — see onAdvanceResolved (PB6). `multiplier` is threaded in (not
+  // read from a ref) so the retry-loop recovery credits the success-time
+  // multiplier even if state has since moved on.
+  async function runResolveCycle(multiplier: number) {
+    const { next } = await resolveNextCardWithServerFallback({
+      category: resolveArgs.category,
+      language: resolveArgs.language,
+      currentListId: resolveArgs.currentListId,
+      currentPictureId: resolveArgs.currentPictureId,
+      isTutorial: resolveArgs.isTutorial,
+      scope: resolveArgs.scope,
+      authContext: resolveArgs.authContext,
+    });
+
+    if (next) {
+      await onAdvanceResolved(next, multiplier);
+      return;
+    }
+
+    // P1 (ad-overlay post-fix §1 C1): all non-ok reasons are transient.
+    // FAILED_TRANSIENT is a no-op when already in warming (reducer rejects it);
+    // legal only from advancing.
+    dispatch({ type: 'FAILED_TRANSIENT' });
+    scheduleRetry(multiplier);
+  }
+
+  // PB6: streak + score commit lives here — only on a successfully resolved
+  // next card. Pairs with the cadence rollback (no commit) on null advance.
+  async function onAdvanceResolved(next: NonNullable<NextGuessResult>, multiplier: number) {
+    // A7 (Phase 2 review): the in-flight resolve may complete AFTER AppState
+    // backgrounding forced FAILED_PERMANENT → `exhausted`. Without this guard,
+    // onWin / applySuccessSideEffects / decideAdSlot / setAdPhase would all
+    // fire on stale state. Bail before any side effect. Both 'advancing'
+    // (initial resolve) and 'warming' (retry recovery) are valid resolving
+    // states — the reducer accepts RESOLVED from either.
+    if (advanceStateRef.current !== 'advancing' && advanceStateRef.current !== 'warming') return;
+    // mountedRef guard: a swipe-home during SuccessOverlay nulls nextCardResolveRef
+    // but does NOT cancel the in-flight Promise. applySuccessSideEffects mutates
+    // AsyncStorage + the local deck + the filesystem — those must NOT fire post-unmount.
+    if (!mountedRef.current) return;
+    const { nextStreak, nextTier, finalPoints } = resolveCorrectGuessOutcome({ multiplier, currentStreak });
+    onWin();
+    await applySuccessSideEffects({
+      listId: sideEffectArgs.listId,
+      categoryKey: sideEffectArgs.categoryKey,
+      language: sideEffectArgs.language,
+      imageFile: sideEffectArgs.imageFile,
+      pictureId: sideEffectArgs.pictureId,
+      scope: sideEffectArgs.scope,
+      userId: sideEffectArgs.userId,
+      points: finalPoints,
+      multiplier,
+      streak: nextStreak,
+      streakMultiplier: nextTier.multiplier,
+    });
+
+    // Unmount can happen while the persistent side effects await. Bail before
+    // cadence/state updates so no ad/UI state mutates after teardown.
+    if (!mountedRef.current) return;
+
+    const { showAd } = consumeAdSlot();
+
+    // P2: when no ad is due, RESOLVED is NOT dispatched here in the INITIAL
+    // resolve (state=advancing) — the resolved next is staged on
+    // pendingNextRef and the dispatch is deferred to handleOverlayDone
+    // (mirrors the ad-path defer to handleAdDone) so the next image's
+    // imageFile URI does not land in route.params while the SuccessOverlay is
+    // still animating. The ad branch below stages on the same ref + flips
+    // adPhase → 'showing'; RESOLVED fires from handleAdDone after the ad
+    // dismisses.
+    //
+    // WARMING EXCEPTION: when state=warming, the resolve that fired this
+    // onAdvanceResolved came from scheduleRetry's fire-and-forget
+    // runResolveCycle() (NOT the promise stored in nextCardResolveRef). By
+    // this point handleOverlayDone has already returned (its await on the
+    // original nextCardResolveRef completed when the first runResolveCycle
+    // returned null+network and dispatched FAILED_TRANSIENT). No later
+    // callback exists to commit a staged next, so we dispatch immediately to
+    // preserve the "RESOLVED exactly once per win cycle" invariant. The A7
+    // guard above already admitted state=warming as a valid resolving state.
+    if (!showAd) {
+      if (advanceStateRef.current === 'advancing') {
+        pendingNextRef.current = next;
+        return;
+      }
+      dispatch({ type: 'RESOLVED', next: next.params });
+      return;
+    }
+
+    // C2 (ad-in-screen-overlay §3.2 step 3-5): showAd branch renders the
+    // in-component overlay. Stage the resolved next on the ref + flip
+    // adPhase → 'showing'. RESOLVED is deferred to handleAdDone so the
+    // reducer lands in `idle` only after the ad dismisses.
+    pendingNextRef.current = next;
+    setAdPhase('showing');
+  }
+
+  // Schedule the next warming retry. Exponential backoff 1s/2s/4s. After the
+  // budget is consumed, the final RETRY_TICK transitions the reducer to
+  // `exhausted` and we do not issue another resolve. `multiplier` is carried
+  // through to the retried runResolveCycle so the success-time value is used
+  // at recovery time (§2.4 option c — explicit arg, no mirror ref).
+  function scheduleRetry(multiplier: number) {
+    retryCountRef.current += 1;
+    const n = retryCountRef.current;
+    const delay = RETRY_DELAYS_MS[n - 1] ?? RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1];
+    retryTimerRef.current = setTimeout(() => {
+      retryTimerRef.current = null;
+      dispatch({ type: 'RETRY_TICK' });
+      if (n < DEFAULT_RETRY_BUDGET) {
+        void runResolveCycle(multiplier);
+      }
+    }, delay);
+  }
+
+  // C2: fires from AdInterstitial's onDone (post-ad). Hides the overlay +
+  // dispatches RESOLVED with the staged next so the idle-entry side-effect
+  // consumes setParams(advance.next). useCallback keeps the onDone ref
+  // stable across re-renders so AdInterstitial's effect deps don't churn.
+  const handleAdDone = useCallback(() => {
+    const next = pendingNextRef.current;
+    pendingNextRef.current = null;
+    setAdPhase('idle');
+    if (next) {
+      dispatch({ type: 'RESOLVED', next: next.params });
+    }
+  }, [dispatch, setAdPhase]);
+
+  const kickoffResolve = (multiplier: number) => {
+    retryCountRef.current = 0;
+    nextCardResolveRef.current = runResolveCycle(multiplier);
+  };
+
+  const awaitResolve = async () => {
+    await nextCardResolveRef.current;
+  };
+
+  const consumePendingNext = () => {
+    const next = pendingNextRef.current;
+    pendingNextRef.current = null;
+    return next;
+  };
+
+  return {
+    kickoffResolve,
+    awaitResolve,
+    consumePendingNext,
+    handleAdDone,
+    clearRetryTimer,
+  };
+}

--- a/screens/GuessScreens/GuessScreen.tsx
+++ b/screens/GuessScreens/GuessScreen.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useContext, useEffect, useReducer, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import type { FC } from 'react';
-import { AppState, Platform, useWindowDimensions, View } from 'react-native';
+import { AppState, useWindowDimensions, View } from 'react-native';
 
 import AdInterstitial from '../../components/Ads/AdInterstitial';
 import GuessExitSwipeMenu from '../../components/Guess/GuessExitSwipeMenu';
@@ -13,21 +13,19 @@ import GuessAdvanceLoader from '../../components/Guess/GuessAdvanceLoader';
 import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../../store/privateGroupTheme-context';
 import { AuthContext } from '../../store/auth-context';
 import { isOnTarget } from "../../utils/targetLocation";
-import { applySuccessSideEffects } from '../../utils/handleGuessOutcome';
-import { resolveNextCardWithServerFallback } from '../../utils/nextCardAdvancer';
-import { advanceReducer, initialAdvance, DEFAULT_RETRY_BUDGET } from '../../utils/advanceState';
-import type { AdvanceEvent, AdvanceSnapshot, AdvanceState } from '../../utils/advanceState';
 import { isE2EMode } from '../../utils/e2eMode';
 import { prefetchIfLow, warmAllDeckIfNeeded } from '../../services/cardPrefetcher';
 import { getNextImagesForScope } from '../../utils/storageDatum';
 import { computeMultiplier, SPEED_MULTIPLIER_BASE } from '../../utils/speedMultiplier';
+import { computePoints } from '../../utils/guessPoints';
+import { useAdvanceStateMachine } from '../../hooks/useAdvanceStateMachine';
+import { useResolveLifecycle } from '../../hooks/useResolveLifecycle';
+import { useAdCadence } from '../../hooks/useAdCadence';
 import { useAdSource } from '../../hooks/useAdSource';
 import { useStreak } from '../../hooks/useStreak';
 import { resolveStreakTier } from '../../constants/streakTiers';
-import { consumeAdSlot } from '../../utils/adCadence';
+import { OverlayZIndex } from '../../constants/overlayZIndex';
 import type { AdScope } from '../../utils/adCadence';
-import { shouldSuppressAds } from '../../services/billing/entitlements';
-import type { AuthContextLike } from '../../services/billing/entitlements';
 import type { AdSource } from '../../services/ads/AdSource';
 
 type HiddenLocation = { x: number; y: number };
@@ -67,38 +65,6 @@ type GuessNavigation = {
   addListener(event: 'beforeRemove', listener: () => void): () => void;
 };
 
-type NextGuessResult = { params: Record<string, unknown> } | null | undefined;
-
-function computePoints(speedMultiplier: number, streakMultiplier: number): number {
-  return Math.round(speedMultiplier * streakMultiplier);
-}
-
-// Exponential retry cadence for the `warming` state (§5.3 + §8 risk row).
-// 3 attempts total, 1s/2s/4s. After the budget is consumed the reducer
-// transitions to `exhausted` via the final RETRY_TICK (no further resolve).
-const RETRY_DELAYS_MS = [1000, 2000, 4000];
-
-type DecideAdSlotArgs = {
-  successesSinceLastAd: number;
-  scope?: AdScope;
-  authContext: AuthContextLike;
-  isAndroid: boolean;
-  adSource: AdSource;
-};
-
-function decideAdSlot({ successesSinceLastAd, scope, authContext, isAndroid, adSource }: DecideAdSlotArgs) {
-  // Cadence decision — owned solely by consumeAdSlot.
-  // Short-circuit on isAndroid preserves the original platform gate so adSource.isReady()
-  // is never evaluated on iOS (where adSource may be a no-op composite).
-  return consumeAdSlot({
-    successesSinceLastAd,
-    scope,
-    isAdFree: shouldSuppressAds(authContext),
-    isE2E: isE2EMode(),
-    isSourceReady: isAndroid && adSource.isReady(),
-  });
-}
-
 type SharedParams = {
   onTarget: boolean;
   imageFile?: string;
@@ -116,28 +82,6 @@ type SharedParams = {
   language?: string;
   scope?: AdScope;
 };
-
-function buildSharedParams(args: SharedParams): SharedParams {
-  return { ...args };
-}
-
-type ResolveCorrectGuessOutcomeArgs = {
-  multiplier: number;
-  currentStreak: number;
-};
-
-type CorrectGuessOutcome = {
-  nextStreak: number;
-  nextTier: ReturnType<typeof resolveStreakTier>;
-  finalPoints: number;
-};
-
-function resolveCorrectGuessOutcome({ multiplier, currentStreak }: ResolveCorrectGuessOutcomeArgs): CorrectGuessOutcome {
-  const nextStreak = currentStreak + 1;
-  const nextTier = resolveStreakTier(nextStreak);
-  const finalPoints = computePoints(multiplier, nextTier.multiplier);
-  return { nextStreak, nextTier, finalPoints };
-}
 
 type GuessScreenProps = {
   navigation: GuessNavigation;
@@ -181,57 +125,10 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
 
   const [showSuccess, setShowSuccess] = useState(false);
   const [successMultiplier, setSuccessMultiplier] = useState<number>(SPEED_MULTIPLIER_BASE);
-  // C1: mirror successMultiplier into a ref so the in-flight resolve kicked off
-  // inside the same render as setSuccessMultiplier reads the FRESH value. The
-  // state update is batched + committed on the next tick, but runResolveCycle
-  // captures the closure now — without the ref, onAdvanceResolved would score
-  // the win with the previous-tap multiplier.
-  const successMultiplierRef = useRef<number>(SPEED_MULTIPLIER_BASE);
   const { streak, tier, multiplier: streakMultiplier, onWin, onLose, reset } = useStreak();
-  const [advance, dispatchAdvance] = useReducer(
-    (prev: AdvanceSnapshot, event: AdvanceEvent) => advanceReducer(prev, event),
-    initialAdvance,
-  );
-  // PT6: retry timers live in a ref so they survive renders but can be cleared
-  // synchronously from cleanup / AppState handlers without waiting for state.
-  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const retryCountRef = useRef<number>(0);
-  // Mirror advance.state into a ref so the AppState listener (mounted once) can
-  // read the latest state without re-subscribing on every transition.
-  const advanceStateRef = useRef<AdvanceState>(advance.state);
-  // C1 (ad-in-screen-overlay §4.2): holds the in-flight next-card resolve
-  // Promise kicked off in applySuccessPath so handleOverlayDone can await it
-  // instead of re-entering the cascade at dismiss. Discarded on unmount (PT6
-  // cleanup) so a swipe-home during the overlay never lands a setState-after-
-  // unmount when the trailing resolve settles.
-  const nextCardResolveRef = useRef<Promise<void> | null>(null);
-  // CONCERN #1 (post-implementation verification pass): PT6 cleanup nulls
-  // nextCardResolveRef but cannot cancel the in-flight runResolveCycle()
-  // Promise. When it settles post-unmount, onAdvanceResolved would fire
-  // applySuccessSideEffects → bufferScore (AsyncStorage) + removeImageFromList
-  // (deck mutation) + deleteImageFromStorage (file delete). User decision:
-  // ABORT the win-credit on swipe-home. Flipped to false in the PT6 cleanup
-  // below; checked at the top of onAdvanceResolved.
-  const mountedRef = useRef(true);
-  // Snapshot ref used by `dispatch` to compute the next state synchronously.
-  // useEffect([advance.state]) updates advanceStateRef AFTER commit, but an
-  // awaited async chain (e.g. runResolveCycle → onAdvanceResolved) continues
-  // on the microtask queue before passive effects run, leaving the ref stale.
-  // dispatch updates both refs synchronously so the A7 guard inside
-  // onAdvanceResolved and the AppState listener see the post-event state
-  // immediately. The useEffect below is defense-in-depth (re-syncs from the
-  // committed advance in case the optimistic update diverged).
-  const advanceSnapRef = useRef<AdvanceSnapshot>(advance);
-  const dispatch = useCallback((event: AdvanceEvent) => {
-    const next = advanceReducer(advanceSnapRef.current, event);
-    advanceSnapRef.current = next;
-    advanceStateRef.current = next.state;
-    dispatchAdvance(event);
-  }, [dispatchAdvance]);
-  useEffect(() => {
-    advanceSnapRef.current = advance;
-    advanceStateRef.current = advance.state;
-  }, [advance]);
+  const { advance, dispatch, advanceStateRef } = useAdvanceStateMachine({
+    navigation,
+  });
   // Hints show on the first card of each game series (every fresh mount of
   // GuessScreen). Advancing to later cards uses setParams (no remount), so the
   // dismissed state persists for the rest of the series. Suppressed in e2e mode.
@@ -241,16 +138,67 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
   const authContext = useContext(AuthContext);
   const { userId } = authContext;
 
-  const [successesSinceLastAd, setSuccessesSinceLastAd] = useState(0);
   const adSource = useAdSource();
+  const {
+    consumeAdSlot,
+    resetSuccessesSinceLastAd,
+  } = useAdCadence({ scope, authContext, adSource });
 
   // C2 (ad-in-screen-overlay §4.4): in-component overlay state. adPhase gates
-  // the conditional <AdInterstitial> render. pendingNextRef holds the resolved
-  // next card so the post-ad RESOLVED dispatch can fire from handleAdDone —
-  // the advance state machine stays in `advancing` during the ad (no premature
-  // setParams), then lands in `idle` on dismiss.
+  // the conditional <AdInterstitial> render.
   const [adPhase, setAdPhase] = useState<'idle' | 'showing'>('idle');
-  const pendingNextRef = useRef<NonNullable<NextGuessResult> | null>(null);
+
+  // §2.3 (2) + §2.4: resolve-lifecycle machinery (nextCardResolveRef,
+  // pendingNextRef, runResolveCycle, onAdvanceResolved, scheduleRetry,
+  // retryTimerRef, retryCountRef, mountedRef, handleAdDone) lives in the hook.
+  // `multiplier` is threaded explicitly through runResolveCycle →
+  // onAdvanceResolved → scheduleRetry → runResolveCycle so the success-time
+  // value survives the retry loop with no parallel multiplier mirror ref.
+  const {
+    kickoffResolve,
+    awaitResolve,
+    consumePendingNext,
+    handleAdDone,
+    clearRetryTimer,
+  } = useResolveLifecycle({
+    dispatch,
+    advanceStateRef,
+    setAdPhase,
+    currentStreak: streak,
+    onWin,
+    resolveArgs: {
+      category,
+      language,
+      currentListId: listId,
+      currentPictureId: pictureId,
+      isTutorial,
+      scope,
+      authContext,
+    },
+    sideEffectArgs: {
+      listId,
+      categoryKey: category?.key,
+      language,
+      imageFile,
+      pictureId,
+      scope,
+      userId,
+    },
+    consumeAdSlot,
+  });
+
+  // PT6 cleanup ownership stays in GuessScreen: clear retry timers only when a
+  // real mid-advance -> terminal/idle transition happens, not on every render.
+  const previousAdvanceStateRef = useRef(advance.state);
+  useEffect(() => {
+    const previousState = previousAdvanceStateRef.current;
+    previousAdvanceStateRef.current = advance.state;
+    const wasMidAdvance = previousState === 'advancing' || previousState === 'warming';
+    const isMidAdvance = advance.state === 'advancing' || advance.state === 'warming';
+    if (wasMidAdvance && !isMidAdvance) {
+      clearRetryTimer();
+    }
+  }, [advance.state, clearRetryTimer]);
 
   const { group, theme } = useScopedPrivateGroupTheme(scope);
 
@@ -261,22 +209,6 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
       headerTintColor: theme.headerTintColor,
     });
   }, [navigation, theme?.primaryColor, theme?.headerTintColor]);
-
-  // PB1: the advance reducer is the single source of truth for advance. The reducer
-  // itself is pure (no navigation); this idle-entry side-effect consumes a staged
-  // `advance.next` via setParams whenever the machine lands in `idle` with a non-null
-  // payload. Identity-tracked (single-apply-per-resolve latch) so a re-dispatch with
-  // the same `next` reference (e.g. test mocks returning a shared object, or any
-  // future code path that re-stages without a new reference) does not double-apply
-  // setParams. The latch's premise is now the in-overlay RESOLVED dispatch — the
-  // AdScreen round-trip is gone, but the single-apply invariant still holds.
-  const appliedNextRef = useRef<Record<string, unknown> | null>(null);
-  useEffect(() => {
-    if (advance.state === 'idle' && advance.next && appliedNextRef.current !== advance.next) {
-      appliedNextRef.current = advance.next;
-      navigation.setParams(advance.next);
-    }
-  }, [advance.state, advance.next, navigation]);
 
   // Eagerly warm the 'all' deck on entering a real-category streak so the
   // category→all fallback is instant when the category exhausts. Fire-and-forget;
@@ -292,44 +224,6 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only warm
   }, []);
 
-  // PT6: clear any pending retry timer on unmount so we never setState after
-  // unmount (Leave tap during warming, navigation.popToTop, etc.). C1: also
-  // discard the in-flight next-card resolve ref so a swipe-home during the
-  // SuccessOverlay does not land a setState-after-unmount when the trailing
-  // resolve settles.
-  useEffect(() => {
-    return () => {
-      if (retryTimerRef.current !== null) {
-        clearTimeout(retryTimerRef.current);
-        retryTimerRef.current = null;
-      }
-      nextCardResolveRef.current = null;
-      mountedRef.current = false;
-    };
-  }, []);
-
-  // PT6 (Phase 1 review fix B): also clear any in-flight retry timer when
-  // the screen transitions OUT of a mid-advance state (advancing/warming →
-  // idle/exhausted). React 19 batches the idle→advancing→warming dispatches
-  // (separated only by a microtask boundary in runResolveCycle) into a single
-  // commit, so a cleanup keyed on a derived isMidAdvance boolean would fire on
-  // that batched commit — AFTER scheduleRetry has already set the timer — and
-  // silently cancel the next retry. Track the previous state in a ref and only
-  // clear when actually leaving mid-advance. Forward-safety: today the timer
-  // self-nulls at firing so this is a no-op, but a future regression that
-  // schedules a timer and transitions without self-nulling will be caught.
-  const prevAdvanceStateRef = useRef<AdvanceState>(advance.state);
-  useEffect(() => {
-    const prev = prevAdvanceStateRef.current;
-    prevAdvanceStateRef.current = advance.state;
-    const wasMidAdvance = prev === 'advancing' || prev === 'warming';
-    const isMidAdvanceNow = advance.state === 'advancing' || advance.state === 'warming';
-    if (wasMidAdvance && !isMidAdvanceNow && retryTimerRef.current !== null) {
-      clearTimeout(retryTimerRef.current);
-      retryTimerRef.current = null;
-    }
-  }, [advance.state]);
-
   // PT2: AppState listener. Backgrounding from any mid-advance state
   // (advancing/warming) clears retry timers and forces `exhausted` so the
   // player lands on a deterministic state on foreground (timers don't survive
@@ -339,15 +233,12 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
       if (nextAppState === 'active') return;
       const current = advanceStateRef.current;
       if (current !== 'idle' && current !== 'exhausted') {
-        if (retryTimerRef.current !== null) {
-          clearTimeout(retryTimerRef.current);
-          retryTimerRef.current = null;
-        }
+        clearRetryTimer();
         dispatch({ type: 'FAILED_PERMANENT' });
       }
     });
     return () => sub.remove();
-  }, [dispatch]);
+  }, [dispatch, clearRetryTimer]);
 
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const uri = imageFile;
@@ -404,34 +295,33 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
       currentListId: listId,
     }).catch(() => {});
     setSuccessMultiplier(multiplier);
-    successMultiplierRef.current = multiplier;
     setShowSuccess(true);
     // C1 (§4.2): the WIN dispatch + resolve kickoff both fire at WIN time so
     // the ~2-3s SuccessOverlay window covers a Tier-1/Tier-2 fetch. The A7
     // guard in onAdvanceResolved requires advanceStateRef to read 'advancing'
     // before the in-flight resolve can commit side effects, so dispatch(WIN)
-    // precedes the kickoff. handleOverlayDone awaits nextCardResolveRef.current
-    // at dismiss — usually already settled.
+    // precedes the kickoff. handleOverlayDone awaits the in-flight resolve at
+    // dismiss — usually already settled. The multiplier is threaded through
+    // kickoffResolve so it survives the retry loop without a mirror ref.
     dispatch({ type: 'WIN' });
-    retryCountRef.current = 0;
-    nextCardResolveRef.current = runResolveCycle();
+    kickoffResolve(multiplier);
   }
 
   function applyFailurePath(sharedParams: SharedParams) {
     onLose();
-    setSuccessesSinceLastAd(0);
+    resetSuccessesSinceLastAd();
     navigation.replace('ResultScreen', sharedParams);
   }
 
   async function toAdScreen(targetInfos: TargetInfos) {
     const onTarget = isOnTarget(targetInfos);
     const multiplier = computeMultiplier(targetInfos?.elapsedMs ?? 0);
-    const sharedParams = buildSharedParams({
+    const sharedParams: SharedParams = {
       onTarget, imageFile: uri, pictureId, description,
       imageHeight, imageWidth, isPortrait, hiddenLocation,
       screenHeight, screenWidth, listId, isTutorial,
       category, language, scope,
-    });
+    };
     if (!onTarget) {
       applyFailurePath(sharedParams);
       return;
@@ -444,10 +334,11 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
     // "frozen" loading spinner. The advance state machine takes over the UI
     // (advancing/warming) while the next card resolves.
     setShowSuccess(false);
-    // C1 (§4.2): await the resolve kicked off in applySuccessPath. The ref is
-    // always populated when handleOverlayDone fires (showSuccess is only true
-    // after applySuccessPath); no fallback branch per agent-defaults §2.2.
-    await nextCardResolveRef.current;
+    // C1 (§4.2): await the resolve kicked off in applySuccessPath. The
+    // in-flight ref is always populated when handleOverlayDone fires
+    // (showSuccess is only true after applySuccessPath); no fallback branch
+    // per agent-defaults §2.2.
+    await awaitResolve();
     // P2: in the no-ad path, RESOLVED is dispatched HERE (after the overlay
     // animation completes) instead of inside onAdvanceResolved so the next
     // card's imageFile URI does not land in route.params WHILE the overlay is
@@ -459,131 +350,11 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
     // through an internal ref kept fresh on every parent render, so the
     // adPhase read sees the latest committed value — no stale-closure risk.
     if (adPhase !== 'showing') {
-      const next = pendingNextRef.current;
-      pendingNextRef.current = null;
+      const next = consumePendingNext();
       if (next) {
         dispatch({ type: 'RESOLVED', next: next.params });
       }
     }
-  }
-
-  // Drives the advance state machine from a single resolve attempt. Called
-  // initially by handleOverlayDone (state=advancing) and re-entered on each
-  // scheduled retry tick (state=warming). Side effects (streak commit, score
-  // buffer, ad cadence, setParams/navigation) fire ONLY on a successful
-  // resolve — see onAdvanceResolved (PB6).
-  async function runResolveCycle() {
-    const { next, reason } = await resolveNextCardWithServerFallback({
-      category, language, currentListId: listId, currentPictureId: pictureId, isTutorial, scope, authContext,
-    });
-
-    if (next) {
-      await onAdvanceResolved(next);
-      return;
-    }
-
-    // P1 (ad-overlay post-fix §1 C1): treat reason='empty' the same as
-    // reason='network'|'server' — all non-ok reasons are transient. The
-    // cascade's Tier 4 looping-replay almost always recovers on retry (the
-    // server doesn't delete played cards); the safety-net panel only mounts
-    // after 3 failed retries (state='exhausted'). Never interrupt the streak
-    // on a single empty cascade.
-    // FAILED_TRANSIENT is a no-op when already in warming (reducer rejects it);
-    // legal only from advancing.
-    dispatch({ type: 'FAILED_TRANSIENT' });
-    scheduleRetry();
-  }
-
-  // PB6: streak + score commit lives here — only on a successfully resolved
-  // next card. Pairs with the cadence rollback (no commit) on null advance.
-  async function onAdvanceResolved(next: NonNullable<NextGuessResult>) {
-    // A7 (Phase 2 review): the in-flight resolve may complete AFTER AppState
-    // backgrounding forced FAILED_PERMANENT → `exhausted`. Without this guard,
-    // onWin / applySuccessSideEffects / decideAdSlot / setAdPhase would all
-    // fire on stale state (the reducer correctly rejects the trailing RESOLVED,
-    // but the side effects have already happened). Mirror advance.state via
-    // advanceStateRef and bail before any side effect. Both 'advancing'
-    // (initial resolve) and 'warming' (retry recovery) are valid resolving
-    // states — the reducer accepts RESOLVED from either.
-    if (advanceStateRef.current !== 'advancing' && advanceStateRef.current !== 'warming') return;
-    // mountedRef guard: a swipe-home during SuccessOverlay nulls nextCardResolveRef
-    // but does NOT cancel the in-flight Promise. applySuccessSideEffects mutates
-    // AsyncStorage + the local deck + the filesystem — those must NOT fire post-unmount.
-    if (!mountedRef.current) return;
-    const { nextStreak, nextTier, finalPoints } = resolveCorrectGuessOutcome({ multiplier: successMultiplierRef.current, currentStreak: streak });
-    onWin();
-    await applySuccessSideEffects({ listId, categoryKey: category?.key, language, imageFile: uri, pictureId, scope, userId, points: finalPoints, multiplier: successMultiplierRef.current, streak: nextStreak, streakMultiplier: nextTier.multiplier });
-
-    const { showAd, nextCount } = decideAdSlot({
-      successesSinceLastAd, scope, authContext,
-      isAndroid: Platform.OS === 'android',
-      adSource,
-    });
-    setSuccessesSinceLastAd(nextCount);
-
-    // P2: when no ad is due, RESOLVED is NOT dispatched here in the INITIAL
-    // resolve (state=advancing) — the resolved next is staged on
-    // pendingNextRef and the dispatch is deferred to handleOverlayDone
-    // (mirrors the ad-path defer to handleAdDone) so the next image's
-    // imageFile URI does not land in route.params while the SuccessOverlay is
-    // still animating. The ad branch below stages on the same ref + flips
-    // adPhase → 'showing'; RESOLVED fires from handleAdDone after the ad
-    // dismisses. handleOverlayDone's `adPhase !== 'showing'` guard keeps the
-    // two paths mutually exclusive (no double dispatch).
-    //
-    // WARMING EXCEPTION: when state=warming, the resolve that fired this
-    // onAdvanceResolved came from scheduleRetry's fire-and-forget
-    // runResolveCycle() (NOT the promise stored in nextCardResolveRef). By
-    // this point handleOverlayDone has already returned (its await on the
-    // original nextCardResolveRef completed when the first runResolveCycle
-    // returned null+network and dispatched FAILED_TRANSIENT). No later
-    // callback exists to commit a staged next, so we dispatch immediately to
-    // preserve the "RESOLVED exactly once per win cycle" invariant. The A7
-    // guard above already admitted state=warming as a valid resolving state.
-    if (!showAd) {
-      if (advanceStateRef.current === 'advancing') {
-        pendingNextRef.current = next;
-        return;
-      }
-      dispatch({ type: 'RESOLVED', next: next.params });
-      return;
-    }
-
-    // C2 (ad-in-screen-overlay §3.2 step 3-5): showAd branch renders the
-    // in-component overlay. Stage the resolved next on the ref + flip
-    // adPhase → 'showing'. RESOLVED is deferred to handleAdDone so the
-    // reducer lands in `idle` only after the ad dismisses.
-    pendingNextRef.current = next;
-    setAdPhase('showing');
-  }
-
-  // C2: fires from AdInterstitial's onDone (post-ad). Hides the overlay +
-  // dispatches RESOLVED with the staged next so the idle-entry side-effect
-  // consumes setParams(advance.next). useCallback keeps the onDone ref
-  // stable across re-renders so AdInterstitial's effect deps don't churn.
-  const handleAdDone = useCallback(() => {
-    const next = pendingNextRef.current;
-    pendingNextRef.current = null;
-    setAdPhase('idle');
-    if (next) {
-      dispatch({ type: 'RESOLVED', next: next.params });
-    }
-  }, [dispatch]);
-
-  // Schedule the next warming retry. Exponential backoff 1s/2s/4s. After the
-  // budget is consumed, the final RETRY_TICK transitions the reducer to
-  // `exhausted` and we do not issue another resolve.
-  function scheduleRetry() {
-    retryCountRef.current += 1;
-    const n = retryCountRef.current;
-    const delay = RETRY_DELAYS_MS[n - 1] ?? RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1];
-    retryTimerRef.current = setTimeout(() => {
-      retryTimerRef.current = null;
-      dispatch({ type: 'RETRY_TICK' });
-      if (n < DEFAULT_RETRY_BUDGET) {
-        void runResolveCycle();
-      }
-    }, delay);
   }
 
   function handleExitToHome() {
@@ -639,7 +410,7 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
     <NextCardImageWarmer uris={nextCardUris} />
     <SuccessOverlay visible={showSuccess} multiplier={successMultiplier} points={computePoints(successMultiplier, streakMultiplier)} streakTier={tier} onDone={handleOverlayDone} />
     {adPhase === 'showing' && (
-      <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, zIndex: 9998 }}>
+      <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, zIndex: OverlayZIndex.AD_INTERSTITIAL }}>
         <AdInterstitial adSource={adSource} onDone={handleAdDone} />
       </View>
     )}

--- a/screens/GuessScreens/GuessScreen.tsx
+++ b/screens/GuessScreens/GuessScreen.tsx
@@ -474,7 +474,7 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
   // resolve — see onAdvanceResolved (PB6).
   async function runResolveCycle() {
     const { next, reason } = await resolveNextCardWithServerFallback({
-      category, language, currentListId: listId, isTutorial, scope, authContext,
+      category, language, currentListId: listId, currentPictureId: pictureId, isTutorial, scope, authContext,
     });
 
     if (next) {
@@ -643,7 +643,7 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
         <AdInterstitial adSource={adSource} onDone={handleAdDone} />
       </View>
     )}
-    {advance.state === 'warming' && (
+    {(advance.state === 'warming' || (advance.state === 'advancing' && !showSuccess)) && (
       <GuessAdvanceLoader />
     )}
     {advance.state === 'exhausted' && (

--- a/services/cardDeck.js
+++ b/services/cardDeck.js
@@ -44,6 +44,22 @@ function isPrivateScope(scope) {
  */
 const fetchInFlight = new Map();
 
+/**
+ * Build the dedup key for an in-flight fetchCardBatch call.
+ *
+ * The key encodes BOTH scope identity and fetch mode so unrelated calls stay
+ * independent:
+ * - scope: `public`, or `private:<groupId>:<categoryId|all>`.
+ * - mode: derived from pictureIdOverride — `'cursor'` when undefined (read
+ *   getLastImageUuid), `'head'` when null (fresh-from-start fetch),
+ *   `uuid:<id>` when an explicit picture id is requested.
+ *
+ * Consequence: two concurrent cursor calls for the same scope collapse onto
+ * one promise; a cursor call and a head call do NOT (different batches).
+ *
+ * @param {object} args - { categoryKey, categoryId, language, scope, pictureIdOverride }
+ * @returns {string} dedup key used by fetchInFlight
+ */
 function fetchBatchDedupKey({ categoryKey, categoryId, language, scope, pictureIdOverride }) {
   const lang = normalizeLanguage(language);
   const mode = pictureIdOverride === undefined
@@ -60,6 +76,27 @@ function fetchBatchDedupKey({ categoryKey, categoryId, language, scope, pictureI
   return `${categoryKey || 'all'}:${lang}:${scopePart}:${mode}`;
 }
 
+/**
+ * Shared transport for EVERY card-fetch caller (background prefetcher,
+ * foreground top-up, SwipeImage.loadNewImages). Resolves the next batch from
+ * the backend for the given scope.
+ *
+ * pictureIdOverride resolution:
+ * - `undefined` → read the persisted cursor via getLastImageUuid.
+ * - `null` → head fetch (query from start, ignore cursor).
+ * - `PUBLIC_FEED_END_CURSOR` sentinel → coerced to null (legacy self-heal).
+ * - any other value → fetch the batch following that exact picture id.
+ *
+ * In-flight collapse: concurrent callers with the same dedup key share ONE
+ * promise. The promise is stored in fetchInFlight BEFORE the first await so
+ * the second caller sees it synchronously; the entry is deleted in `.finally`,
+ * identity-guarded so a late clear cannot evict a newer promise for the key.
+ * Eliminates the duplicate network round-trip + base64 decode that previously
+ * occurred when prefetch/top-up/loadNewImages fired near-simultaneously.
+ *
+ * @param {object} opts - { categoryKey, categoryId, language, scope, authContext, pictureIdOverride }
+ * @returns {Promise<object>} backend batch response from getImages
+ */
 export function fetchCardBatch({ categoryKey, categoryId, language, scope, authContext, pictureIdOverride } = {}) {
   const key = fetchBatchDedupKey({ categoryKey, categoryId, language, scope, pictureIdOverride });
   const existing = fetchInFlight.get(key);
@@ -98,6 +135,14 @@ export function fetchCardBatch({ categoryKey, categoryId, language, scope, authC
   return p;
 }
 
+/**
+ * Overwrite (not append) the persisted deck for the scope with the given cards.
+ * Public scope → storeImageList; private scope → writeGroupFeedCache.
+ * Always returns null (callers ignore the deck contents here).
+ *
+ * @param {object} args - { cards, categoryKey, categoryId, language, scope }
+ * @returns {Promise<null>}
+ */
 export async function persistCardBatch({ cards, categoryKey, categoryId, language, scope } = {}) {
   const lang = normalizeLanguage(language);
 
@@ -138,6 +183,17 @@ function appendCardBatchLockKey({ categoryKey, categoryId, language, scope }) {
   return `cardDeck:append:public:${categoryKey || 'all'}:${lang}`;
 }
 
+/**
+ * Append a batch to the persisted deck, scope-aware (mirrors persistCardBatch
+ * but appends instead of overwriting). Dedups incoming cards against the
+ * existing deck via dedupByPictureId, then serializes the read-modify-write
+ * per scope under withScopeLock. The append lock key (appendCardBatchLockKey)
+ * is deliberately separate from the fetch dedup key (fetchBatchDedupKey), so
+ * the append lock never blocks the fetch path — no deadlock.
+ *
+ * @param {object} args - { cards, categoryKey, categoryId, language, scope }
+ * @returns {Promise<null>} always null (matches persistCardBatch contract)
+ */
 export async function appendCardBatch({ cards, categoryKey, categoryId, language, scope } = {}) {
   const lang = normalizeLanguage(language);
 

--- a/services/cardDeck.js
+++ b/services/cardDeck.js
@@ -27,25 +27,75 @@ function isPrivateScope(scope) {
   return !!scope && scope.kind === 'private' && !!scope.groupId;
 }
 
-export async function fetchCardBatch({ categoryKey, categoryId, language, scope, authContext, pictureIdOverride } = {}) {
+/**
+ * In-flight dedup for fetchCardBatch. Concurrent callers for the SAME scope
+ * AND fetch mode collapse onto ONE in-flight promise; different modes
+ * (cursor vs head vs explicit uuid) and different scopes run independently.
+ * Mirrors the `inFlight` Map pattern in services/cardPrefetcher.ts.
+ *
+ * Why: nothing previously deduped concurrent fetchCardBatch calls. When the
+ * deck ran low, prefetchIfLow / foregroundTopUp / SwipeImage.loadNewImages
+ * all fired near-simultaneously, each reading the SAME persisted cursor
+ * (which only advances deep inside getImages) and each POSTing the identical
+ * next_image_batch → the same batch downloaded 2×–4×. appendCardBatch's
+ * dedup hid the duplicate from the persisted deck but the network work and
+ * base64 decode still repeated. Collapsing the callers onto one promise
+ * eliminates the duplicate network round-trip at the source.
+ */
+const fetchInFlight = new Map();
+
+function fetchBatchDedupKey({ categoryKey, categoryId, language, scope, pictureIdOverride }) {
   const lang = normalizeLanguage(language);
-  const lastImageUuid = await getLastImageUuid(categoryKey, lang);
-  const pictureId = pictureIdOverride !== undefined ? pictureIdOverride : lastImageUuid;
+  const mode = pictureIdOverride === undefined
+    ? 'cursor'
+    : pictureIdOverride === null
+      ? 'head'
+      : `uuid:${pictureIdOverride}`;
+  let scopePart;
+  if (isPrivateScope(scope)) {
+    scopePart = `private:${scope.groupId}:${resolveCategoryId(categoryId) ?? 'all'}`;
+  } else {
+    scopePart = 'public';
+  }
+  return `${categoryKey || 'all'}:${lang}:${scopePart}:${mode}`;
+}
 
-  // Legacy self-heal: prior app versions persisted PUBLIC_FEED_END_CURSOR to
-  // mark a category exhausted. The cold-mount path now bypasses the cursor
-  // (always passes null), but refillOrFallback's foreground load and the
-  // background prefetcher still call fetchCardBatch with no override. Treat
-  // the stale sentinel as a fresh cursor so those paths also re-query from
-  // head; the next non-empty batch overwrites the stale key with a real uuid.
-  const effectivePictureId = pictureId === PUBLIC_FEED_END_CURSOR ? null : pictureId;
+export function fetchCardBatch({ categoryKey, categoryId, language, scope, authContext, pictureIdOverride } = {}) {
+  const key = fetchBatchDedupKey({ categoryKey, categoryId, language, scope, pictureIdOverride });
+  const existing = fetchInFlight.get(key);
+  if (existing) {
+    return existing;
+  }
 
-  return getImages(effectivePictureId, authContext, {
-    category_id: resolveCategoryId(categoryId),
-    category_key: categoryKey || 'all',
-    language: resolveServerLanguage(language),
-    scope,
+  const p = (async () => {
+    const lang = normalizeLanguage(language);
+    const lastImageUuid = await getLastImageUuid(categoryKey, lang);
+    const pictureId = pictureIdOverride !== undefined ? pictureIdOverride : lastImageUuid;
+
+    // Legacy self-heal: prior app versions persisted PUBLIC_FEED_END_CURSOR to
+    // mark a category exhausted. The cold-mount path now bypasses the cursor
+    // (always passes null), but refillOrFallback's foreground load and the
+    // background prefetcher still call fetchCardBatch with no override. Treat
+    // the stale sentinel as a fresh cursor so those paths also re-query from
+    // head; the next non-empty batch overwrites the stale key with a real uuid.
+    const effectivePictureId = pictureId === PUBLIC_FEED_END_CURSOR ? null : pictureId;
+
+    return getImages(effectivePictureId, authContext, {
+      category_id: resolveCategoryId(categoryId),
+      category_key: categoryKey || 'all',
+      language: resolveServerLanguage(language),
+      scope,
+    });
+  })();
+
+  fetchInFlight.set(key, p);
+  p.finally(() => {
+    if (fetchInFlight.get(key) === p) {
+      fetchInFlight.delete(key);
+    }
   });
+
+  return p;
 }
 
 export async function persistCardBatch({ cards, categoryKey, categoryId, language, scope } = {}) {

--- a/utils/guessPoints.ts
+++ b/utils/guessPoints.ts
@@ -1,0 +1,31 @@
+import { resolveStreakTier } from '../constants/streakTiers';
+
+/**
+ * Guess points combine the speed bonus and the current streak tier.
+ * Shared helper so overlay preview and persisted score use one formula.
+ */
+export function computePoints(speedMultiplier: number, streakMultiplier: number): number {
+  return Math.round(speedMultiplier * streakMultiplier);
+}
+
+export type ResolveCorrectGuessOutcomeArgs = {
+  multiplier: number;
+  currentStreak: number;
+};
+
+export type CorrectGuessOutcome = {
+  nextStreak: number;
+  nextTier: ReturnType<typeof resolveStreakTier>;
+  finalPoints: number;
+};
+
+/**
+ * Resolve the next streak state and final score for a correct guess.
+ * Shared pure helper so lifecycle code stays focused on async coordination.
+ */
+export function resolveCorrectGuessOutcome({ multiplier, currentStreak }: ResolveCorrectGuessOutcomeArgs): CorrectGuessOutcome {
+  const nextStreak = currentStreak + 1;
+  const nextTier = resolveStreakTier(nextStreak);
+  const finalPoints = computePoints(multiplier, nextTier.multiplier);
+  return { nextStreak, nextTier, finalPoints };
+}

--- a/utils/handleGuessOutcome.js
+++ b/utils/handleGuessOutcome.js
@@ -3,6 +3,16 @@ import { removeImageFromList, deleteImageFromStorage } from './storageDatum';
 import { resolveNextCard } from './nextCardResolver';
 import { SPEED_MULTIPLIER_BASE } from './speedMultiplier';
 
+/**
+ * Best-effort side effects of a correct guess: buffer the score, remove the
+ * played card from its OWN deck namespace (removeImageFromList by listId) so
+ * the deck advances past it, and delete the cached image file. Score buffering
+ * runs first; storage cleanup is wrapped so a failure there cannot unwind an
+ * already-buffered score.
+ *
+ * @param {object} args - { listId, categoryKey, language, imageFile, pictureId, scope, userId, points, multiplier, streak, streakMultiplier }
+ * @returns {Promise<void>}
+ */
 export async function applySuccessSideEffects({ listId, categoryKey, language, imageFile, pictureId, scope, userId, points = SPEED_MULTIPLIER_BASE, multiplier, streak = 0, streakMultiplier }) {
   await bufferScore({
     guessId: mintGuessId(),
@@ -26,6 +36,15 @@ export async function applySuccessSideEffects({ listId, categoryKey, language, i
   }
 }
 
+/**
+ * Resolve the params for the next card after a guess. Forwards
+ * currentPictureId (the just-played card) into resolveNextCard so it can be
+ * excluded from the next pick. Read-only: performs no network or storage
+ * mutation. Returns null if no next card is available.
+ *
+ * @param {object} args - { category, language, currentListId, isTutorial, scope, currentPictureId }
+ * @returns {Promise<{params: object}|null>}
+ */
 export async function resolveNextGuessParams({ category, language, currentListId, isTutorial, scope, currentPictureId }) {
   const result = await resolveNextCard({ category, language, currentListId, scope, currentPictureId });
   if (!result || !result.card) return null;

--- a/utils/handleGuessOutcome.js
+++ b/utils/handleGuessOutcome.js
@@ -26,8 +26,8 @@ export async function applySuccessSideEffects({ listId, categoryKey, language, i
   }
 }
 
-export async function resolveNextGuessParams({ category, language, currentListId, isTutorial, scope }) {
-  const result = await resolveNextCard({ category, language, currentListId, scope });
+export async function resolveNextGuessParams({ category, language, currentListId, isTutorial, scope, currentPictureId }) {
+  const result = await resolveNextCard({ category, language, currentListId, scope, currentPictureId });
   if (!result || !result.card) return null;
 
   const card = result.card;

--- a/utils/imagesRequests.js
+++ b/utils/imagesRequests.js
@@ -111,7 +111,7 @@ export async function prepareImageUpload(context, { contentType, contentLength }
 async function getImagesInfos({ config, userId, filters }) {
   //console.log("getImagesInfos");
   const url = `${process.env.EXPO_PUBLIC_APP_BACKEND_URL}api/v1/users/${userId}/get_image_batch`;
-  const requestConfig = { ...config };
+  const requestConfig = { ...config, timeout: 15000 };
   const params = {};
   if (filters?.category_id != null) params.category_id = filters.category_id;
   if (filters?.language != null) params.language = filters.language;
@@ -142,7 +142,7 @@ async function getNextImagesInfos({ config, userId, pictureId, filters }){
   const imageData = {
     image: imageBody
   };
-  const response = await axios.post(url, imageData, config )
+  const response = await axios.post(url, imageData, { ...config, timeout: 15000 })
     .then((response) => {
       //console.log("response getNextImagesInfos", response);
       return response;
@@ -158,12 +158,15 @@ async function getNextImagesInfos({ config, userId, pictureId, filters }){
 
 async function getImageFromStorage({ storageUrl, token }) {
   console.log("getImageFromStorage");
-  const config = usesBackendStorage(storageUrl) ? { headers: setStorageDownloadHeaders(token) } : {};
+  const config = usesBackendStorage(storageUrl) ? { headers: setStorageDownloadHeaders(token), timeout: 15000 } : { timeout: 15000 };
   const imageData = await axios.get(storageUrl, config)
   .then((response) => {
     //console.log("imageData response, getImageFromStorage");
     return response.data;
-  }).catch((error) => console.log("error getImageFromStorage", error.request));
+  }).catch((error) => {
+    const reason = error?.response?.status ?? error?.code ?? error?.message ?? 'unknown';
+    console.warn("getImageFromStorage failed", storageUrl, reason);
+  });
   // if "The specified key does not exist" -> send server image is not in aws -> error
   return imageData;
 };
@@ -321,10 +324,10 @@ export async function getImages(pictureId, context, filters = {}) {
     };
 
     const lastBatchPictureId = imagesInfosData[imagesInfosData.length - 1].name;
+    await saveLastImageUuid(lastBatchPictureId, filters?.category_key, filters?.language);
     const images = await downloadImageBatch(imagesInfosData, token);
 
     if (images.length > 0) {
-      await saveLastImageUuid(lastBatchPictureId, filters?.category_key, filters?.language);
       return { isError: false, images: images };
     }
 

--- a/utils/imagesRequests.js
+++ b/utils/imagesRequests.js
@@ -108,6 +108,18 @@ export async function prepareImageUpload(context, { contentType, contentLength }
 
 
 
+/**
+ * Fetch the head (first) image-metadata batch for a user. Used when no cursor
+ * exists yet (`pictureId === null` in `getImages`). Hits `get_image_batch`.
+ * `timeout: 15000` on every request. Returns `{ data: 401 }` on auth failure
+ * or `{ data: null, errorReason }` on other failures — never throws.
+ *
+ * @param {Object}  params
+ * @param {Object}  params.config  Axios config (headers) to merge with timeout.
+ * @param {string|number} params.userId Target user id.
+ * @param {Object}  [params.filters] Optional `category_id` / `language` filters.
+ * @returns {Promise<{data: 401} | {data: null, errorReason: GetImagesErrorReason} | import('axios').AxiosResponse>}
+ */
 async function getImagesInfos({ config, userId, filters }) {
   //console.log("getImagesInfos");
   const url = `${process.env.EXPO_PUBLIC_APP_BACKEND_URL}api/v1/users/${userId}/get_image_batch`;
@@ -131,6 +143,21 @@ async function getImagesInfos({ config, userId, filters }) {
   return response;
 };
 
+/**
+ * Fetch the next image-metadata batch using keyset pagination "after" a cursor.
+ * Posts the last picture's `name` as `{ image: { name: pictureId } }` to
+ * `next_image_batch`; the server returns strictly newer rows. Same timeout
+ * (15000) and same `{ data: 401 }` / `{ data: null, errorReason }` error
+ * contract as `getImagesInfos` — never throws.
+ *
+ * @param {Object}  params
+ * @param {Object}  params.config    Axios config (headers) to merge with timeout.
+ * @param {string|number} params.userId Target user id.
+ * @param {string}  params.pictureId Keyset cursor: the `name` of the last
+ *   image of the previous batch.
+ * @param {Object}  [params.filters] Optional `category_id` / `language` filters.
+ * @returns {Promise<{data: 401} | {data: null, errorReason: GetImagesErrorReason} | import('axios').AxiosResponse>}
+ */
 async function getNextImagesInfos({ config, userId, pictureId, filters }){
   //console.log("getNextImagesInfos");
   const url = `${process.env.EXPO_PUBLIC_APP_BACKEND_URL}api/v1/users/${userId}/next_image_batch`;
@@ -156,6 +183,20 @@ async function getNextImagesInfos({ config, userId, pictureId, filters }){
   return response;
 };
 
+/**
+ * Download one image's bytes from its storage URL (backend or external).
+ * GET with `timeout: 15000`; auth headers are attached only when the URL is
+ * backend-hosted (`usesBackendStorage`). On failure it `console.warn`s the URL
+ * + reason and resolves `undefined` (a falsy sentinel) — it does NOT throw, so
+ * a `Promise.all` batch keeps the successful downloads and the caller drops
+ * failures.
+ *
+ * @param {Object} params
+ * @param {string} params.storageUrl Absolute URL to fetch.
+ * @param {string} [params.token]    Auth token, attached only for backend URLs.
+ * @returns {Promise<string|undefined>} Resolves to the response body on
+ *   success, or `undefined` on failure.
+ */
 async function getImageFromStorage({ storageUrl, token }) {
   console.log("getImageFromStorage");
   const config = usesBackendStorage(storageUrl) ? { headers: setStorageDownloadHeaders(token), timeout: 15000 } : { timeout: 15000 };
@@ -192,6 +233,17 @@ async function ensureDirExists() {
   Paths.cache.create({ idempotent: true, intermediates: true });
 };
 
+/**
+ * Decode a base64 data-URL and persist it to the cache dir as a file.
+ * Writes `<filename>.<ext>` under `Paths.cache` and returns its `file://` uri.
+ * Returns `false` when `imageData` is not a base64 data-URL (caller treats
+ * falsy as "skip this image"). Does not throw.
+ *
+ * @param {string|*} imageData The raw base64 data-URL from storage.
+ * @param {string}   filename  Filename stem (no extension); extension is
+ *   parsed from the data-URL prefix.
+ * @returns {Promise<string|false>} The written file's `file://` uri, or `false`.
+ */
 async function extractBase64(imageData, filename) {
   console.log("extract base64 filename", filename);
 
@@ -215,6 +267,15 @@ async function extractBase64(imageData, filename) {
 
 };
 
+/**
+ * Fetch one image's bytes and decode to a cached `file://` path. Composes
+ * `getImageFromStorage` → `extractBase64`. Returns the file uri, or `false`
+ * (from `extractBase64`) when the payload is not base64. Does not throw.
+ *
+ * @param {Object} image Metadata row with at least `storage_url` and `name`.
+ * @param {string} token Auth token forwarded to `getImageFromStorage`.
+ * @returns {Promise<string|false>} Cached file uri or `false`.
+ */
 async function handleImagesDownload(image, token) {
   console.log("handleImagesDownload");
   console.log("image location", image.storage_url);
@@ -258,6 +319,16 @@ export function buildImageObject(image, filePath) {
   return imageObject;
 }
 
+/**
+ * Download + decode every image in a metadata batch concurrently. Uses
+ * `Promise.all`, so it resolves when the slowest image finishes (failures do
+ * not short-circuit). Per-image failures resolve falsy and are dropped by
+ * `.filter(Boolean)`, so the result holds only the partial successes.
+ *
+ * @param {Array<Object>} imagesInfosData Batch of metadata rows.
+ * @param {string}        token           Auth token for `getImageFromStorage`.
+ * @returns {Promise<Array<Object>>} Built `Image` objects (failures excluded).
+ */
 async function downloadImageBatch(imagesInfosData, token) {
   const downloadedImages = await Promise.all(
     imagesInfosData.map(async (image) => {
@@ -275,6 +346,34 @@ async function downloadImageBatch(imagesInfosData, token) {
 }
 
 
+/**
+ * Main feed entry. Resolves one playable batch of images for the public feed
+ * (private scopes are delegated to `fetchPrivateFeedPageForGame`).
+ *
+ * Bounded retry loop: at most `MAX_EMPTY_DOWNLOAD_BATCHES` (3) consecutive
+ * "broken" batches — a batch whose metadata fetched OK but yielded zero
+ * downloaded images — are skipped before giving up with a `reason: 'server'`
+ * error. Each iteration:
+ *   1. fetch metadata (`getImagesInfos` for the head / `getNextImagesInfos`
+ *      for an "after cursor" batch keyed by the previous tail `name`);
+ *   2. early returns: `data === null` → `{ isError: true, reason }`;
+ *      `data === 401` → auth error (no 'auth' `reason`; global apiClient
+ *      unauthorized handler owns logout/nav out-of-band);
+ *      empty `imagesInfosData.length === 0` → `{ isError: false, reason:'empty',
+ *      images: [] }` BEFORE any cursor write;
+ *   3. CURSOR ADVANCE: `saveLastImageUuid(lastBatchPictureId, ...)` is fired
+ *      for every valid non-empty batch — strictly BEFORE `downloadImageBatch`.
+ *      So the cursor never freezes on a broken batch: if every download in a
+ *      batch fails, the cursor has already advanced past it and the loop
+ *      re-queries beyond it next pass instead of re-querying the same batch
+ *      forever. Accepted trade-off over the old freeze behaviour.
+ *
+ * @param {string|null} pictureId Cursor: `name` of the last image of the
+ *   previous page, or `null` for the first page.
+ * @param {Object}      context   Auth context (forwarded to `getBackendHeaders`).
+ * @param {Object}      [filters] Optional `{ category_id, language, category_key, scope }`.
+ * @returns {Promise<GetImagesResult>}
+ */
 export async function getImages(pictureId, context, filters = {}) {
   console.log("getImages");
   console.log("getImages pictureId", pictureId);
@@ -297,7 +396,6 @@ export async function getImages(pictureId, context, filters = {}) {
 
   let nextPictureId = pictureId;
   let skippedBrokenBatches = 0;
-  let lastSkippedPictureId = null;
 
   while (skippedBrokenBatches <= MAX_EMPTY_DOWNLOAD_BATCHES) {
     const imagesInfos = nextPictureId === null
@@ -332,7 +430,6 @@ export async function getImages(pictureId, context, filters = {}) {
     }
 
     skippedBrokenBatches += 1;
-    lastSkippedPictureId = lastBatchPictureId;
     nextPictureId = lastBatchPictureId;
   }
 

--- a/utils/nextCardAdvancer.ts
+++ b/utils/nextCardAdvancer.ts
@@ -29,6 +29,7 @@ export type AdvancerArgs = {
   category?: { id?: string | number | null; key?: string } | null;
   language?: string | null;
   currentListId?: number;
+  currentPictureId?: string;
   isTutorial?: boolean;
   scope?: unknown;
   authContext?: unknown;
@@ -103,6 +104,7 @@ async function foregroundTopUp(
       category: args.category,
       language: args.language,
       currentListId: args.currentListId,
+      currentPictureId: args.currentPictureId,
       isTutorial: args.isTutorial,
       scope: args.scope,
     });
@@ -142,12 +144,13 @@ export async function resolveNextCardWithServerFallback({
   category,
   language,
   currentListId,
+  currentPictureId,
   isTutorial,
   scope,
   authContext,
 }: AdvancerArgs): Promise<ResolveNextCardResult> {
   const categoryKey = category?.key || 'all';
-  const resolveArgs = { category, language, currentListId, isTutorial, scope };
+  const resolveArgs = { category, language, currentListId, currentPictureId, isTutorial, scope };
   const topUpArgs: AdvancerArgs = { ...resolveArgs, authContext };
 
   // Tier 1 — local deck.

--- a/utils/nextCardResolver.js
+++ b/utils/nextCardResolver.js
@@ -8,14 +8,15 @@ import { getNextImageForScope } from './storageDatum';
  *   the separate All listId space starts at its first card.
  * Returns { card, category } | null. Never mutates, never fetches.
  */
-export async function resolveNextCard({ category, language, currentListId, scope }) {
+export async function resolveNextCard({ category, language, currentListId, scope, currentPictureId }) {
+  const exclude = currentPictureId ? { excludePictureId: currentPictureId } : {};
   const inAll = category?.key === 'all';
   if (inAll) {
-    const card = await getNextImageForScope({ category, language, currentListId, scope });
+    const card = await getNextImageForScope({ category, language, currentListId, scope, ...exclude });
     return card ? { card, category } : null;
   }
 
-  const cat = await getNextImageForScope({ category, language, currentListId, scope });
+  const cat = await getNextImageForScope({ category, language, currentListId, scope, ...exclude });
   if (cat) return { card: cat, category };
 
   const allCard = await getNextImageForScope({
@@ -23,6 +24,7 @@ export async function resolveNextCard({ category, language, currentListId, scope
     language,
     currentListId: undefined,
     scope,
+    ...exclude,
   });
   return allCard ? { card: allCard, category: RECENT_ALL_CATEGORY } : null;
 }

--- a/utils/nextCardResolver.js
+++ b/utils/nextCardResolver.js
@@ -2,11 +2,22 @@ import { RECENT_ALL_CATEGORY } from '../constants/categories';
 import { getNextImageForScope } from './storageDatum';
 
 /**
- * Read-only orchestrator: pick the deck to advance in.
+ * Read-only client resolver: pick the deck to advance in. Never mutates,
+ * never fetches.
+ *
  * - In "All" → advance WITHIN All using the real cursor (else first-card loop).
- * - In a real category → try it; on the category/All boundary pass undefined so
- *   the separate All listId space starts at its first card.
- * Returns { card, category } | null. Never mutates, never fetches.
+ * - In a real category → try it; on the category→'all' cross-fallback pass
+ *   `currentListId: undefined` because listIds are per-namespace (meaningless
+ *   cross-namespace); `pictureId` is the only cross-namespace identity, so the
+ *   All listId space starts at its first card.
+ *
+ * currentPictureId (the just-played card) is spread as `excludePictureId` into
+ * EVERY getNextImageForScope call — both the in-category call and the 'all'
+ * cross-fallback — so the just-played card is never re-served. This is the fix
+ * for the stuck-on-card bug.
+ *
+ * @param {object} args - { category, language, currentListId, scope, currentPictureId }
+ * @returns {Promise<{card: object, category: object}|null>}
  */
 export async function resolveNextCard({ category, language, currentListId, scope, currentPictureId }) {
   const exclude = currentPictureId ? { excludePictureId: currentPictureId } : {};

--- a/utils/storageDatum.js
+++ b/utils/storageDatum.js
@@ -18,6 +18,13 @@ function lastImageUuidKey(categoryKey, language) {
   return `lastImageUuid:${categoryKey || 'all'}:${language || 'any'}`;
 };
 
+/**
+ * Read the persisted deck for (categoryKey, language) and drop entries whose
+ * local image file no longer exists, persisting the trimmed list when needed.
+ * @param {string} categoryKey - Category key ('all' for the global deck).
+ * @param {string} language - Language code ('any' when unset).
+ * @returns {Promise<Array<object>|null>} Viable cards, or null when none stored/unparseable.
+ */
 export async function getLocalImages(categoryKey, language) {
   const stored = await AsyncStorage.getItem(imageListKey(categoryKey, language));
   if (!stored) {
@@ -53,7 +60,17 @@ export async function getLocalImages(categoryKey, language) {
  * is ordered ascending by listId (see getLastImageId / getLastListId).
  * - currentListId is a finite number → first item whose listId is strictly greater.
  * - otherwise (undefined/null/NaN) → first item of the deck.
- * Returns null when the deck is missing or empty.
+ *
+ * When `excludePictureId` is provided, any card whose `pictureId === excludePictureId`
+ * is dropped BEFORE selection, so the just-played card is never re-served.
+ *
+ * Returns null when the deck is missing or empty after filtering.
+ *
+ * @param {string} categoryKey - Category key (use 'all' for the global deck).
+ * @param {string} language - Language code ('any' when unset).
+ * @param {number} [currentListId] - Cursor listId; non-finite → deck head.
+ * @param {string} [excludePictureId] - pictureId to filter out before selecting.
+ * @returns {Promise<object|null>} The next card, or null.
  */
 export async function getNextImage(categoryKey, language, currentListId, excludePictureId) {
   const raw = await getLocalImages(categoryKey, language);
@@ -79,7 +96,15 @@ export async function getNextImage(categoryKey, language, currentListId, exclude
  * Scope-aware next-card reader. Public scope delegates to getNextImage; private
  * scope reads the group feed cache instead (mirrors SwipeImage's derivation:
  * categoryId is undefined for "all", otherwise the numeric category id).
+ *
+ * In both branches the `excludePictureId` pre-filter (drop cards whose
+ * `pictureId === excludePictureId` BEFORE selection) is applied identically,
+ * so the just-played card is never re-served regardless of scope.
+ *
  * Read-only.
+ *
+ * @param {{ category?: { key?: string, id?: unknown }|null, language?: string|null, currentListId?: number, scope?: unknown, excludePictureId?: string }} args
+ * @returns {Promise<object|null>} The next card, or null.
  */
 export async function getNextImageForScope({ category, language, currentListId, scope, excludePictureId }) {
   const isPrivate = scope?.kind === 'private' && scope?.groupId;
@@ -239,11 +264,29 @@ export async function getLastImageId(categoryKey, language) {
   return 0;
 };
 
+/**
+ * Persist the feed cursor (last-served image uuid) for (categoryKey, language).
+ * Stored at `lastImageUuid:<categoryKey|'all'>:<language|'any'>`. Callers may
+ * write the `PUBLIC_FEED_END_CURSOR` sentinel to mark the public feed as
+ * exhausted; readers treat that sentinel as null.
+ * @param {string} imageUuid - Cursor value (or PUBLIC_FEED_END_CURSOR sentinel).
+ * @param {string} categoryKey - Category key ('all' for the global deck).
+ * @param {string} language - Language code ('any' when unset).
+ * @returns {Promise<null>}
+ */
 export async function saveLastImageUuid(imageUuid, categoryKey, language) {
   await AsyncStorage.setItem(lastImageUuidKey(categoryKey, language), imageUuid);
   return null;
 };
 
+/**
+ * Read the persisted feed cursor for (categoryKey, language).
+ * Key: `lastImageUuid:<categoryKey|'all'>:<language|'any'>`. May return the
+ * `PUBLIC_FEED_END_CURSOR` sentinel; callers MUST treat that as null/exhausted.
+ * @param {string} categoryKey - Category key ('all' for the global deck).
+ * @param {string} language - Language code ('any' when unset).
+ * @returns {Promise<string|null>} Stored cursor, sentinel, or null when unset.
+ */
 export async function getLastImageUuid(categoryKey, language) {
   const lastImageUuid = await AsyncStorage.getItem(lastImageUuidKey(categoryKey, language));
   return lastImageUuid;
@@ -365,6 +408,13 @@ async function removeFromCache(localUri) {
   deleteFileIfPresent(new File(localUri));
 };
 
+/**
+ * Wipe the persisted deck for (categoryKey, language): delete each card's
+ * cached image file, drop the deck key, and clear the feed cursor.
+ * @param {string} categoryKey - Category key ('all' for the global deck).
+ * @param {string} language - Language code ('any' when unset).
+ * @returns {Promise<void>}
+ */
 export async function emptyImageList(categoryKey, language) {
   const listKey = imageListKey(categoryKey, language);
   const localList = await AsyncStorage.getItem(listKey)
@@ -437,6 +487,15 @@ function dedupByPictureId(prior, incoming) {
   return incoming.filter((c) => !c?.pictureId || !priorIds.has(c.pictureId));
 }
 
+/**
+ * Read-modify-write the deck for (categoryKey, language): read the persisted
+ * deck, `dedupByPictureId` the incoming batch against it, `normalizeListIds`
+ * the merged result, and write back.
+ * @param {Array<object>} updatedImageList - Incoming cards to merge.
+ * @param {string} categoryKey - Category key ('all' for the global deck).
+ * @param {string} language - Language code ('any' when unset).
+ * @returns {Promise<Array<object>>} The new persisted deck (post-dedup/normalize).
+ */
 export async function updateImageList(updatedImageList, categoryKey, language) {
   const listKey = imageListKey(categoryKey, language);
   const imageList = await AsyncStorage.getItem(listKey);
@@ -448,6 +507,16 @@ export async function updateImageList(updatedImageList, categoryKey, language) {
 };
 
 
+/**
+ * Splice the card whose `listId === listId` out of the persisted deck for
+ * (categoryKey, language). NOTE: removes from ONE (categoryKey, language)
+ * namespace only — used to drop the just-played card from its own category.
+ * No-op (returns null) when the deck key is unset.
+ * @param {number} listId - listId of the card to remove.
+ * @param {string} categoryKey - Category key ('all' for the global deck).
+ * @param {string} language - Language code ('any' when unset).
+ * @returns {Promise<null>}
+ */
 export async function removeImageFromList(listId, categoryKey, language) {
   const listKey = imageListKey(categoryKey, language);
   const imageList = await AsyncStorage.getItem(listKey);

--- a/utils/storageDatum.js
+++ b/utils/storageDatum.js
@@ -55,9 +55,16 @@ export async function getLocalImages(categoryKey, language) {
  * - otherwise (undefined/null/NaN) → first item of the deck.
  * Returns null when the deck is missing or empty.
  */
-export async function getNextImage(categoryKey, language, currentListId) {
-  const images = await getLocalImages(categoryKey, language);
-  if (!Array.isArray(images) || images.length === 0) {
+export async function getNextImage(categoryKey, language, currentListId, excludePictureId) {
+  const raw = await getLocalImages(categoryKey, language);
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return null;
+  }
+
+  const images = excludePictureId
+    ? raw.filter((image) => image?.pictureId !== excludePictureId)
+    : raw;
+  if (images.length === 0) {
     return null;
   }
 
@@ -74,16 +81,23 @@ export async function getNextImage(categoryKey, language, currentListId) {
  * categoryId is undefined for "all", otherwise the numeric category id).
  * Read-only.
  */
-export async function getNextImageForScope({ category, language, currentListId, scope }) {
+export async function getNextImageForScope({ category, language, currentListId, scope, excludePictureId }) {
   const isPrivate = scope?.kind === 'private' && scope?.groupId;
   if (!isPrivate) {
-    return getNextImage(category?.key || 'all', language, currentListId);
+    return getNextImage(category?.key || 'all', language, currentListId, excludePictureId);
   }
 
   const categoryId = category?.key === 'all' ? undefined : category?.id;
   const cache = await readGroupFeedCache(scope.groupId, { categoryId, language });
-  const images = cache?.images;
-  if (!Array.isArray(images) || images.length === 0) {
+  const raw = cache?.images;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return null;
+  }
+
+  const images = excludePictureId
+    ? raw.filter((image) => image?.pictureId !== excludePictureId)
+    : raw;
+  if (images.length === 0) {
     return null;
   }
 


### PR DESCRIPTION
This pull request introduces several improvements and refactors across the codebase, focusing mainly on overlay z-index management, robust test coverage for edge cases, and enhancements to image request handling. The most important changes are summarized below.

### Overlay z-index refactor

* Replaced hardcoded z-index values in overlay components with named constants from the new `OverlayZIndex` module for improved maintainability and clarity. This affects `GuessExhaustedPanel`, `GuessExitSwipeMenu`, `SuccessOverlay`, and `EnigmaOverlay` components. [[1]](diffhunk://#diff-43933cd402b699f099c5521f39de5b0fee4d7f08f75ff8738f9f02454b1087d4R9) [[2]](diffhunk://#diff-43933cd402b699f099c5521f39de5b0fee4d7f08f75ff8738f9f02454b1087d4L62-R62) [[3]](diffhunk://#diff-7bcd43420569e16b19ee104467338638f901cdd6ba9dadf0bee367709abaec65R5) [[4]](diffhunk://#diff-7bcd43420569e16b19ee104467338638f901cdd6ba9dadf0bee367709abaec65L90-R91) [[5]](diffhunk://#diff-7bcd43420569e16b19ee104467338638f901cdd6ba9dadf0bee367709abaec65L147-R155) [[6]](diffhunk://#diff-7bcd43420569e16b19ee104467338638f901cdd6ba9dadf0bee367709abaec65L165-R167) [[7]](diffhunk://#diff-7242e3c985ae27ab2fae5cde11c1b5d8ad2419dc974c23b57d708cae1ee0ddccL1-R6) [[8]](diffhunk://#diff-7242e3c985ae27ab2fae5cde11c1b5d8ad2419dc974c23b57d708cae1ee0ddccL262-R263) [[9]](diffhunk://#diff-2bdc17bcb3bd0ebf85ededfa161f79178b534229dfd6d7334b659601f8ad0568R5) [[10]](diffhunk://#diff-2bdc17bcb3bd0ebf85ededfa161f79178b534229dfd6d7334b659601f8ad0568L102-R103) [[11]](diffhunk://#diff-2bdc17bcb3bd0ebf85ededfa161f79178b534229dfd6d7334b659601f8ad0568L156-R164) [[12]](diffhunk://#diff-2bdc17bcb3bd0ebf85ededfa161f79178b534229dfd6d7334b659601f8ad0568L174-R176)

### Test robustness and coverage

* Improved test cleanup in `GuessScreen.test.tsx` by tracking all mounted renderers and ensuring they are unmounted after each test to prevent side effects. [[1]](diffhunk://#diff-eb917be80b9909c08d6af95843e215093bc6ba102328f122a445ca4efc00d161L236-R236) [[2]](diffhunk://#diff-eb917be80b9909c08d6af95843e215093bc6ba102328f122a445ca4efc00d161R263-R270) [[3]](diffhunk://#diff-eb917be80b9909c08d6af95843e215093bc6ba102328f122a445ca4efc00d161L310-R324)
* Added new tests for critical edge cases:
  - Ensured that the retry recovery path correctly threads the success-time multiplier, preventing state regressions.
  - Verified that cadence and ad state are not updated after unmounting during pending success side effects, avoiding setState-after-unmount warnings.
* Updated an existing test to check that the loader is shown during the foreground-fetch gap after the success animation, addressing a frozen screen symptom.

### Image request handling

* Updated image request tests to consistently include a 15-second timeout in all axios calls, reflecting recent changes in the request logic. [[1]](diffhunk://#diff-1b2f0547cf261843d5a06a08c7e2c684bf6861235d45986e27dfdb8ec02b68c3R239) [[2]](diffhunk://#diff-1b2f0547cf261843d5a06a08c7e2c684bf6861235d45986e27dfdb8ec02b68c3L304-R305) [[3]](diffhunk://#diff-1b2f0547cf261843d5a06a08c7e2c684bf6861235d45986e27dfdb8ec02b68c3R329) [[4]](diffhunk://#diff-1b2f0547cf261843d5a06a08c7e2c684bf6861235d45986e27dfdb8ec02b68c3L340-R342) [[5]](diffhunk://#diff-1b2f0547cf261843d5a06a08c7e2c684bf6861235d45986e27dfdb8ec02b68c3L382-R384)

### Minor code improvements

* Documented the `loadNewImages` callback in `SwipeImage.js` to clarify its behavior and contract for future maintainers.
* Minor import cleanups and additions to support the above changes. [[1]](diffhunk://#diff-43933cd402b699f099c5521f39de5b0fee4d7f08f75ff8738f9f02454b1087d4L1) [[2]](diffhunk://#diff-1d440ab1601f75e6772410567b9538507683bc7085b8f7d2558e45ce5940fe3bL10-R10)

These changes collectively improve code clarity, test reliability, and maintainability, while also addressing subtle UI bugs and edge cases.