### PR TITLE
Fix/guess flow timing

### DIFF
--- a/__tests__/GuessScreen.test.tsx
+++ b/__tests__/GuessScreen.test.tsx
@@ -199,11 +199,14 @@ jest.mock('../services/ads/InternalProAdSource', () => ({
 // per-test overrides drive the warmer-wiring assertions below. Other exports
 // stay real so the unmocked resolve chain (nextCardAdvancer → nextCardResolver
 // → getNextImageForScope SINGULAR) keeps working in tests that exercise it.
+// E1: clearExhaustedCategory is mocked (jest.fn) so handleSwitchCategory tests
+// can assert the call without invoking AsyncStorage / groupFeedCache.
 jest.mock('../utils/storageDatum', () => {
   const actual = jest.requireActual('../utils/storageDatum');
   return {
     ...actual,
     getNextImagesForScope: jest.fn().mockResolvedValue([]),
+    clearExhaustedCategory: jest.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -539,11 +542,10 @@ describe('GuessScreen', () => {
     });
   });
 
-  it('overlay onDone with null (deck exhausted) dispatches FAILED_TRANSIENT → warming, NOT GuessExhaustedPanel (no navigation.reset)', async () => {
-    // C1 (P1 post-fix): a single empty cascade result must NOT interrupt the
-    // streak. reason='empty' is now treated as transient — the cascade's Tier 4
-    // looping-replay will recover on retry as long as the server has any
-    // matching row. The panel only mounts after 3 failed retries (safety net).
+  it('overlay onDone with null (deck empty) dispatches FAILED_PERMANENT → exhausted, mounts GuessExhaustedPanel (no retry)', async () => {
+    // F3b: reason='empty' (default cardDeck mock) is deterministic — the
+    // cascade already tried Tier 3 'all' cross-fallback + Tier 4 looping-replay
+    // before returning null. No retry; straight to exhausted + safety-net panel.
     const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
     const route = {
       params: {
@@ -579,13 +581,13 @@ describe('GuessScreen', () => {
       overlayProps.onDone();
     });
 
-    // Warming observable: GuessAdvanceLoader renders only when state==='warming'.
-    expect(mockGuessAdvanceLoader).toHaveBeenCalled();
-    // Safety-net panel must NOT mount on a single empty cascade.
-    expect(mockGuessExhaustedPanel).not.toHaveBeenCalled();
+    // No warming — deterministic empty → straight to exhausted.
+    expect(mockGuessAdvanceLoader).not.toHaveBeenCalled();
+    // Safety-net panel mounts immediately on FAILED_PERMANENT.
+    expect(mockGuessExhaustedPanel).toHaveBeenCalled();
     expect(navigateToNextGuess).not.toHaveBeenCalled();
     expect(navigation.setParams).not.toHaveBeenCalled();
-    // Regression (T5): prefetch fired on win but did not interfere with the warming fallback.
+    // Regression (T5): prefetch fired on win but did not interfere with the exhausted transition.
     expect(prefetchIfLow).toHaveBeenCalledTimes(1);
   });
 
@@ -1348,8 +1350,10 @@ describe('GuessScreen', () => {
       expect(navigateToNextGuess).not.toHaveBeenCalled();
     });
 
-    it('T11: handleOverlayDone dispatches FAILED_TRANSIENT → warming (NOT GuessExhaustedPanel) when deck is truly empty after warm retry', async () => {
-      // C1 (P1 post-fix): single empty cascade → warming, no panel interrupt.
+    it('T11: handleOverlayDone dispatches FAILED_PERMANENT → exhausted (mounts GuessExhaustedPanel, no retry) when deck is truly empty after warm retry', async () => {
+      // F3b: empty is deterministic. The cascade already tried Tier 3 'all'
+      // cross-fallback + Tier 4 looping-replay before returning null. No retry;
+      // exhausted panel mounts immediately.
       const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
       warmAllDeckIfNeeded.mockResolvedValue(undefined);
 
@@ -1378,16 +1382,16 @@ describe('GuessScreen', () => {
       // foregroundTopUp's Tier 2 short-circuit recheck — this is intentional
       // and correct.
       expect(resolveNextGuessParams).toHaveBeenCalledTimes(3);
-      // Warming observable: GuessAdvanceLoader renders only when state==='warming'.
-      expect(mockGuessAdvanceLoader).toHaveBeenCalled();
-      // Safety-net panel must NOT mount on a single empty cascade.
-      expect(mockGuessExhaustedPanel).not.toHaveBeenCalled();
+      // No warming — deterministic empty → straight to exhausted.
+      expect(mockGuessAdvanceLoader).not.toHaveBeenCalled();
+      // Safety-net panel mounts on FAILED_PERMANENT.
+      expect(mockGuessExhaustedPanel).toHaveBeenCalled();
       expect(navigateToNextGuess).not.toHaveBeenCalled();
       expect(navigation.setParams).not.toHaveBeenCalled();
     });
 
-    it('T12: handleOverlayDone does NOT warm when category is "all" (still dispatches FAILED_TRANSIENT → warming, no immediate GuessExhaustedPanel)', async () => {
-      // C1 (P1 post-fix): single empty cascade → warming, no panel interrupt.
+    it('T12: handleOverlayDone does NOT warm when category is "all" (dispatches FAILED_PERMANENT → exhausted, mounts GuessExhaustedPanel, no retry)', async () => {
+      // F3b: empty is deterministic. No retry; exhausted panel mounts.
       const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
 
       resolveNextGuessParams.mockResolvedValue(null);
@@ -1415,10 +1419,10 @@ describe('GuessScreen', () => {
       // foregroundTopUp's Tier 2 short-circuit recheck — this is intentional
       // and correct.
       expect(resolveNextGuessParams).toHaveBeenCalledTimes(2);
-      // Warming observable: GuessAdvanceLoader renders only when state==='warming'.
-      expect(mockGuessAdvanceLoader).toHaveBeenCalled();
-      // Safety-net panel must NOT mount on a single empty cascade.
-      expect(mockGuessExhaustedPanel).not.toHaveBeenCalled();
+      // No warming — deterministic empty → straight to exhausted.
+      expect(mockGuessAdvanceLoader).not.toHaveBeenCalled();
+      // Safety-net panel mounts on FAILED_PERMANENT.
+      expect(mockGuessExhaustedPanel).toHaveBeenCalled();
       expect(navigateToNextGuess).not.toHaveBeenCalled();
     });
   });
@@ -1822,8 +1826,8 @@ describe('GuessScreen', () => {
       }));
     });
 
-    it('PB6: win → next card null → streak NOT incremented, score NOT buffered, dispatches FAILED_TRANSIENT → warming (no panel on single empty)', async () => {
-      // C1 (P1 post-fix): single empty cascade → warming, no panel interrupt.
+    it('PB6: win → next card null → streak NOT incremented, score NOT buffered, dispatches FAILED_PERMANENT → exhausted (no retry)', async () => {
+      // F3b: deterministic empty → exhausted, no warming, no commit.
       const navigation = makeNav();
       isOnTarget.mockReturnValue(true);
       applySuccessSideEffects.mockResolvedValue(undefined);
@@ -1836,10 +1840,10 @@ describe('GuessScreen', () => {
       // PB6: failed advance does not credit the streak or buffer the score.
       expect(streakSpies().onWin).not.toHaveBeenCalled();
       expect(applySuccessSideEffects).not.toHaveBeenCalled();
-      // Warming observable: GuessAdvanceLoader renders only when state==='warming'.
-      expect(mockGuessAdvanceLoader).toHaveBeenCalled();
-      // Safety-net panel must NOT mount on a single empty cascade.
-      expect(mockGuessExhaustedPanel).not.toHaveBeenCalled();
+      // No warming — deterministic empty → straight to exhausted.
+      expect(mockGuessAdvanceLoader).not.toHaveBeenCalled();
+      // Safety-net panel mounts on FAILED_PERMANENT.
+      expect(mockGuessExhaustedPanel).toHaveBeenCalled();
     });
   });
 
@@ -1853,12 +1857,10 @@ describe('GuessScreen', () => {
       return call[1] as (state: string) => void;
     }
 
-    it('win → next card null + reason "empty" → dispatch FAILED_TRANSIENT (warming state), GuessExhaustedPanel NOT rendered, retry scheduled', async () => {
-      // C1 (P1 post-fix): a single empty cascade result must NOT interrupt the
-      // streak. reason='empty' is now treated as transient — the cascade's
-      // Tier 4 looping-replay will recover on retry as long as the server has
-      // any matching row. The panel only mounts as a safety net after 3 failed
-      // retries (tested separately via the network-retry path below).
+    it('F3b: win → next card null + reason "empty" → dispatch FAILED_PERMANENT → exhausted, mounts GuessExhaustedPanel, NO retry scheduled', async () => {
+      // F3b: reason='empty' is deterministic — the cascade already tried Tier 3
+      // 'all' cross-fallback + Tier 4 looping-replay before returning null. Do
+      // NOT retry; straight to exhausted + safety-net panel.
       jest.useFakeTimers();
       resolveNextCardWithServerFallback.mockResolvedValue({ next: null, reason: 'empty' });
       const navigation = makeNav();
@@ -1866,15 +1868,20 @@ describe('GuessScreen', () => {
       await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
       await act(async () => { lastOverlayProps().onDone(); });
 
-      // Warming observable: GuessAdvanceLoader renders only when state==='warming'.
-      expect(mockGuessAdvanceLoader).toHaveBeenCalled();
-      // Safety-net panel must NOT mount on a single empty cascade.
-      expect(mockGuessExhaustedPanel).not.toHaveBeenCalled();
+      // No warming — deterministic empty → straight to exhausted.
+      expect(mockGuessAdvanceLoader).not.toHaveBeenCalled();
+      // Safety-net panel mounts on FAILED_PERMANENT.
+      expect(mockGuessExhaustedPanel).toHaveBeenCalled();
       expect(navigation.replace).not.toHaveBeenCalledWith('GuessScreen', expect.anything());
       expect(navigateToNextGuess).not.toHaveBeenCalled();
-      // Streak + score never committed until recovery lands.
+      // Streak + score never committed.
       expect(streakSpies().onWin).not.toHaveBeenCalled();
       expect(applySuccessSideEffects).not.toHaveBeenCalled();
+
+      // NO retry scheduled — advancing timers must NOT re-invoke the resolver.
+      const callsAfterAdvance = resolveNextCardWithServerFallback.mock.calls.length;
+      await act(async () => { jest.advanceTimersByTime(10000); });
+      expect(resolveNextCardWithServerFallback.mock.calls.length).toBe(callsAfterAdvance);
 
       jest.useRealTimers();
     });
@@ -1914,8 +1921,19 @@ describe('GuessScreen', () => {
       jest.useRealTimers();
     });
 
-    it('warming → background prefetch resolves mid-retry → transitions to idle + advances (N3)', async () => {
+    it('F4 (WHILE-overlay-up): warming retry succeeds WHILE SuccessOverlay still mounted → setParams NOT called until handleOverlayDone (N3 + race fix)', async () => {
+      // F4 race: for tier1+ wins the SuccessOverlay dismisses at ~1200-2600ms
+      // while the first warming retry fires at 1000ms — so the retry can land
+      // WHILE showSuccess===true. Without the overlayVisibleRef commit gate,
+      // onAdvanceResolved's warming branch dispatched RESOLVED unconditionally
+      // → setParams swapped route.params.imageFile BEHIND the still-visible
+      // overlay (next image flashes under the win animation). Fixed by staging
+      // on pendingNextRef when overlayVisibleRef.current===true and deferring
+      // the dispatch to handleOverlayDone (after the fade). This test advances
+      // the retry timer BEFORE firing onDone to exercise the race window.
       jest.useFakeTimers();
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
       const nextParams = { listId: 4, imageFile: 'file:///next.jpg', pictureId: 'p-2' };
       resolveNextCardWithServerFallback
         .mockResolvedValueOnce({ next: null, reason: 'network' })
@@ -1924,19 +1942,195 @@ describe('GuessScreen', () => {
       const navigation = makeNav();
       await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
       await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+      // Flush the in-flight resolve chain (runResolveCycle awaits the mocked
+      // resolver, then dispatches FAILED_TRANSIENT + schedules the retry). NO
+      // onDone yet — overlay stays mounted to exercise the race window.
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      // PRE-CHECK: setParams has not been called yet (no resolve has succeeded).
+      expect(navigation.setParams).not.toHaveBeenCalledWith(nextParams);
+
+      // Advance 1s WHILE overlay is still up — retry 1 succeeds. With the fix
+      // the next is staged on pendingNextRef and NO RESOLVED dispatch fires
+      // (no setParams) — imageFile does NOT swap behind the overlay.
+      await act(async () => { jest.advanceTimersByTime(1000); });
+      expect(navigation.setParams).not.toHaveBeenCalledWith(nextParams);
+
+      // NOW dismiss the overlay — handleOverlayDone drains pendingNextRef and
+      // dispatches RESOLVED → idle → setParams. The next image appears AFTER
+      // the fade.
+      await act(async () => { lastOverlayProps().onDone(); });
+
+      expect(navigation.setParams).toHaveBeenCalledWith(nextParams);
+      expect(navigation.setParams).toHaveBeenCalledTimes(1);
+      expect(mockGuessExhaustedPanel).not.toHaveBeenCalled();
+      // PB6: streak + score committed exactly once on the recovered advance.
+      expect(streakSpies().onWin).toHaveBeenCalledTimes(1);
+      expect(applySuccessSideEffects).toHaveBeenCalledTimes(1);
+
+      jest.useRealTimers();
+    });
+
+    it('F4 (b) AFTER-overlay-down: warming retry succeeds after handleOverlayDone returned → RESOLVED dispatched immediately, setParams called exactly once, NO 7s strand', async () => {
+      // F4 (b): the inverse of the WHILE-overlay-up case. Overlay dismissed
+      // BEFORE the retry fires (tier0 race: dismiss ≈900ms < retry 1000ms).
+      // overlayVisibleRef.current===false at retry time → dispatch RESOLVED
+      // immediately (no staging, no strand). The previous design's effect-only
+      // overlayVisible mirror would have stranded the user in `warming` here
+      // (no transition to re-trigger the effect commit); the ref-as-control-
+      // flow design closes both sides.
+      jest.useFakeTimers();
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+      const nextParams = { listId: 4, imageFile: 'file:///next.jpg', pictureId: 'p-2' };
+      resolveNextCardWithServerFallback
+        .mockResolvedValueOnce({ next: null, reason: 'network' })
+        .mockResolvedValueOnce({ next: { params: nextParams }, reason: 'ok' });
+
+      const navigation = makeNav();
+      await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+      await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+      // Overlay dismissed FIRST → overlayVisibleRef.current===false.
       await act(async () => { lastOverlayProps().onDone(); });
 
       expect(mockGuessAdvanceLoader).toHaveBeenCalled();
       expect(navigation.setParams).not.toHaveBeenCalledWith(nextParams);
 
-      // Fire retry 1 at 1s — second resolve succeeds → RESOLVED → idle + setParams.
+      // Retry 1 at 1s — second resolve succeeds, overlay already down →
+      // dispatch RESOLVED immediately → idle → setParams exactly once.
       await act(async () => { jest.advanceTimersByTime(1000); });
 
       expect(navigation.setParams).toHaveBeenCalledWith(nextParams);
+      expect(navigation.setParams).toHaveBeenCalledTimes(1);
       expect(mockGuessExhaustedPanel).not.toHaveBeenCalled();
-      // PB6: streak + score committed on the recovered advance.
-      expect(streakSpies().onWin).toHaveBeenCalledTimes(1);
-      expect(applySuccessSideEffects).toHaveBeenCalledTimes(1);
+
+      // NO 7s strand: advance well past the retry budget; nothing else fires.
+      const resolveCallsAfterRecovery = resolveNextCardWithServerFallback.mock.calls.length;
+      await act(async () => { jest.advanceTimersByTime(10000); });
+      expect(resolveNextCardWithServerFallback.mock.calls.length).toBe(resolveCallsAfterRecovery);
+      expect(navigation.setParams).toHaveBeenCalledTimes(1);
+
+      jest.useRealTimers();
+    });
+
+    it('F4 (c) warming recovery while overlay up → setParams NOT called until handleOverlayDone (deferred commit invariant)', async () => {
+      // F4 (c): belts-and-suspenders companion to the WHILE-overlay-up rewrite.
+      // Asserts the deferred-commit invariant in isolation: while the overlay is
+      // visible, setParams MUST stay at 0 calls regardless of how many resolves
+      // succeed; only handleOverlayDone unblocks the commit. Guards against a
+      // future regression that re-introduces an unconditional dispatch.
+      jest.useFakeTimers();
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+      const nextParams = { listId: 4, imageFile: 'file:///next.jpg', pictureId: 'p-2' };
+      resolveNextCardWithServerFallback
+        .mockResolvedValueOnce({ next: null, reason: 'network' })
+        .mockResolvedValueOnce({ next: { params: nextParams }, reason: 'ok' });
+
+      const navigation = makeNav();
+      await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+      await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      // Overlay still up. Fire the successful retry.
+      await act(async () => { jest.advanceTimersByTime(1000); });
+
+      // Deferred-commit invariant: staging happened, dispatch did NOT.
+      expect(navigation.setParams).not.toHaveBeenCalled();
+      // The panel must not have appeared either (state stays warming).
+      expect(mockGuessExhaustedPanel).not.toHaveBeenCalled();
+
+      // Commit fires ONLY after handleOverlayDone.
+      await act(async () => { lastOverlayProps().onDone(); });
+      expect(navigation.setParams).toHaveBeenCalledTimes(1);
+      expect(navigation.setParams).toHaveBeenCalledWith(nextParams);
+
+      jest.useRealTimers();
+    });
+
+    it('F4 (d) handleSwitchCategory → clearExhaustedCategory called for current category+language+scope before navigate', async () => {
+      // F3a invalidation (E1): switching category clears the exhausted-cache
+      // entry for the CURRENT category+language+scope so re-entering re-queries
+      // the server (handles newly uploaded images since the category was
+      // marked empty). Fire-and-forget; navigation proceeds without waiting.
+      const { clearExhaustedCategory } = require('../utils/storageDatum');
+      const navigation = makeNav();
+      // Force the exhausted panel to mount so handleSwitchCategory is reachable.
+      resolveNextCardWithServerFallback.mockResolvedValue({ next: null, reason: 'empty' });
+      await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+      await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+      await act(async () => { lastOverlayProps().onDone(); });
+
+      // Exhausted panel mounted; grab its onSwitch callback.
+      expect(mockGuessExhaustedPanel).toHaveBeenCalled();
+      const panelCall = mockGuessExhaustedPanel.mock.calls[mockGuessExhaustedPanel.mock.calls.length - 1][0];
+      expect(panelCall.onSwitch).toEqual(expect.any(Function));
+
+      clearExhaustedCategory.mockClear();
+      await act(async () => { panelCall.onSwitch(); });
+
+      // Cleared for the CURRENT category (PUBLIC_ROUTE_PARAMS: key='nature',
+      // language='fr', scope=undefined → public branch).
+      expect(clearExhaustedCategory).toHaveBeenCalledWith('nature', 'fr', undefined);
+      // And then navigated.
+      expect(navigation.navigate).toHaveBeenCalledWith('GuessPathScreen', {});
+    });
+
+    it('F4 (d-private) handleSwitchCategory → clearExhaustedCategory called for current category+scope in PRIVATE scope', async () => {
+      // F3a private isolation (E1): in a private scope the clear call MUST
+      // carry the scope so the group feed cache (not AsyncStorage) is cleared.
+      const { clearExhaustedCategory } = require('../utils/storageDatum');
+      const navigation = makeNav();
+      const scope = { kind: 'private', groupId: 'g-42' };
+      const route = { params: { ...PUBLIC_ROUTE_PARAMS, scope } };
+      resolveNextCardWithServerFallback.mockResolvedValue({ next: null, reason: 'empty' });
+      await act(async () => { create(<GuessScreen navigation={navigation} route={route} />); });
+      await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+      await act(async () => { lastOverlayProps().onDone(); });
+
+      const panelCall = mockGuessExhaustedPanel.mock.calls[mockGuessExhaustedPanel.mock.calls.length - 1][0];
+      clearExhaustedCategory.mockClear();
+      await act(async () => { panelCall.onSwitch(); });
+
+      expect(clearExhaustedCategory).toHaveBeenCalledWith('nature', 'fr', scope);
+      expect(navigation.navigate).toHaveBeenCalledWith('GuessPathScreen', { scope });
+    });
+
+    it('F4 (f) staged-then-background orphan: warming stages next on pendingNextRef → AppState backgrounding → FAILED_PERMANENT → pendingNextRef is null (no leak)', async () => {
+      // F4 nit defense: a warming-stages-next followed by AppState
+      // backgrounding dispatches FAILED_PERMANENT. The terminal transition
+      // MUST null pendingNextRef so a foregrounded session does not observe a
+      // stale staged next from the abandoned cycle. Next WIN overwrites the
+      // ref before read, but null-on-terminal is cheap defense.
+      jest.useFakeTimers();
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+      const nextParams = { listId: 4, imageFile: 'file:///next.jpg', pictureId: 'p-2' };
+      resolveNextCardWithServerFallback
+        .mockResolvedValueOnce({ next: null, reason: 'network' })
+        .mockResolvedValueOnce({ next: { params: nextParams }, reason: 'ok' });
+
+      const navigation = makeNav();
+      await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+      await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      // Overlay still up; fire the successful retry → stages on pendingNextRef
+      // (overlayVisibleRef.current === true).
+      await act(async () => { jest.advanceTimersByTime(1000); });
+      expect(navigation.setParams).not.toHaveBeenCalled();
+
+      // Background mid-stage → AppState listener dispatches FAILED_PERMANENT.
+      const listener = findAppStateListener();
+      await act(async () => { listener('background'); });
+
+      // State lands on exhausted; pendingNextRef has been nulled by the
+      // terminal transition (F4 nit). Verify by dismissing the overlay: the
+      // consumePendingNext + RESOLVED dispatch path must find nothing staged,
+      // so setParams stays at 0 (no orphan commit from the abandoned cycle).
+      expect(mockGuessExhaustedPanel).toHaveBeenCalled();
+      await act(async () => { lastOverlayProps().onDone(); });
+      expect(navigation.setParams).not.toHaveBeenCalled();
 
       jest.useRealTimers();
     });
@@ -2015,6 +2209,99 @@ describe('GuessScreen', () => {
       // foreground-fetch gap after the success animation dismisses; deliberate
       // fix for the "frozen screen after animation" symptom.
       expect(mockGuessAdvanceLoader).toHaveBeenCalled();
+    });
+
+    describe('F3b: retry gating on reason (D1)', () => {
+      // F3b contract: retry only on 'network'. 'empty' | 'server' (and any
+      // unmapped reason) are deterministic — the cascade already tried Tier 3
+      // 'all' cross-fallback + Tier 4 looping-replay before returning null, so
+      // retrying just burns 1s+2s+4s. FAILED_PERMANENT → exhausted, no retry.
+
+      it('(a) reason="network" → FAILED_TRANSIENT dispatched + scheduleRetry fires 3 ticks (1s/2s/4s) → exhausted', async () => {
+        jest.useFakeTimers();
+        resolveNextCardWithServerFallback.mockResolvedValue({ next: null, reason: 'network' });
+        const navigation = makeNav();
+        await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+        await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+        await act(async () => { lastOverlayProps().onDone(); });
+
+        // Warming observable: state=warming → loader mounted, panel NOT yet.
+        expect(mockGuessAdvanceLoader).toHaveBeenCalled();
+        expect(mockGuessExhaustedPanel).not.toHaveBeenCalled();
+
+        // Tick 1 @1s — still warming (retry 1 of 3).
+        await act(async () => { jest.advanceTimersByTime(1000); });
+        expect(mockGuessExhaustedPanel).not.toHaveBeenCalled();
+
+        // Tick 2 @2s — still warming (retry 2 of 3).
+        await act(async () => { jest.advanceTimersByTime(2000); });
+        expect(mockGuessExhaustedPanel).not.toHaveBeenCalled();
+
+        // Tick 3 @4s — final RETRY_TICK transitions reducer to exhausted.
+        await act(async () => { jest.advanceTimersByTime(4000); });
+        expect(mockGuessExhaustedPanel).toHaveBeenCalled();
+
+        // Initial resolve + 2 retry resolves (tick 3 only transitions to
+        // exhausted via RETRY_TICK; n < DEFAULT_RETRY_BUDGET gates the resolve).
+        expect(resolveNextCardWithServerFallback.mock.calls.length).toBe(3);
+
+        jest.useRealTimers();
+      });
+
+      it('(b) reason="empty" → FAILED_PERMANENT dispatched, scheduleRetry NOT called (no further resolves)', async () => {
+        jest.useFakeTimers();
+        resolveNextCardWithServerFallback.mockResolvedValue({ next: null, reason: 'empty' });
+        const navigation = makeNav();
+        await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+        await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+        await act(async () => { lastOverlayProps().onDone(); });
+
+        // No warming — straight to exhausted.
+        expect(mockGuessAdvanceLoader).not.toHaveBeenCalled();
+        expect(mockGuessExhaustedPanel).toHaveBeenCalled();
+
+        const callsAfterAdvance = resolveNextCardWithServerFallback.mock.calls.length;
+        await act(async () => { jest.advanceTimersByTime(10000); });
+        expect(resolveNextCardWithServerFallback.mock.calls.length).toBe(callsAfterAdvance);
+
+        jest.useRealTimers();
+      });
+
+      it('(c) reason="server" → FAILED_PERMANENT dispatched, scheduleRetry NOT called (no further resolves)', async () => {
+        jest.useFakeTimers();
+        resolveNextCardWithServerFallback.mockResolvedValue({ next: null, reason: 'server' });
+        const navigation = makeNav();
+        await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+        await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+        await act(async () => { lastOverlayProps().onDone(); });
+
+        // No warming — straight to exhausted.
+        expect(mockGuessAdvanceLoader).not.toHaveBeenCalled();
+        expect(mockGuessExhaustedPanel).toHaveBeenCalled();
+
+        const callsAfterAdvance = resolveNextCardWithServerFallback.mock.calls.length;
+        await act(async () => { jest.advanceTimersByTime(10000); });
+        expect(resolveNextCardWithServerFallback.mock.calls.length).toBe(callsAfterAdvance);
+
+        jest.useRealTimers();
+      });
+
+      it('(d) reason="ok" with next → onAdvanceResolved called, setParams with next.params (unchanged)', async () => {
+        const nextParams = { listId: 4, imageFile: 'file:///next.jpg', pictureId: 'p-2' };
+        resolveNextCardWithServerFallback.mockResolvedValue({ next: { params: nextParams }, reason: 'ok' });
+        isOnTarget.mockReturnValue(true);
+        applySuccessSideEffects.mockResolvedValue(undefined);
+
+        const navigation = makeNav();
+        await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+        await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+        await act(async () => { lastOverlayProps().onDone(); });
+
+        expect(navigation.setParams).toHaveBeenCalledWith(nextParams);
+        expect(mockGuessExhaustedPanel).not.toHaveBeenCalled();
+        expect(streakSpies().onWin).toHaveBeenCalledTimes(1);
+        expect(applySuccessSideEffects).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('PT2: warming → app backgrounded → state=exhausted on foreground', async () => {

--- a/__tests__/GuessScreen.test.tsx
+++ b/__tests__/GuessScreen.test.tsx
@@ -63,6 +63,18 @@ let mockPictureMountCount = 0;
 // Prefixed with `mock` for jest.mock factory out-of-scope visibility.
 let mockAdMountCount = 0;
 
+// F1 (test-fidelity): configurable auto-dismiss delay for the SuccessOverlay
+// mock. Default null = no auto-fire (preserves the manual-call semantics every
+// existing test relies on — lastOverlayProps().onDone() is authoritative).
+// Timing-sensitive tests (G1a/G1b/G1c) call setMockOverlayDismissDelayMs(ms)
+// to schedule props.onDone() via setTimeout(ms) on mount with visible===true;
+// manual calls still preempt the timer via wrappedOnDone's clear. Prefixed
+// with `mock` for jest.mock factory out-of-scope visibility.
+let mockOverlayDismissDelayMs: number | null = null;
+function setMockOverlayDismissDelayMs(ms: number | null): void {
+  mockOverlayDismissDelayMs = ms;
+}
+
 jest.mock('../components/Picture/GuessPicture', () => {
   const React = jest.requireActual('react');
   return function MockGuessPicture(props: MockPictureProps) {
@@ -90,8 +102,46 @@ jest.mock('../components/Guess/GuessExitSwipeMenu', () => {
 });
 
 jest.mock('../components/Guess/SuccessOverlay', () => {
+  // Cast to typed React so useRef<T>(...) accepts type arguments (the
+  // untyped jest.requireActual returns `any`, which TS2347-rejects generics).
+  const React = jest.requireActual('react') as typeof import('react');
   return function MockSuccessOverlay(props: MockOverlayProps) {
-    mockSuccessOverlay(props);
+    // Mirror real SuccessOverlay's onDoneRef pattern: the auto-fire timer
+    // always invokes the LATEST onDone, surviving parent re-renders without
+    // rescheduling.
+    const onDoneRef = React.useRef<() => void | Promise<void>>(props.onDone);
+    onDoneRef.current = props.onDone;
+    const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // wrappedOnDone is what tests reach via lastOverlayProps().onDone(). A
+    // manual call from a test preempts the scheduled auto-fire by clearing
+    // the timer BEFORE delegating to the real handler — this preserves the
+    // existing manual-call semantics while keeping the auto-fire path honest.
+    const wrappedOnDone = () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      onDoneRef.current();
+    };
+
+    React.useEffect(() => {
+      if (!props.visible) return undefined;
+      if (mockOverlayDismissDelayMs === null) return undefined;
+      const ms = mockOverlayDismissDelayMs;
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        onDoneRef.current();
+      }, ms);
+      return () => {
+        if (timerRef.current !== null) {
+          clearTimeout(timerRef.current);
+          timerRef.current = null;
+        }
+      };
+    }, [props.visible]);
+
+    mockSuccessOverlay({ ...props, onDone: wrappedOnDone });
     return null;
   };
 });
@@ -303,6 +353,9 @@ describe('GuessScreen', () => {
     jest.clearAllMocks();
     mockPictureMountCount = 0;
     mockAdMountCount = 0;
+    // F1: reset the SuccessOverlay mock's auto-dismiss delay so per-test
+    // overrides do not leak across tests.
+    setMockOverlayDismissDelayMs(null);
     const { isE2EMode } = require('../utils/e2eMode');
     isE2EMode.mockReturnValue(false);
     consumeAdSlot.mockReturnValue({ showAd: false, nextCount: 1 });
@@ -2862,6 +2915,124 @@ describe('GuessScreen', () => {
       expect(navigation.navigate).not.toHaveBeenCalledWith('AdScreen', expect.anything());
       // Sanity: the next card actually landed (proves the flow ran to completion).
       expect(navigation.setParams).toHaveBeenCalledWith(expect.objectContaining({ listId: 4 }));
+    });
+  });
+
+  // F1 (G1): win-animation / ad overlap fix. Mirror the E1 no-ad commit gate
+  // onto the showAd branch: defer setAdPhase('showing') until the SuccessOverlay
+  // has dismissed so AdInterstitial never mounts under the still-animating
+  // success burst. Terminal-drain defense prevents an orphan ad firing on top
+  // of the exhausted panel after a backgrounding mid-deferred cycle.
+  describe('F1 G1: ad trigger deferred until SuccessOverlay dismisses', () => {
+    function findAppStateListener(): (state: string) => void {
+      const mock = AppState.addEventListener as unknown as jest.Mock;
+      const call = mock.mock.calls.find((c: unknown[]) => c[0] === 'change');
+      if (!call || typeof call[1] !== 'function') {
+        throw new Error('AppState "change" listener was not registered');
+      }
+      return call[1] as (state: string) => void;
+    }
+
+    it('G1a: win + ad due + FAST resolve (overlay still up) → AdInterstitial NOT mounted until SuccessOverlay onDone fires', async () => {
+      jest.useFakeTimers();
+      setMockOverlayDismissDelayMs(100);
+      consumeAdSlot.mockReturnValue({ showAd: true, nextCount: 0 });
+      shouldSuppressAds.mockReturnValue(false);
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+      resolveNextCardWithServerFallback.mockResolvedValue({ next: { params: { listId: 4 } }, reason: 'ok' });
+
+      const navigation = makeNav();
+      await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+      await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+      // Resolve settles fast while overlay still animating → ad must be deferred.
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      // Ad NOT mounted yet (overlayVisibleRef.current === true at resolve time).
+      expect(mockAdMountCount).toBe(0);
+
+      // Advance LESS than the dismiss delay — overlay still up, ad still deferred.
+      await act(async () => { jest.advanceTimersByTime(50); });
+      expect(mockAdMountCount).toBe(0);
+
+      // Advance PAST the dismiss delay — SuccessOverlay's auto-fire triggers
+      // handleOverlayDone → consumeDeferredAd → setAdPhase('showing') → mount.
+      await act(async () => { jest.advanceTimersByTime(60); });
+      expect(mockAdMountCount).toBe(1);
+
+      jest.useRealTimers();
+    });
+
+    it('G1b: deferred-ad set → AppState backgrounding dispatches FAILED_PERMANENT → onDone fires → AdInterstitial NOT mounted (drain prevents orphan)', async () => {
+      jest.useFakeTimers();
+      setMockOverlayDismissDelayMs(100);
+      consumeAdSlot.mockReturnValue({ showAd: true, nextCount: 0 });
+      shouldSuppressAds.mockReturnValue(false);
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+      resolveNextCardWithServerFallback.mockResolvedValue({ next: { params: { listId: 4 } }, reason: 'ok' });
+
+      const navigation = makeNav();
+      await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+      await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+      // Deferred state: ad deferred, overlay still up.
+      expect(mockAdMountCount).toBe(0);
+
+      // Background mid-deferred → AppState listener dispatches FAILED_PERMANENT;
+      // the terminal drain MUST also clear adDeferredRef so a later onDone
+      // cannot orphan an ad on top of the exhausted panel.
+      const listener = findAppStateListener();
+      await act(async () => { listener('background'); });
+
+      // State landed on exhausted; safety-net panel mounted.
+      expect(mockGuessExhaustedPanel).toHaveBeenCalled();
+
+      // Fire onDone (animation completes / overlay auto-dismisses). Without the
+      // drain, handleOverlayDone would see adDeferred===true and trigger the ad
+      // on top of the exhausted panel. Drain must prevent this.
+      await act(async () => { jest.advanceTimersByTime(150); });
+
+      expect(mockAdMountCount).toBe(0);
+
+      jest.useRealTimers();
+    });
+
+    it('G1c: win + ad due + SLOW resolve (overlay already down) → AdInterstitial mounted immediately on resolve (no extra wait)', async () => {
+      jest.useFakeTimers();
+      setMockOverlayDismissDelayMs(100);
+      consumeAdSlot.mockReturnValue({ showAd: true, nextCount: 0 });
+      shouldSuppressAds.mockReturnValue(false);
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+
+      let resolveAdvance!: (v: { next: { params: Record<string, unknown> }; reason: string }) => void;
+      resolveNextCardWithServerFallback.mockReturnValue(new Promise((r) => {
+        resolveAdvance = r as (v: { next: { params: Record<string, unknown> }; reason: string }) => void;
+      }));
+
+      const navigation = makeNav();
+      await act(async () => { create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />); });
+      await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+
+      // Advance PAST the dismiss delay while resolve is still pending — overlay
+      // auto-dismisses; handleOverlayDone awaits the still-pending resolve and
+      // consumes no deferred ad (the flag was never set: resolve hasn't run).
+      await act(async () => { jest.advanceTimersByTime(150); });
+      expect(mockAdMountCount).toBe(0);
+
+      // Resolve settles AFTER the overlay is already down → overlayVisibleRef
+      // === false in the ad branch → setAdPhase('showing') fires immediately
+      // (fast-path), no extra wait for a second onDone.
+      await act(async () => {
+        resolveAdvance({ next: { params: { listId: 4 } }, reason: 'ok' });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockAdMountCount).toBe(1);
+
+      jest.useRealTimers();
     });
   });
 

--- a/__tests__/cardPrefetcher.test.ts
+++ b/__tests__/cardPrefetcher.test.ts
@@ -5,15 +5,17 @@ jest.mock('../services/cardDeck', () => ({
 jest.mock('../utils/storageDatum', () => ({
   getRemainingDeckCount: jest.fn(),
   normalizeListIds: jest.fn((cards) => cards),
+  isCategoryExhausted: jest.fn().mockResolvedValue(false),
+  markCategoryExhausted: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('../utils/e2eMode', () => ({ isE2EMode: jest.fn(() => false) }));
 
 import { fetchCardBatch, appendCardBatch } from '../services/cardDeck';
-import { getRemainingDeckCount, normalizeListIds } from '../utils/storageDatum';
+import { getRemainingDeckCount, normalizeListIds, isCategoryExhausted, markCategoryExhausted } from '../utils/storageDatum';
 import { isE2EMode } from '../utils/e2eMode';
 import {
   LOW_CARD_THRESHOLD,
-  ALL_WARM_THRESHOLD,
+  TARGET_BATCH_SIZE,
   LOOKAHEAD_PREFETCH,
   prefetchIfLow,
   warmAllDeckIfNeeded,
@@ -25,6 +27,8 @@ const appendMock = appendCardBatch as jest.MockedFunction<typeof appendCardBatch
 const remainingMock = getRemainingDeckCount as jest.MockedFunction<typeof getRemainingDeckCount>;
 const e2eMock = isE2EMode as jest.MockedFunction<typeof isE2EMode>;
 const normalizeMock = normalizeListIds as jest.MockedFunction<typeof normalizeListIds>;
+const isExhaustedMock = isCategoryExhausted as jest.MockedFunction<typeof isCategoryExhausted>;
+const markExhaustedMock = markCategoryExhausted as jest.MockedFunction<typeof markCategoryExhausted>;
 
 const IMAGES = [{ listId: 1 }, { listId: 2 }, { listId: 3 }];
 
@@ -40,14 +44,16 @@ describe('cardPrefetcher', () => {
     remainingMock.mockResolvedValue(0);
     fetchMock.mockResolvedValue({ isError: false, images: IMAGES } as never);
     appendMock.mockResolvedValue(null as never);
+    isExhaustedMock.mockResolvedValue(false);
+    markExhaustedMock.mockResolvedValue(undefined);
   });
 
-  it('exports LOW_CARD_THRESHOLD equal to 3 (lowered for warmer decode pipeline)', () => {
-    expect(LOW_CARD_THRESHOLD).toBe(3);
+  it('exports LOW_CARD_THRESHOLD equal to 4 (refill at ≤3 remaining)', () => {
+    expect(LOW_CARD_THRESHOLD).toBe(4);
   });
 
-  it('exports ALL_WARM_THRESHOLD equal to 5 (intentionally unchanged)', () => {
-    expect(ALL_WARM_THRESHOLD).toBe(5);
+  it('exports TARGET_BATCH_SIZE equal to 5 (single source of truth for category top-up + all-deck fill)', () => {
+    expect(TARGET_BATCH_SIZE).toBe(5);
   });
 
   it('exports LOOKAHEAD_PREFETCH equal to 3', () => {
@@ -84,6 +90,14 @@ describe('cardPrefetcher', () => {
       language: 'fr',
       scope: { kind: 'public' },
     });
+  });
+
+  it('fires prefetch when count === 3 (the previously-broken boundary)', async () => {
+    remainingMock.mockResolvedValue(3);
+
+    await prefetchIfLow({ categoryKey: 'all', language: 'fr', scope: { kind: 'public' }, authContext: { token: 'x' } });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('skips append when fetchCardBatch returns isError', async () => {
@@ -133,8 +147,10 @@ describe('cardPrefetcher', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('warms the "all" deck in addition to the category fetch when categoryKey !== "all" and count is low', async () => {
-    remainingMock.mockResolvedValueOnce(2);
+  it('warms the "all" deck in addition to the category fetch when the total deck is below TARGET_BATCH_SIZE', async () => {
+    // count=0 + category returns 3 (IMAGES) = 3 < TARGET_BATCH_SIZE=5 → top-up
+    // of 2 fires from 'all'. Pins the (count + appendedCount) gate at deck level.
+    remainingMock.mockResolvedValueOnce(0);
     remainingMock.mockResolvedValueOnce(0);
     fetchMock.mockImplementation((params) =>
       okResponse((params as { categoryKey: string }).categoryKey === 'all' ? [{ listId: 100 }] : IMAGES),
@@ -154,8 +170,11 @@ describe('cardPrefetcher', () => {
     expect(allAppend![0]).toMatchObject({ cards: [{ listId: 100 }], categoryKey: 'all' });
   });
 
-  it('does not re-warm while the persisted "all" deck still has cards', async () => {
-    remainingMock.mockResolvedValueOnce(0).mockResolvedValueOnce(2);
+  it('does not re-warm while the persisted "all" deck already has >= TARGET_BATCH_SIZE cards', async () => {
+    // B1/F1: the gate is now `count >= target` (was `count > 0`). A partial
+    // 'all' deck (e.g. 2 cards) MUST top up to TARGET_BATCH_SIZE=5; only a
+    // deck already at >= target short-circuits.
+    remainingMock.mockResolvedValueOnce(0).mockResolvedValueOnce(TARGET_BATCH_SIZE);
     fetchMock.mockImplementation(() => okResponse());
 
     await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
@@ -340,12 +359,12 @@ describe('cardPrefetcher', () => {
     expect(fetchMock).toHaveBeenCalledWith(expect.objectContaining({ categoryKey: 'all' }));
   });
 
-  it('warmAllDeckIfNeeded short-circuits when cursor-filtered remaining > 0 (RC8/CB3)', async () => {
-    // Same persisted 'all' deck, but now listId=10 leaves cursor-ahead cards
-    // (listIds 11+). The cursor-aware count is 2 → warm short-circuits even
-    // though a count-only check would also have short-circuited; this test
-    // pins that the cursor-aware path still gates correctly when ahead > 0.
-    remainingMock.mockResolvedValue(2);
+  it('warmAllDeckIfNeeded short-circuits when cursor-filtered remaining >= target (RC8/CB3 + B1 gate)', async () => {
+    // B1/F1: the early-return gate is now `count >= target` (default
+    // TARGET_BATCH_SIZE=5). Same persisted 'all' deck semantics as before —
+    // the cursor-aware count is consulted with currentListId and short-
+    // circuits when the deck already has enough cards ahead of the cursor.
+    remainingMock.mockResolvedValue(TARGET_BATCH_SIZE);
 
     await warmAllDeckIfNeeded({
       language: 'fr',
@@ -366,5 +385,136 @@ describe('cardPrefetcher', () => {
     expect(remainingMock).toHaveBeenCalledWith(expect.objectContaining({
       currentListId: undefined,
     }));
+  });
+
+  // ─── B1 / F1: download 5 at once, topping up from 'all' ───
+
+  it('B1(a): category returns 2 + count=0 → fetches 3 from "all" to reach TARGET_BATCH_SIZE=5', async () => {
+    remainingMock.mockResolvedValue(0); // count=0; 'all' count=0
+    fetchMock.mockImplementation((params) =>
+      okResponse(
+        (params as { categoryKey: string }).categoryKey === 'all'
+          ? [{ listId: 100 }, { listId: 101 }, { listId: 102 }]
+          : [{ listId: 1 }, { listId: 2 }],
+      ),
+    );
+
+    await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const categoryCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'city');
+    const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+    expect(categoryCalls).toHaveLength(1);
+    expect(allCalls).toHaveLength(1);
+    // count(0) + appended(2) = 2 → target = 5 - 2 = 3
+    expect(allCalls[0]![0]).toMatchObject({ categoryKey: 'all', language: 'fr' });
+  });
+
+  it('B1(b): category returns 5 → no "all" top-up (total deck already at target)', async () => {
+    remainingMock.mockResolvedValue(0);
+    fetchMock.mockImplementation(() => okResponse([
+      { listId: 1 }, { listId: 2 }, { listId: 3 }, { listId: 4 }, { listId: 5 },
+    ]));
+
+    await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+    expect(allCalls).toHaveLength(0);
+  });
+
+  it('B1(c): category known-empty (isCategoryExhausted true) → skips category fetch, fetches 5 from "all"', async () => {
+    isExhaustedMock.mockResolvedValue(true);
+    remainingMock.mockResolvedValue(0);
+    fetchMock.mockImplementation((params) =>
+      okResponse(
+        (params as { categoryKey: string }).categoryKey === 'all'
+          ? [{ listId: 100 }, { listId: 101 }, { listId: 102 }, { listId: 103 }, { listId: 104 }]
+          : [],
+      ),
+    );
+
+    await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(isExhaustedMock).toHaveBeenCalledWith('city', 'fr', { kind: 'public' });
+    const categoryCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'city');
+    const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+    expect(categoryCalls).toHaveLength(0);
+    expect(allCalls).toHaveLength(1);
+  });
+
+  it('B1(d): categoryKey === "all" → never tops up (single fetch, single cycle)', async () => {
+    remainingMock.mockResolvedValue(0);
+    fetchMock.mockImplementation(() => okResponse([{ listId: 1 }]));
+
+    await prefetchIfLow({ categoryKey: 'all', language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(isExhaustedMock).not.toHaveBeenCalled();
+  });
+
+  it('B1(e): category fetch returns 0 + non-"all" → markCategoryExhausted called (prefetcher writes cache)', async () => {
+    remainingMock.mockResolvedValue(0);
+    fetchMock.mockImplementation((params) =>
+      okResponse((params as { categoryKey: string }).categoryKey === 'all' ? [{ listId: 100 }] : []),
+    );
+
+    await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(markExhaustedMock).toHaveBeenCalledWith('city', 'fr', { kind: 'public' });
+  });
+
+  it('B1(e-CC4): isError (5xx) → markCategoryExhausted NOT called (transient blip must not poison cache)', async () => {
+    remainingMock.mockResolvedValue(0);
+    fetchMock.mockImplementation((params) =>
+      (params as { categoryKey: string }).categoryKey === 'all'
+        ? okResponse([{ listId: 100 }])
+        : Promise.resolve({ isError: true } as never),
+    );
+
+    await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(markExhaustedMock).not.toHaveBeenCalled();
+  });
+
+  it('B1(f): deck-level gate pin — count=2 + category returns 2 → fetches 1 from "all"; count=2 + category returns 4 → no top-up', async () => {
+    // Branch 1: count=2 + appended=2 = 4 < 5 → top-up of 1.
+    remainingMock.mockResolvedValueOnce(2).mockResolvedValueOnce(0);
+    fetchMock.mockImplementationOnce(() => okResponse([{ listId: 1 }, { listId: 2 }]));
+    fetchMock.mockImplementation(() => okResponse([{ listId: 100 }]));
+
+    await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const allCallsBranch1 = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+    expect(allCallsBranch1).toHaveLength(1);
+
+    __resetForTests();
+    jest.clearAllMocks();
+    e2eMock.mockReturnValue(false);
+    remainingMock.mockResolvedValue(0);
+    isExhaustedMock.mockResolvedValue(false);
+
+    // Branch 2: count=2 + appended=4 = 6 >= 5 → no top-up.
+    remainingMock.mockResolvedValueOnce(2);
+    fetchMock.mockImplementation(() => okResponse([{ listId: 1 }, { listId: 2 }, { listId: 3 }, { listId: 4 }]));
+
+    await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const allCallsBranch2 = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+    expect(allCallsBranch2).toHaveLength(0);
   });
 });

--- a/__tests__/nextCardAdvancer.test.ts
+++ b/__tests__/nextCardAdvancer.test.ts
@@ -8,7 +8,7 @@ jest.mock('../services/cardDeck', () => ({
 
 let mockFileExists = true;
 jest.mock('expo-file-system', () => {
-  const File = jest.fn().mockImplementation(function MockFile(firstArg: string | { uri?: string }, secondArg?: string) {
+  const File = jest.fn().mockImplementation(function MockFile(this: { uri: string | undefined; exists: boolean; delete: jest.Mock }, firstArg: string | { uri?: string }, secondArg?: string) {
     const baseUri = typeof firstArg === 'string' ? firstArg : firstArg?.uri;
     this.uri = secondArg ? `${baseUri}${secondArg}` : baseUri;
     this.exists = mockFileExists;
@@ -30,6 +30,8 @@ jest.mock('../utils/storageDatum', () => {
     getDeckCountForScope: jest.fn(),
     getRemainingDeckCount: jest.fn(),
     normalizeListIds: jest.fn((cards) => cards),
+    isCategoryExhausted: jest.fn(),
+    markCategoryExhausted: jest.fn(),
   };
 });
 jest.mock('../utils/e2eMode', () => ({ isE2EMode: jest.fn(() => false) }));
@@ -46,7 +48,7 @@ jest.mock('../services/cardPrefetcher', () => {
 
 import { resolveNextGuessParams } from '../utils/handleGuessOutcome';
 import { fetchCardBatch, appendCardBatch } from '../services/cardDeck';
-import { getDeckCountForScope, getRemainingDeckCount, normalizeListIds } from '../utils/storageDatum';
+import { getDeckCountForScope, getRemainingDeckCount, normalizeListIds, isCategoryExhausted, markCategoryExhausted } from '../utils/storageDatum';
 import { isE2EMode } from '../utils/e2eMode';
 import { warmAllDeckIfNeeded, prefetchIfLow, __resetForTests } from '../services/cardPrefetcher';
 import { resolveNextCardWithServerFallback } from '../utils/nextCardAdvancer';
@@ -60,6 +62,18 @@ const countMock = getDeckCountForScope as jest.MockedFunction<typeof getDeckCoun
 const remainingMock = getRemainingDeckCount as jest.MockedFunction<typeof getRemainingDeckCount>;
 const e2eMock = isE2EMode as jest.MockedFunction<typeof isE2EMode>;
 const normalizeMock = normalizeListIds as jest.MockedFunction<typeof normalizeListIds>;
+const isExhaustedMock = isCategoryExhausted as jest.MockedFunction<typeof isCategoryExhausted>;
+const markExhaustedMock = markCategoryExhausted as jest.MockedFunction<typeof markCategoryExhausted>;
+
+// jest.setup.js globally mocks AsyncStorage; cast to a typed mock view so
+// .mockResolvedValue / .mockImplementation are visible to TypeScript.
+const mockAsyncStorage = AsyncStorage as unknown as {
+  getItem: jest.MockedFunction<(key: string) => Promise<string | null>>;
+  setItem: jest.MockedFunction<(key: string, value: string) => Promise<void>>;
+  removeItem: jest.MockedFunction<(key: string) => Promise<void>>;
+  getAllKeys: jest.MockedFunction<() => Promise<readonly string[]>>;
+  multiRemove: jest.MockedFunction<(keys: readonly string[]) => Promise<void>>;
+};
 
 const CARD_PARAMS = { listId: 9, pictureId: 'img-9', imageFile: 'file:///nine.jpg' };
 const A_CARD_RESULT = { params: CARD_PARAMS };
@@ -84,6 +98,9 @@ describe('resolveNextCardWithServerFallback', () => {
     // (returns before touching inFlight) for the existing Tier-2/3/4 tests.
     remainingMock.mockResolvedValue(100);
     countMock.mockResolvedValue(100);
+    // F3a defaults: cache miss (don't short-circuit) + write resolves silently.
+    isExhaustedMock.mockResolvedValue(false);
+    markExhaustedMock.mockResolvedValue(undefined);
   });
 
   it('returns the locally-resolved card without any server fetch when the deck has a next card', async () => {
@@ -433,7 +450,7 @@ describe('resolveNextCardWithServerFallback', () => {
       appendMock.mockImplementation(realCardDeck.appendCardBatch as never);
       resolveMock.mockImplementation(realHandleGuess.resolveNextGuessParams as never);
       normalizeMock.mockImplementation(realStorage.normalizeListIds as never);
-      AsyncStorage.setItem.mockResolvedValue(undefined);
+      mockAsyncStorage.setItem.mockResolvedValue(undefined);
     });
 
     it('does NOT return the just-played card when the server re-serves it in Tier 2', async () => {
@@ -446,8 +463,8 @@ describe('resolveNextCardWithServerFallback', () => {
         'imageList:city:fr',
         JSON.stringify([{ listId: 1, pictureId: 'played-card', imageFile: 'file:///cache/played.jpg' }]),
       );
-      AsyncStorage.getItem.mockImplementation((key: string) => Promise.resolve(store.get(key) ?? null));
-      AsyncStorage.setItem.mockImplementation((key: string, value: string) => {
+      mockAsyncStorage.getItem.mockImplementation((key: string) => Promise.resolve(store.get(key) ?? null));
+      mockAsyncStorage.setItem.mockImplementation((key: string, value: string) => {
         store.set(key, value);
         return Promise.resolve();
       });
@@ -471,6 +488,164 @@ describe('resolveNextCardWithServerFallback', () => {
       expect(result.reason).toBe('ok');
       expect(result.next).not.toBeNull();
       expect((result.next as { params: { pictureId?: string } }).params.pictureId).toBe('new-card');
+    });
+  });
+
+  // ─── F3a — exhausted-category cache (Tier 2 short-circuit) ──────────────
+  //
+  // When the server returned 0 cards for a (categoryKey, language, scope)
+  // tuple on a prior advance, the tuple is cached as exhausted. Subsequent
+  // advances short-circuit at Tier 2 → straight to Tier 3 ('all' cross-
+  // fallback) with zero server round-trips. Guards: never cache 'all'; never
+  // read/write on the Tier-4 head-replay path; only the genuine-empty branch
+  // writes (5xx MUST NOT poison).
+  describe('resolveNextCardWithServerFallback — F3a exhausted-category cache', () => {
+    it('(a) isCategoryExhausted=false → foregroundTopUp fetches normally (no short-circuit)', async () => {
+      resolveMock
+        .mockResolvedValueOnce(null as never)   // Tier 1
+        .mockResolvedValueOnce(null as never)   // Tier 2 recheck
+        .mockResolvedValueOnce(A_CARD_RESULT as never);
+      fetchMock.mockResolvedValue({ isError: false, images: [{ listId: 9 }] } as never);
+      isExhaustedMock.mockResolvedValue(false);
+
+      const result = await resolveNextCardWithServerFallback(BASE_ARGS);
+
+      expect(result.reason).toBe('ok');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(expect.objectContaining({ categoryKey: 'city' }));
+    });
+
+    it('(b) isCategoryExhausted=true + non-null override + non-"all" → returns {ok:false,reason:"empty"} WITHOUT fetchCardBatch; Tier 3 still runs', async () => {
+      resolveMock
+        .mockResolvedValueOnce(null as never)   // Tier 1
+        .mockResolvedValueOnce(A_CARD_RESULT as never); // Tier 3 warmed 'all' hits
+      isExhaustedMock.mockResolvedValue(true);
+
+      const result = await resolveNextCardWithServerFallback(BASE_ARGS);
+
+      expect(result.reason).toBe('ok');
+      // The city fetch was short-circuited — no fetchCardBatch for the category.
+      expect(fetchMock).not.toHaveBeenCalled();
+      // Read happened for the city tuple (Tier 2 path, pictureIdOverride=undefined).
+      expect(isExhaustedMock).toHaveBeenCalledWith('city', 'fr', BASE_ARGS.scope);
+      // Control reached Tier 3 (cache short-circuit does NOT bypass T3).
+      expect(warmMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('(c) server returns empty + non-null override + non-"all" → markCategoryExhausted called for the tuple', async () => {
+      resolveMock
+        .mockResolvedValueOnce(null as never)   // Tier 1
+        .mockResolvedValueOnce(null as never)   // Tier 2 recheck (still empty)
+        .mockResolvedValueOnce(A_CARD_RESULT as never); // Tier 3 warmed 'all'
+      fetchMock.mockResolvedValue({ isError: false, images: [] } as never);
+
+      await resolveNextCardWithServerFallback(BASE_ARGS);
+
+      expect(markExhaustedMock).toHaveBeenCalledWith('city', 'fr', BASE_ARGS.scope);
+    });
+
+    it('(d) categoryKey === "all" → NEVER writes cache even on empty', async () => {
+      resolveMock.mockResolvedValue(null as never);
+      fetchMock.mockResolvedValue({ isError: false, images: [] } as never);
+
+      await resolveNextCardWithServerFallback({ ...BASE_ARGS, category: { key: 'all' } });
+
+      expect(markExhaustedMock).not.toHaveBeenCalled();
+    });
+
+    it('(e) Tier 4 (pictureIdOverride=null) → NEVER reads AND NEVER writes the cache', async () => {
+      // category='all' end-to-end so the only non-trivial tier is Tier 4
+      // (head replay with pictureIdOverride=null). Both Tier 2 and Tier 4 have
+      // categoryKey='all' AND Tier 4 has isHeadReplay=true, so cache is never
+      // consulted.
+      resolveMock.mockResolvedValue(null as never);
+      fetchMock.mockResolvedValue({ isError: false, images: [] } as never);
+
+      await resolveNextCardWithServerFallback({ ...BASE_ARGS, category: { key: 'all' } });
+
+      expect(isExhaustedMock).not.toHaveBeenCalled();
+      expect(markExhaustedMock).not.toHaveBeenCalled();
+    });
+
+    it('(h) cache-hit at Tier 2 → control still reaches Tier 3 ("all" cross-fallback runs)', async () => {
+      // Tier 2 short-circuits with reason='empty' (cache hit). The cascade
+      // pushes the reason and continues to Tier 3 — the cache hit must NOT
+      // bypass T3. Tier 3 warms 'all' and resolves a card.
+      resolveMock
+        .mockResolvedValueOnce(null as never)   // Tier 1
+        .mockResolvedValueOnce(A_CARD_RESULT as never); // Tier 3 warmed 'all'
+      isExhaustedMock.mockResolvedValue(true);
+
+      const result = await resolveNextCardWithServerFallback(BASE_ARGS);
+
+      expect(result.reason).toBe('ok');
+      expect(warmMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('(j) CC4 defensive pin: 5xx (r.isError=true → reason="server") does NOT write the exhausted cache', async () => {
+      // Only the genuine-empty branch writes. A 5xx blip must not poison the
+      // cache — otherwise a transient server error permanently marks a
+      // category exhausted.
+      resolveMock
+        .mockResolvedValueOnce(null as never)   // Tier 1
+        .mockResolvedValueOnce(null as never)   // Tier 2 recheck
+        .mockResolvedValueOnce(A_CARD_RESULT as never); // Tier 3 warmed 'all'
+      fetchMock.mockResolvedValue({ isError: true } as never);
+
+      await resolveNextCardWithServerFallback(BASE_ARGS);
+
+      expect(markExhaustedMock).not.toHaveBeenCalled();
+    });
+
+    describe('private scope isolation + purge (real AsyncStorage)', () => {
+      const realStorage = jest.requireActual('../utils/storageDatum');
+      const realGroupFeedCache = jest.requireActual('../services/groups/groupFeedCache');
+
+      // In-memory AsyncStorage so the real helpers' writes are observable
+      // across groups without leaking between tests.
+      let store: Map<string, string>;
+      const memoryAsyncStorage = () => ({
+        getItem: (key: string) => Promise.resolve(store.has(key) ? store.get(key)! : null),
+        setItem: (key: string, value: string) => { store.set(key, value); return Promise.resolve(); },
+        removeItem: (key: string) => { store.delete(key); return Promise.resolve(); },
+        getAllKeys: () => Promise.resolve(Array.from(store.keys())),
+        multiRemove: (keys: string[]) => { for (const k of keys) store.delete(k); return Promise.resolve(); },
+      });
+
+      beforeEach(() => {
+        store = new Map();
+        const mem = memoryAsyncStorage();
+        mockAsyncStorage.getItem.mockImplementation(mem.getItem as never);
+        mockAsyncStorage.setItem.mockImplementation(mem.setItem as never);
+        mockAsyncStorage.removeItem.mockImplementation(mem.removeItem as never);
+        mockAsyncStorage.getAllKeys.mockImplementation(mem.getAllKeys as never);
+        mockAsyncStorage.multiRemove.mockImplementation(mem.multiRemove as never);
+      });
+
+      it('(g) group A marking category exhausted does NOT mark it for group B (distinct groupFeedCache keys)', async () => {
+        await realStorage.markCategoryExhausted('city', 'fr', { kind: 'private', groupId: 'groupA' });
+
+        expect(await realStorage.isCategoryExhausted('city', 'fr', { kind: 'private', groupId: 'groupA' })).toBe(true);
+        // Group B reads the same (categoryKey, language) but its own groupId — MUST be false.
+        expect(await realStorage.isCategoryExhausted('city', 'fr', { kind: 'private', groupId: 'groupB' })).toBe(false);
+
+        // Keys are groupId-scoped (no cross-contamination).
+        const keys = await AsyncStorage.getAllKeys();
+        expect(keys).toContain('groupFeedExhausted:groupA:city:fr');
+        expect(keys).not.toContain('groupFeedExhausted:groupB:city:fr');
+      });
+
+      it('(i) purgeAllPrivateCaches drops the private exhausted marker', async () => {
+        await realStorage.markCategoryExhausted('city', 'fr', { kind: 'private', groupId: 'groupA' });
+        expect(await realStorage.isCategoryExhausted('city', 'fr', { kind: 'private', groupId: 'groupA' })).toBe(true);
+
+        await realGroupFeedCache.purgeAllPrivateCaches();
+
+        expect(await realStorage.isCategoryExhausted('city', 'fr', { kind: 'private', groupId: 'groupA' })).toBe(false);
+        const keys = await AsyncStorage.getAllKeys();
+        expect(keys).not.toContain('groupFeedExhausted:groupA:city:fr');
+      });
     });
   });
 });

--- a/__tests__/storageDatum.test.js
+++ b/__tests__/storageDatum.test.js
@@ -6,6 +6,9 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 
 jest.mock('../services/groups/groupFeedCache', () => ({
   readGroupFeedCache: jest.fn(),
+  markGroupCategoryExhausted: jest.fn(),
+  isGroupCategoryExhausted: jest.fn(),
+  clearGroupCategoryExhausted: jest.fn(),
 }));
 
 const mockDelete = jest.fn();
@@ -32,12 +35,14 @@ jest.mock('expo-file-system', () => {
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { File } from 'expo-file-system';
-import { readGroupFeedCache } from '../services/groups/groupFeedCache';
+import { readGroupFeedCache, markGroupCategoryExhausted, isGroupCategoryExhausted, clearGroupCategoryExhausted } from '../services/groups/groupFeedCache';
 
 import {
   clearE2EHiddenGuessCard,
+  clearExhaustedCategory,
   deleteImageFromStorage,
   emptyImageList,
+  exhaustedCategoryKey,
   getDeckCountForScope,
   getE2EHiddenGuessCard,
   getLastImageId,
@@ -51,6 +56,8 @@ import {
   getRemainingDeckCount,
   getSessionLanguageFilter,
   getUserTags,
+  isCategoryExhausted,
+  markCategoryExhausted,
   removeImageFromList,
   saveE2EHiddenGuessCard,
   saveLastImageUuid,
@@ -70,6 +77,12 @@ describe('storageDatum utilities', () => {
     AsyncStorage.setItem.mockResolvedValue(undefined);
     AsyncStorage.removeItem.mockResolvedValue(undefined);
     readGroupFeedCache.mockReset();
+    markGroupCategoryExhausted.mockReset();
+    isGroupCategoryExhausted.mockReset();
+    clearGroupCategoryExhausted.mockReset();
+    markGroupCategoryExhausted.mockResolvedValue(undefined);
+    isGroupCategoryExhausted.mockResolvedValue(false);
+    clearGroupCategoryExhausted.mockResolvedValue(undefined);
   });
 
   it('reads the local image list and returns null when none is stored', async () => {
@@ -760,6 +773,58 @@ describe('storageDatum utilities', () => {
       expect(count).toBe(3);
       expect(File).not.toHaveBeenCalled();
       expect(mockDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exhaustedCategory cache (F3a)', () => {
+    it('exhaustedCategoryKey mirrors lastImageUuidKey format and falls back to all/any', () => {
+      expect(exhaustedCategoryKey('city', 'fr')).toBe('exhaustedCategory:city:fr');
+      expect(exhaustedCategoryKey(undefined, undefined)).toBe('exhaustedCategory:all:any');
+      expect(exhaustedCategoryKey(null, null)).toBe('exhaustedCategory:all:any');
+    });
+
+    it('PUBLIC scope round-trips mark → is → clear against AsyncStorage', async () => {
+      await markCategoryExhausted('city', 'fr', { kind: 'public' });
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith('exhaustedCategory:city:fr', '1');
+
+      AsyncStorage.getItem.mockResolvedValueOnce('1');
+      expect(await isCategoryExhausted('city', 'fr', { kind: 'public' })).toBe(true);
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith('exhaustedCategory:city:fr');
+
+      AsyncStorage.getItem.mockResolvedValueOnce(null);
+      expect(await isCategoryExhausted('city', 'fr', { kind: 'public' })).toBe(false);
+
+      await clearExhaustedCategory('city', 'fr', { kind: 'public' });
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('exhaustedCategory:city:fr');
+    });
+
+    it('PRIVATE scope delegates to groupFeedCache helpers with scope.groupId (isolation)', async () => {
+      const privateScope = { kind: 'private', groupId: 'g-7' };
+
+      await markCategoryExhausted('city', 'fr', privateScope);
+      expect(markGroupCategoryExhausted).toHaveBeenCalledWith('g-7', 'city', 'fr');
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+
+      await isCategoryExhausted('city', 'fr', privateScope);
+      expect(isGroupCategoryExhausted).toHaveBeenCalledWith('g-7', 'city', 'fr');
+
+      await clearExhaustedCategory('city', 'fr', privateScope);
+      expect(clearGroupCategoryExhausted).toHaveBeenCalledWith('g-7', 'city', 'fr');
+      expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('exhaustedCategory:city:fr');
+    });
+
+    it('PUBLIC scope without kind still uses AsyncStorage (defensive default)', async () => {
+      await markCategoryExhausted('city', 'fr', undefined);
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith('exhaustedCategory:city:fr', '1');
+      expect(markGroupCategoryExhausted).not.toHaveBeenCalled();
+    });
+
+    it('emptyImageList now also drops the public exhausted key for the tuple', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(null);
+
+      await emptyImageList('city', 'fr');
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('exhaustedCategory:city:fr');
     });
   });
 });

--- a/constants/overlayZIndex.ts
+++ b/constants/overlayZIndex.ts
@@ -17,10 +17,10 @@
  *
  * Why AdInterstitial (9998) sits BELOW SuccessOverlay / GuessExhaustedPanel
  * (9999):
- *   - SuccessOverlay animates over the picture right after a correct guess;
- *     the interstitial only mounts later (advance state 'showing'). The +1
- *     margin guarantees a still-visible success burst is never obscured if
- *     both ever overlap during the brief swap window.
+ *   - AdInterstitial (9998) mounts only AFTER SuccessOverlay (9999) has
+ *     dismissed (see `useResolveLifecycle` ad-branch `overlayVisibleRef`
+ *     gate); the z-order is defense-in-depth only, not the primary
+ *     race-prevention mechanism.
  *   - GuessExhaustedPanel is the terminal "no more cards" gate; it must sit
  *     above every gameplay layer (including any lingering ad) so the user
  *     always sees the exit CTA.

--- a/hooks/useResolveLifecycle.ts
+++ b/hooks/useResolveLifecycle.ts
@@ -50,6 +50,11 @@ export type UseResolveLifecycleArgs = {
   // Cadence state stays owned by useAdCadence; the lifecycle only asks it to
   // consume the current slot after success side effects commit.
   consumeAdSlot: () => ConsumeAdSlotResult;
+  // F4: mirrors `showSuccess` from GuessScreen as a synchronous ref so the
+  // warming-retry commit gate can read overlay visibility WITHOUT waiting for
+  // a passive effect flush. Writer lives in GuessScreen (`applyShowSuccess`);
+  // a useEffect([showSuccess]) mirror is kept there as belt-and-suspenders.
+  overlayVisibleRef: RefObject<boolean>;
 };
 
 export type UseResolveLifecycleResult = {
@@ -58,6 +63,7 @@ export type UseResolveLifecycleResult = {
   consumePendingNext: () => NonNullable<NextGuessResult> | null;
   handleAdDone: () => void;
   clearRetryTimer: () => void;
+  clearPendingNext: () => void;
 };
 
 // Owns the resolve-lifecycle machinery: the in-flight next-card Promise ref,
@@ -75,6 +81,7 @@ export function useResolveLifecycle({
   resolveArgs,
   sideEffectArgs,
   consumeAdSlot,
+  overlayVisibleRef,
 }: UseResolveLifecycleArgs): UseResolveLifecycleResult {
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const retryCountRef = useRef<number>(0);
@@ -112,6 +119,9 @@ export function useResolveLifecycle({
         retryTimerRef.current = null;
       }
       nextCardResolveRef.current = null;
+      // F4 nit: drop a staged next on unmount so a warming-stages-next +
+      // background orphan cannot leak across screen lifetime.
+      pendingNextRef.current = null;
       mountedRef.current = false;
     };
   }, []);
@@ -131,7 +141,7 @@ export function useResolveLifecycle({
   // read from a ref) so the retry-loop recovery credits the success-time
   // multiplier even if state has since moved on.
   async function runResolveCycle(multiplier: number) {
-    const { next } = await resolveNextCardWithServerFallback({
+    const { next, reason } = await resolveNextCardWithServerFallback({
       category: resolveArgs.category,
       language: resolveArgs.language,
       currentListId: resolveArgs.currentListId,
@@ -146,11 +156,20 @@ export function useResolveLifecycle({
       return;
     }
 
-    // P1 (ad-overlay post-fix §1 C1): all non-ok reasons are transient.
-    // FAILED_TRANSIENT is a no-op when already in warming (reducer rejects it);
-    // legal only from advancing.
-    dispatch({ type: 'FAILED_TRANSIENT' });
-    scheduleRetry(multiplier);
+    // F3b: retry only on network. The cascade (nextCardAdvancer) already tried
+    // Tier 3 'all' cross-fallback + Tier 4 looping-replay before returning null,
+    // so a non-network null is deterministic — retrying just burns 1s+2s+4s.
+    // 'empty' | 'server' (and any unmapped reason) → FAILED_PERMANENT → exhausted.
+    if (reason === 'network') {
+      dispatch({ type: 'FAILED_TRANSIENT' });
+      scheduleRetry(multiplier);
+      return;
+    }
+    // F4 nit: terminal transition — drop any staged next so a
+    // staged-next-then-background orphan cannot leak (the next WIN overwrites
+    // the ref before read, but null-on-terminal is cheap defense).
+    pendingNextRef.current = null;
+    dispatch({ type: 'FAILED_PERMANENT' });
   }
 
   // PB6: streak + score commit lives here — only on a successfully resolved
@@ -189,26 +208,22 @@ export function useResolveLifecycle({
 
     const { showAd } = consumeAdSlot();
 
-    // P2: when no ad is due, RESOLVED is NOT dispatched here in the INITIAL
-    // resolve (state=advancing) — the resolved next is staged on
-    // pendingNextRef and the dispatch is deferred to handleOverlayDone
-    // (mirrors the ad-path defer to handleAdDone) so the next image's
-    // imageFile URI does not land in route.params while the SuccessOverlay is
-    // still animating. The ad branch below stages on the same ref + flips
-    // adPhase → 'showing'; RESOLVED fires from handleAdDone after the ad
-    // dismisses.
-    //
-    // WARMING EXCEPTION: when state=warming, the resolve that fired this
-    // onAdvanceResolved came from scheduleRetry's fire-and-forget
-    // runResolveCycle() (NOT the promise stored in nextCardResolveRef). By
-    // this point handleOverlayDone has already returned (its await on the
-    // original nextCardResolveRef completed when the first runResolveCycle
-    // returned null+network and dispatched FAILED_TRANSIENT). No later
-    // callback exists to commit a staged next, so we dispatch immediately to
-    // preserve the "RESOLVED exactly once per win cycle" invariant. The A7
-    // guard above already admitted state=warming as a valid resolving state.
+    // F4 (ref-as-control-flow): the no-ad commit gate reads
+    // `overlayVisibleRef.current` (a synchronous mirror of GuessScreen's
+    // `showSuccess` state) instead of `advanceStateRef.current`. This unifies
+    // the advancing + warming branches into a single rule and closes the
+    // animation-overlap race: for tier1+ wins the SuccessOverlay dismisses at
+    // ~1200-2600ms while the first warming retry fires at 1000ms, so the retry
+    // can land WHILE the overlay is still animating. The previous
+    // `advanceStateRef.current === 'advancing'` predicate was FALSE for warming,
+    // so the warming branch fell through to an UNCONDITIONAL `RESOLVED` dispatch
+    // → the next image swapped behind the still-visible overlay. Now: when the
+    // overlay is up (advancing OR warming retry mid-overlay) → stage on
+    // pendingNextRef (commit deferred to handleOverlayDone after the fade); when
+    // the overlay is already down (success-first-try with no overlay, OR a
+    // warming retry landing after overlay dismissed) → dispatch immediately.
     if (!showAd) {
-      if (advanceStateRef.current === 'advancing') {
+      if (overlayVisibleRef.current) {
         pendingNextRef.current = next;
         return;
       }
@@ -270,11 +285,20 @@ export function useResolveLifecycle({
     return next;
   };
 
+  // F4 nit: terminal-cleanup callback for call sites that dispatch
+  // FAILED_PERMANENT directly (GuessScreen's AppState backgrounding listener)
+  // so they also drop any staged next — mirrors the nulling done at the hook's
+  // own FAILED_PERMANENT dispatch and at unmount.
+  const clearPendingNext = useCallback(() => {
+    pendingNextRef.current = null;
+  }, []);
+
   return {
     kickoffResolve,
     awaitResolve,
     consumePendingNext,
     handleAdDone,
     clearRetryTimer,
+    clearPendingNext,
   };
 }

--- a/hooks/useResolveLifecycle.ts
+++ b/hooks/useResolveLifecycle.ts
@@ -64,6 +64,14 @@ export type UseResolveLifecycleResult = {
   handleAdDone: () => void;
   clearRetryTimer: () => void;
   clearPendingNext: () => void;
+  /**
+   * F1 (G1): single-read-and-reset of the deferred-ad flag. Returns true when
+   * the showAd branch staged the next on pendingNextRef BUT deferred
+   * setAdPhase('showing') because overlayVisibleRef.current was true at
+   * resolve time. handleOverlayDone calls this after applyShowSuccess(false)
+   * so the ad trigger lands only after the success burst has dismissed.
+   */
+  consumeDeferredAd: () => boolean;
 };
 
 // Owns the resolve-lifecycle machinery: the in-flight next-card Promise ref,
@@ -106,6 +114,13 @@ export function useResolveLifecycle({
   // deferred RESOLVED (staged in onAdvanceResolved, consumed by
   // handleOverlayDone via consumePendingNext).
   const pendingNextRef = useRef<NonNullable<NextGuessResult> | null>(null);
+  // F1 (G1): mirror of the no-ad branch's overlayVisibleRef commit gate,
+  // applied to the showAd branch's setAdPhase('showing') trigger. Set when
+  // the ad slot is consumed while the SuccessOverlay is still animating;
+  // consumed by handleOverlayDone after applyShowSuccess(false) so the
+  // interstitial never mounts under the success burst. Drained on terminal
+  // transitions + unmount so a backgrounded cycle cannot orphan an ad.
+  const adDeferredRef = useRef<boolean>(false);
 
   // PT6: clear any pending retry timer on unmount so we never setState after
   // unmount (Leave tap during warming, navigation.popToTop, etc.). C1: also
@@ -122,6 +137,9 @@ export function useResolveLifecycle({
       // F4 nit: drop a staged next on unmount so a warming-stages-next +
       // background orphan cannot leak across screen lifetime.
       pendingNextRef.current = null;
+      // F1 (G1): also drop a deferred-ad flag so a re-mount cannot observe a
+      // stale deferred state from the prior instance.
+      adDeferredRef.current = false;
       mountedRef.current = false;
     };
   }, []);
@@ -169,6 +187,10 @@ export function useResolveLifecycle({
     // staged-next-then-background orphan cannot leak (the next WIN overwrites
     // the ref before read, but null-on-terminal is cheap defense).
     pendingNextRef.current = null;
+    // F1 (G1): clear the deferred-ad flag on terminal transition so a later
+    // handleOverlayDone (overlay animation completing post-backgrounding)
+    // cannot orphan an ad on top of the exhausted panel.
+    adDeferredRef.current = false;
     dispatch({ type: 'FAILED_PERMANENT' });
   }
 
@@ -231,11 +253,20 @@ export function useResolveLifecycle({
       return;
     }
 
-    // C2 (ad-in-screen-overlay §3.2 step 3-5): showAd branch renders the
-    // in-component overlay. Stage the resolved next on the ref + flip
-    // adPhase → 'showing'. RESOLVED is deferred to handleAdDone so the
-    // reducer lands in `idle` only after the ad dismisses.
+    // C2 (ad-in-screen-overlay §3.2 step 3-5) + F1 (G1): showAd branch stages
+    // the resolved next on pendingNextRef for handleAdDone. setAdPhase('showing')
+    // is gated on overlayVisibleRef.current (mirror of the no-ad branch's
+    // commit gate at :225-229) so AdInterstitial never mounts under the
+    // still-animating success burst. When the overlay is up at resolve time,
+    // the trigger is deferred to handleOverlayDone via adDeferredRef; when the
+    // overlay is already down (slow resolve past tier-0 duration, or a
+    // no-overlay win path), the ad mounts immediately. RESOLVED is always
+    // deferred to handleAdDone.
     pendingNextRef.current = next;
+    if (overlayVisibleRef.current) {
+      adDeferredRef.current = true;
+      return;
+    }
     setAdPhase('showing');
   }
 
@@ -272,6 +303,10 @@ export function useResolveLifecycle({
 
   const kickoffResolve = (multiplier: number) => {
     retryCountRef.current = 0;
+    // F1 (G1): reset the deferred-ad flag at cycle start so a stale flag from
+    // a prior win cannot leak across consecutive cycles. Belt-and-suspenders
+    // alongside the advancing/warming tap-gate (disabled={state !== 'idle'}).
+    adDeferredRef.current = false;
     nextCardResolveRef.current = runResolveCycle(multiplier);
   };
 
@@ -285,12 +320,24 @@ export function useResolveLifecycle({
     return next;
   };
 
+  // F1 (G1): single-read-and-reset of the deferred-ad flag. Mirrors
+  // consumePendingNext's pattern so handleOverlayDone can decide whether to
+  // trigger the deferred ad or fall through to the no-ad RESOLVED dispatch.
+  const consumeDeferredAd = () => {
+    const prev = adDeferredRef.current;
+    adDeferredRef.current = false;
+    return prev;
+  };
+
   // F4 nit: terminal-cleanup callback for call sites that dispatch
   // FAILED_PERMANENT directly (GuessScreen's AppState backgrounding listener)
   // so they also drop any staged next — mirrors the nulling done at the hook's
-  // own FAILED_PERMANENT dispatch and at unmount.
+  // own FAILED_PERMANENT dispatch and at unmount. F1 (G1): also clears the
+  // deferred-ad flag for the same orphan-prevention reason. Single helper for
+  // both refs minimizes call-site churn.
   const clearPendingNext = useCallback(() => {
     pendingNextRef.current = null;
+    adDeferredRef.current = false;
   }, []);
 
   return {
@@ -300,5 +347,6 @@ export function useResolveLifecycle({
     handleAdDone,
     clearRetryTimer,
     clearPendingNext,
+    consumeDeferredAd,
   };
 }

--- a/screens/GuessScreens/GuessScreen.tsx
+++ b/screens/GuessScreens/GuessScreen.tsx
@@ -172,6 +172,7 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
     kickoffResolve,
     awaitResolve,
     consumePendingNext,
+    consumeDeferredAd,
     handleAdDone,
     clearRetryTimer,
     clearPendingNext,
@@ -363,16 +364,18 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
     // (showSuccess is only true after applySuccessPath); no fallback branch
     // per agent-defaults §2.2.
     await awaitResolve();
-    // P2: in the no-ad path, RESOLVED is dispatched HERE (after the overlay
-    // animation completes) instead of inside onAdvanceResolved so the next
-    // card's imageFile URI does not land in route.params WHILE the overlay is
-    // still animating its fade-out (which would flash the next image behind
-    // the semi-transparent overlay). The ad path sets adPhase='showing' before
-    // this point, so the guard skips the dispatch here and leaves it to
-    // handleAdDone (sole dispatch site for the ad path). handleOverlayDone is
-    // not memoized (re-created every render) and SuccessOverlay reads onDone
-    // through an internal ref kept fresh on every parent render, so the
-    // adPhase read sees the latest committed value — no stale-closure risk.
+    // P2 / F1 (G1): after applyShowSuccess(false) + awaitResolve, three
+    // branches reach here: (a) no-ad path dispatches RESOLVED here; (b)
+    // deferred-ad path (overlay was still animating when resolve settled)
+    // triggers setAdPhase('showing') here via consumeDeferredAd — pendingNext
+    // was already staged on the hook, handleAdDone will commit RESOLVED on
+    // dismiss; (c) non-deferred ad path (overlay-down fast path at resolve
+    // time) already set adPhase='showing' inside onAdvanceResolved, so the
+    // guard skips the dispatch here and leaves RESOLVED to handleAdDone.
+    if (consumeDeferredAd()) {
+      setAdPhase('showing');
+      return;
+    }
     if (adPhase !== 'showing') {
       const next = consumePendingNext();
       if (next) {

--- a/screens/GuessScreens/GuessScreen.tsx
+++ b/screens/GuessScreens/GuessScreen.tsx
@@ -15,7 +15,7 @@ import { AuthContext } from '../../store/auth-context';
 import { isOnTarget } from "../../utils/targetLocation";
 import { isE2EMode } from '../../utils/e2eMode';
 import { prefetchIfLow, warmAllDeckIfNeeded } from '../../services/cardPrefetcher';
-import { getNextImagesForScope } from '../../utils/storageDatum';
+import { getNextImagesForScope, clearExhaustedCategory } from '../../utils/storageDatum';
 import { computeMultiplier, SPEED_MULTIPLIER_BASE } from '../../utils/speedMultiplier';
 import { computePoints } from '../../utils/guessPoints';
 import { useAdvanceStateMachine } from '../../hooks/useAdvanceStateMachine';
@@ -124,6 +124,20 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
   const isPrivate = scope?.kind === 'private';
 
   const [showSuccess, setShowSuccess] = useState(false);
+  // F4: synchronous mirror of `showSuccess` so useResolveLifecycle's no-ad
+  // commit gate can read overlay visibility WITHOUT waiting for a passive
+  // effect flush. Written synchronously by `applyShowSuccess` at every
+  // setShowSuccess call site; the effect mirror below is belt-and-suspenders.
+  const overlayVisibleRef = useRef(false);
+  // F4 (CC2): single source of truth for `showSuccess` writes — writes
+  // `overlayVisibleRef.current` SYNCHRONOUSLY before the state update so the
+  // warming-retry commit gate in useResolveLifecycle never observes a stale
+  // false-while-overlay-mounted. A passive effect mirror (below) catches any
+  // call site that slips past this helper.
+  const applyShowSuccess = (next: boolean) => {
+    overlayVisibleRef.current = next;
+    setShowSuccess(next);
+  };
   const [successMultiplier, setSuccessMultiplier] = useState<number>(SPEED_MULTIPLIER_BASE);
   const { streak, tier, multiplier: streakMultiplier, onWin, onLose, reset } = useStreak();
   const { advance, dispatch, advanceStateRef } = useAdvanceStateMachine({
@@ -160,12 +174,14 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
     consumePendingNext,
     handleAdDone,
     clearRetryTimer,
+    clearPendingNext,
   } = useResolveLifecycle({
     dispatch,
     advanceStateRef,
     setAdPhase,
     currentStreak: streak,
     onWin,
+    overlayVisibleRef,
     resolveArgs: {
       category,
       language,
@@ -190,6 +206,11 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
   // PT6 cleanup ownership stays in GuessScreen: clear retry timers only when a
   // real mid-advance -> terminal/idle transition happens, not on every render.
   const previousAdvanceStateRef = useRef(advance.state);
+  
+  useEffect(() => {
+    overlayVisibleRef.current = showSuccess;
+  }, [showSuccess]);
+  
   useEffect(() => {
     const previousState = previousAdvanceStateRef.current;
     previousAdvanceStateRef.current = advance.state;
@@ -234,11 +255,14 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
       const current = advanceStateRef.current;
       if (current !== 'idle' && current !== 'exhausted') {
         clearRetryTimer();
+        // F4 nit: terminal transition dispatched outside the hook — also drop
+        // any staged next so a staged-next-then-background orphan cannot leak.
+        clearPendingNext();
         dispatch({ type: 'FAILED_PERMANENT' });
       }
     });
     return () => sub.remove();
-  }, [dispatch, clearRetryTimer]);
+  }, [dispatch, clearRetryTimer, clearPendingNext]);
 
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const uri = imageFile;
@@ -295,7 +319,7 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
       currentListId: listId,
     }).catch(() => {});
     setSuccessMultiplier(multiplier);
-    setShowSuccess(true);
+    applyShowSuccess(true);
     // C1 (§4.2): the WIN dispatch + resolve kickoff both fire at WIN time so
     // the ~2-3s SuccessOverlay window covers a Tier-1/Tier-2 fetch. The A7
     // guard in onAdvanceResolved requires advanceStateRef to read 'advancing'
@@ -333,7 +357,7 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
     // R1 (§5.10): hide the success overlay FIRST so it never reads as a
     // "frozen" loading spinner. The advance state machine takes over the UI
     // (advancing/warming) while the next card resolves.
-    setShowSuccess(false);
+    applyShowSuccess(false);
     // C1 (§4.2): await the resolve kicked off in applySuccessPath. The
     // in-flight ref is always populated when handleOverlayDone fires
     // (showSuccess is only true after applySuccessPath); no fallback branch
@@ -362,6 +386,11 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
   }
 
   function handleSwitchCategory() {
+    // F3a invalidation (E1): clear the exhausted-cache entry for the CURRENT
+    // category+scope so re-entering re-queries the server (handles newly
+    // uploaded images since the category was marked empty). Fire-and-forget —
+    // navigation proceeds without waiting; the next mount re-queries fresh.
+    clearExhaustedCategory(category?.key, language, scope).catch(() => {});
     navigation.navigate('GuessPathScreen', isPrivate ? { scope } : {});
   }
 

--- a/services/cardPrefetcher.ts
+++ b/services/cardPrefetcher.ts
@@ -5,16 +5,18 @@ import { fetchCardBatch, appendCardBatch } from './cardDeck';
  * normalization cannot leak cards with missing/NaN listIds into storage.
  * Idempotent — normalizing already-normalized cards is a no-op.
  */
-import { getRemainingDeckCount, normalizeListIds } from '../utils/storageDatum';
+import { getRemainingDeckCount, normalizeListIds, isCategoryExhausted, markCategoryExhausted } from '../utils/storageDatum';
 import { isE2EMode } from '../utils/e2eMode';
 
 // Refill when only 3 cards remain — combined with NextCardImageWarmer decode prefetch, the user never waits for cold decode or server round-trip.
-export const LOW_CARD_THRESHOLD = 3;
+export const LOW_CARD_THRESHOLD = 4;
 /**
- * Cross-fallback warm-'all'-on-low trigger. Intentionally higher than
- * LOW_CARD_THRESHOLD — gates the 'all' deck warming, not per-win prefetch.
+ * Single source of truth for the deck-fill target. Gates BOTH the category
+ * top-up decision in `prefetchIfLow` (fetch from 'all' when the total deck
+ * `(count + appendedCount) < TARGET_BATCH_SIZE`) AND the early-return inside
+ * `warmAllDeckIfNeeded` (skip when the 'all' deck already has ≥ target cards).
  */
-export const ALL_WARM_THRESHOLD = 5;
+export const TARGET_BATCH_SIZE = 5;
 /**
  * Per-win look-ahead window for image preload (Phase 3, gated on spike).
  * Kept here so threshold tuning lives in one place.
@@ -40,6 +42,13 @@ export type WarmAllParams = Omit<PrefetchParams, 'categoryKey' | 'categoryId'> &
    * Default `undefined` = cursor-agnostic (counts the whole 'all' deck).
    */
   currentListId?: number;
+  /**
+   * Target deck size for the early-return gate. The function fills the 'all'
+   * deck until it has ≥ `target` cards; previously it only warmed when empty
+   * (`count > 0` gate skipped any partial deck). Default `TARGET_BATCH_SIZE`.
+   * B1/F1: callers pass an explicit remainder to top up a partial deck.
+   */
+  target?: number;
 };
 
 const inFlight = new Map<string, Promise<void>>();
@@ -124,29 +133,77 @@ export async function prefetchIfLow({
   }
 
   const p = (async () => {
-    try {
-      const r = await fetchCardBatch({
-        categoryKey,
-        categoryId,
-        language,
-        scope,
-        authContext,
-      });
-      if (r && !r.isError && r.images?.length) {
-        // T2.6 defense-in-depth: normalize before append (aligns with T1.9).
-        const cards = normalizeListIds(r.images);
-        await appendCardBatch({
-          cards,
+    let appendedCount = 0;
+
+    // F1/B1: consult C1's exhausted-category cache before the category fetch.
+    // If the category is known-empty (cache hit), skip the round-trip and let
+    // the top-up below fetch the full TARGET_BATCH_SIZE from 'all'. 'all' is
+    // never cached (Tier 3/4 fallback must stay live), so the consult is
+    // guarded on `categoryKey !== 'all'`.
+    let skipCategoryFetch = false;
+    if (categoryKey !== 'all') {
+      try {
+        skipCategoryFetch = await isCategoryExhausted(categoryKey, language, scope);
+      } catch {
+        skipCategoryFetch = false;
+      }
+    }
+
+    if (!skipCategoryFetch) {
+      try {
+        const r = await fetchCardBatch({
           categoryKey,
           categoryId,
           language,
           scope,
+          authContext,
         });
+        if (r && !r.isError && r.images?.length) {
+          // T2.6 defense-in-depth: normalize before append (aligns with T1.9).
+          const cards = normalizeListIds(r.images);
+          await appendCardBatch({
+            cards,
+            categoryKey,
+            categoryId,
+            language,
+            scope,
+          });
+          appendedCount = cards.length;
+        } else if (
+          r &&
+          !r.isError &&
+          Array.isArray(r.images) &&
+          r.images.length === 0 &&
+          categoryKey !== 'all'
+        ) {
+          // F3a/B1: server returned genuine empty (NOT a 5xx isError — a
+          // transient server blip MUST NOT poison the cache; mirror C1's CC4
+          // defensive pin at nextCardAdvancer.ts:142-158). Paired-write note
+          // (CC1): utils/nextCardAdvancer.ts#foregroundTopUp writes the SAME
+          // cache with a DIFFERENT guard (`pictureIdOverride !== null &&
+          // categoryKey !== 'all'` — Tier-4 head path excluded so newly-
+          // uploaded images surface). The prefetcher has no pictureIdOverride
+          // context (it never runs on the Tier-4 head path), so its guard is
+          // `categoryKey !== 'all'` only. Both sites use the SAME helper;
+          // first-wins is defense-in-depth. Keep this comment in sync with
+          // nextCardAdvancer.ts:144-156.
+          await markCategoryExhausted(categoryKey, language, scope).catch(() => {});
+        }
+      } catch (e) {
+        if (__DEV__) {
+          console.warn('[cardPrefetcher] prefetch failed', dk, e);
+        }
       }
-    } catch (e) {
-      if (__DEV__) {
-        console.warn('[cardPrefetcher] prefetch failed', dk, e);
-      }
+    }
+
+    // F1/B1: deck-level top-up. When the total deck `(count + appendedCount)`
+    // is still below TARGET_BATCH_SIZE AND we are not already on the 'all'
+    // deck, fill the remainder from 'all' in the same cycle. The resolver
+    // merges category + 'all' decks at read time. Replaces the old
+    // side-effect gated on `count < ALL_WARM_THRESHOLD`.
+    if (categoryKey !== 'all' && count + appendedCount < TARGET_BATCH_SIZE) {
+      const target = TARGET_BATCH_SIZE - (count + appendedCount);
+      warmAllDeckIfNeeded({ language, scope, authContext, target });
     }
   })();
 
@@ -157,10 +214,6 @@ export async function prefetchIfLow({
     }
   });
 
-  if (categoryKey !== 'all' && count < ALL_WARM_THRESHOLD) {
-    warmAllDeckIfNeeded({ language, scope, authContext });
-  }
-
   return p;
 }
 
@@ -168,12 +221,19 @@ export async function prefetchIfLow({
  * Warm the 'all' deck in the background. Concurrent callers share the in-flight
  * promise, and callers re-check the persisted 'all' deck on each attempt so a
  * drained fallback deck can be warmed again later in the session.
+ *
+ * B1/F1: contract broadened — fills the 'all' deck until it has ≥ `target`
+ * cards (default `TARGET_BATCH_SIZE`). The previous `count > 0` early-return
+ * skipped warming whenever the deck had ANY cards, so a partial 'all' deck
+ * (e.g. 2 cards) never got topped up to 5. The retuned `count >= target` gate
+ * is the actual F1 fix. Name retained to minimize churn.
  */
 export async function warmAllDeckIfNeeded({
   language,
   scope,
   authContext,
   currentListId,
+  target = TARGET_BATCH_SIZE,
 }: WarmAllParams): Promise<void> {
   if (isE2EMode()) {
     return;
@@ -191,7 +251,7 @@ export async function warmAllDeckIfNeeded({
     currentListId,
     scope,
   });
-  if (count > 0) {
+  if (count >= target) {
     return;
   }
 

--- a/services/groups/groupFeedCache.js
+++ b/services/groups/groupFeedCache.js
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { File, Paths } from 'expo-file-system';
 
 const PREFIX = 'groupFeed';
+const EXHAUSTED_PREFIX = 'groupFeedExhausted';
 
 function groupFeedListKey(groupId, categoryKey, language) {
   return `${PREFIX}:${groupId}:${categoryKey || 'all'}:${language || 'any'}`;
@@ -11,7 +12,11 @@ function groupFeedCursorKey(groupId, categoryKey, language) {
   return `${groupFeedListKey(groupId, categoryKey, language)}:cursor`;
 }
 
-export { groupFeedListKey, groupFeedCursorKey };
+function groupFeedExhaustedKey(groupId, categoryKey, language) {
+  return `${EXHAUSTED_PREFIX}:${groupId}:${categoryKey || 'all'}:${language || 'any'}`;
+}
+
+export { groupFeedListKey, groupFeedCursorKey, groupFeedExhaustedKey };
 
 function localFileExists(uri) {
   try {
@@ -103,6 +108,27 @@ export async function clearAllGroupFeedCaches() {
   }
 }
 
+export async function markGroupCategoryExhausted(groupId, categoryKey, language) {
+  await AsyncStorage.setItem(groupFeedExhaustedKey(groupId, categoryKey, language), '1');
+}
+
+export async function isGroupCategoryExhausted(groupId, categoryKey, language) {
+  return (await AsyncStorage.getItem(groupFeedExhaustedKey(groupId, categoryKey, language))) === '1';
+}
+
+export async function clearGroupCategoryExhausted(groupId, categoryKey, language) {
+  await AsyncStorage.removeItem(groupFeedExhaustedKey(groupId, categoryKey, language));
+}
+
+export async function clearAllGroupFeedExhaustedMarkers() {
+  const keys = await AsyncStorage.getAllKeys();
+  const target = keys.filter((key) => typeof key === 'string' && key.startsWith(`${EXHAUSTED_PREFIX}:`));
+
+  if (target.length > 0) {
+    await AsyncStorage.multiRemove(target);
+  }
+}
+
 // Private group feed images are written under Paths.cache with a `private-`
 // basename prefix (see services/groups/groupFeedApi.js extractBase64) so the
 // purge below can target them without touching public cache files written by
@@ -123,6 +149,7 @@ function isPrivateCacheUri(uri) {
 
 export async function purgeAllPrivateCaches() {
   await clearAllGroupFeedCaches();
+  await clearAllGroupFeedExhaustedMarkers();
 
   try {
     Paths.cache.create({ idempotent: true, intermediates: true });

--- a/utils/handleGuessOutcome.js
+++ b/utils/handleGuessOutcome.js
@@ -43,7 +43,7 @@ export async function applySuccessSideEffects({ listId, categoryKey, language, i
  * mutation. Returns null if no next card is available.
  *
  * @param {object} args - { category, language, currentListId, isTutorial, scope, currentPictureId }
- * @returns {Promise<{params: object}|null>}
+ * @returns {Promise<{params: Object<string, *>}|null>}
  */
 export async function resolveNextGuessParams({ category, language, currentListId, isTutorial, scope, currentPictureId }) {
   const result = await resolveNextCard({ category, language, currentListId, scope, currentPictureId });

--- a/utils/nextCardAdvancer.ts
+++ b/utils/nextCardAdvancer.ts
@@ -16,6 +16,7 @@
 import { resolveNextGuessParams } from './handleGuessOutcome';
 import { fetchCardBatch, appendCardBatch } from '../services/cardDeck';
 import { warmAllDeckIfNeeded, getInFlightPrefetch, getPrefetchScopeKey } from '../services/cardPrefetcher';
+import { isCategoryExhausted, markCategoryExhausted } from './storageDatum';
 
 export type NextGuessResult = { params: Record<string, unknown> } | null | undefined;
 
@@ -77,6 +78,13 @@ async function foregroundTopUp(
   categoryKey: string,
   pictureIdOverride?: string | null,
 ): Promise<ForegroundTopUpResult> {
+  // Tier 4 (looping replay) passes pictureIdOverride: null to reset the cursor
+  // to head. The exhausted-category cache is meaningless there — newly-uploaded
+  // cards must surface — so gate every cache interaction on !isHeadReplay.
+  // Tier 2 passes pictureIdOverride: undefined; the local distinguishes null
+  // (head replay) from undefined (cursor advance).
+  const isHeadReplay = pictureIdOverride === null;
+
   // PB4 (T2.7) Option A: consult the prefetcher's in-flight dedup WITHOUT
   // triggering a new prefetch. The scopeKey derivation must match
   // `prefetchIfLow`'s internal `dedupKey` (shared via `getPrefetchScopeKey`).
@@ -92,6 +100,15 @@ async function foregroundTopUp(
     // source of truth for "do we have cards?" via the post-fetch resolve the
     // caller already performs.
     await inFlight.catch(() => {});
+  }
+
+  // F3a: short-circuit exhausted non-'all' categories before issuing a server
+  // round-trip. Only the cursor-based Tier 2 path (no head replay) and only a
+  // real category (the 'all' deck is the Tier 3/4 fallback and must stay live
+  // so newly-uploaded images surface). On hit, returns 'empty' so control
+  // flows straight to the Tier 3 'all' cross-fallback below.
+  if (!isHeadReplay && categoryKey !== 'all' && await isCategoryExhausted(categoryKey, args.language, args.scope)) {
+    return { ok: false, reason: 'empty' };
   }
 
   // PB4 (T2.7): Tier 2 short-circuit. After the prefetch-await, re-check the
@@ -123,7 +140,22 @@ async function foregroundTopUp(
       ...(pictureIdOverride !== undefined ? { pictureIdOverride } : {}),
     });
     if (!r || r.isError === true) return { ok: false, reason: 'server' };
-    if (!r.images || r.images.length === 0) return { ok: false, reason: 'empty' };
+    if (!r.images || r.images.length === 0) {
+      // F3a: cache the empty result so subsequent advances short-circuit at
+      // Tier 2 with zero server round-trips. ONLY the genuine-empty branch
+      // writes — the 5xx branch above MUST NOT poison the cache (a transient
+      // server blip must not permanently mark a category exhausted). 'all' and
+      // Tier-4 head-replay paths are excluded so newly-uploaded cards surface.
+      // Paired-write note (CC1): services/cardPrefetcher.ts (B1) writes the
+      // SAME cache with a DIFFERENT guard (categoryKey !== 'all' only — the
+      // prefetcher has no pictureIdOverride context and never runs on the
+      // Tier-4 head path). Both sites use the SAME helper; first-wins is
+      // defense-in-depth. Keep this comment in sync with the prefetcher site.
+      if (!isHeadReplay && categoryKey !== 'all') {
+        await markCategoryExhausted(categoryKey, args.language, args.scope).catch(() => {});
+      }
+      return { ok: false, reason: 'empty' };
+    }
     await appendCardBatch({
       cards: r.images,
       categoryKey,

--- a/utils/storageDatum.d.ts
+++ b/utils/storageDatum.d.ts
@@ -47,3 +47,10 @@ export function getNextImagesForScope(args?: NextImagesForScopeArgs): Promise<Ca
 export function getOnboardingCompleted(): Promise<boolean>;
 export function getSessionLanguageFilter(): Promise<string | null>;
 export function saveSessionLanguageFilter(code: string | null): Promise<null>;
+
+// F3a exhausted-category cache (scope-aware: PUBLIC → AsyncStorage, PRIVATE →
+// group feed cache namespace via services/groups/groupFeedCache).
+export function exhaustedCategoryKey(categoryKey: string | null | undefined, language?: string | null): string;
+export function markCategoryExhausted(categoryKey: string | null | undefined, language: string | null | undefined, scope: unknown): Promise<void>;
+export function isCategoryExhausted(categoryKey: string | null | undefined, language: string | null | undefined, scope: unknown): Promise<boolean>;
+export function clearExhaustedCategory(categoryKey: string | null | undefined, language: string | null | undefined, scope: unknown): Promise<void>;

--- a/utils/storageDatum.js
+++ b/utils/storageDatum.js
@@ -1,6 +1,11 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { File, Paths } from "expo-file-system";
-import { readGroupFeedCache } from "../services/groups/groupFeedCache";
+import {
+  readGroupFeedCache,
+  markGroupCategoryExhausted,
+  isGroupCategoryExhausted,
+  clearGroupCategoryExhausted,
+} from "../services/groups/groupFeedCache";
 
 const E2E_HIDDEN_GUESS_CARD_KEY = 'e2eHiddenGuessCard';
 const SESSION_LANGUAGE_FILTER_KEY = 'sessionLanguageFilter';
@@ -16,6 +21,54 @@ function imageListKey(categoryKey, language) {
 
 function lastImageUuidKey(categoryKey, language) {
   return `lastImageUuid:${categoryKey || 'all'}:${language || 'any'}`;
+};
+
+export function exhaustedCategoryKey(categoryKey, language) {
+  return `exhaustedCategory:${categoryKey || 'all'}:${language || 'any'}`;
+};
+
+function isPrivateScope(scope) {
+  return scope?.kind === 'private' && scope?.groupId;
+}
+
+/**
+ * Mark (categoryKey, language) as server-exhausted for `scope`. PUBLIC scope
+ * writes AsyncStorage; PRIVATE scope writes a per-group marker (isolation:
+ * group A exhausting category X MUST NOT mark X for group B).
+ * @param {string} categoryKey - Category key ('all' is intentionally NEVER cached by callers).
+ * @param {string} language - Language code ('any' when unset).
+ * @param {{ kind?: string, groupId?: string }|null|undefined} scope
+ * @returns {Promise<void>}
+ */
+export async function markCategoryExhausted(categoryKey, language, scope) {
+  if (isPrivateScope(scope)) {
+    await markGroupCategoryExhausted(scope.groupId, categoryKey, language);
+    return;
+  }
+  await AsyncStorage.setItem(exhaustedCategoryKey(categoryKey, language), '1');
+};
+
+/**
+ * Read the exhausted flag for (categoryKey, language, scope).
+ * @returns {Promise<boolean>}
+ */
+export async function isCategoryExhausted(categoryKey, language, scope) {
+  if (isPrivateScope(scope)) {
+    return isGroupCategoryExhausted(scope.groupId, categoryKey, language);
+  }
+  return (await AsyncStorage.getItem(exhaustedCategoryKey(categoryKey, language))) === '1';
+};
+
+/**
+ * Clear the exhausted flag for (categoryKey, language, scope).
+ * @returns {Promise<void>}
+ */
+export async function clearExhaustedCategory(categoryKey, language, scope) {
+  if (isPrivateScope(scope)) {
+    await clearGroupCategoryExhausted(scope.groupId, categoryKey, language);
+    return;
+  }
+  await AsyncStorage.removeItem(exhaustedCategoryKey(categoryKey, language));
 };
 
 /**
@@ -429,6 +482,7 @@ export async function emptyImageList(categoryKey, language) {
 
   await AsyncStorage.removeItem(listKey);
   await AsyncStorage.removeItem(lastImageUuidKey(categoryKey, language));
+  await AsyncStorage.removeItem(exhaustedCategoryKey(categoryKey, language));
 };
 
 export async function storeImageList(imageList, categoryKey, language) {


### PR DESCRIPTION
This pull request updates and expands the test suites for card prefetching and card advancement logic, focusing on the new deck top-up and category exhaustion features. The key changes include introducing mocks and tests for the category exhaustion cache, updating threshold constants, and adding comprehensive tests for the new deck refill logic.

**Test coverage improvements:**

* Added mocks for `isCategoryExhausted` and `markCategoryExhausted` in both `cardPrefetcher` and `nextCardAdvancer` test suites to simulate and verify category exhaustion cache behavior. [[1]](diffhunk://#diff-4588119da50568505f9df10332506a67be9f8deff8d1d077d0c89c02a6021ea1R8-R18) [[2]](diffhunk://#diff-dce561039e769e826ee9bbbc914b7c9c2e11ca7e1c9124f28607b2e30bdb2040R33-R34) [[3]](diffhunk://#diff-dce561039e769e826ee9bbbc914b7c9c2e11ca7e1c9124f28607b2e30bdb2040L49-R51) [[4]](diffhunk://#diff-dce561039e769e826ee9bbbc914b7c9c2e11ca7e1c9124f28607b2e30bdb2040R65-R76) [[5]](diffhunk://#diff-dce561039e769e826ee9bbbc914b7c9c2e11ca7e1c9124f28607b2e30bdb2040R101-R103)
* Updated and added tests to cover the new deck refill logic, including:
  - Ensuring prefetch triggers at the correct boundary (`LOW_CARD_THRESHOLD` now 4, with refill at ≤3 remaining) and uses a single source of truth for batch size (`TARGET_BATCH_SIZE` now 5).
  - Verifying that the "all" deck is topped up only when below `TARGET_BATCH_SIZE` and not when already at or above the target. [[1]](diffhunk://#diff-4588119da50568505f9df10332506a67be9f8deff8d1d077d0c89c02a6021ea1L136-R153) [[2]](diffhunk://#diff-4588119da50568505f9df10332506a67be9f8deff8d1d077d0c89c02a6021ea1L157-R177) [[3]](diffhunk://#diff-4588119da50568505f9df10332506a67be9f8deff8d1d077d0c89c02a6021ea1L343-R367)
  - Testing category exhaustion logic: skipping fetches for known-exhausted categories and marking categories as exhausted only on empty (not error) responses.

**Test infrastructure and utility changes:**

* Improved AsyncStorage mocking for better type safety and to ensure test reliability. [[1]](diffhunk://#diff-dce561039e769e826ee9bbbc914b7c9c2e11ca7e1c9124f28607b2e30bdb2040R65-R76) [[2]](diffhunk://#diff-dce561039e769e826ee9bbbc914b7c9c2e11ca7e1c9124f28607b2e30bdb2040L436-R453) [[3]](diffhunk://#diff-dce561039e769e826ee9bbbc914b7c9c2e11ca7e1c9124f28607b2e30bdb2040L449-R467)
* Minor fixes to mock implementations for consistency and to match updated code expectations.

These changes ensure that the new deck top-up and exhaustion logic are thoroughly tested and that test infrastructure is robust and type-safe.