### PR TITLE
Fix/guess bugs ux

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,9 @@
 - Shared style tokens live in `constants/theme.js`.
 - Native folders `android/` and `ios/` are part of this repo, but avoid touching generated build output under them unless task requires it.
 - `postinstall` runs `patch-package`; current checked-in patch covers `react-native-google-mobile-ads`.
+- Public guess category catalog is bundled in `constants/defaultCategories.js` (`getDefaultCategories()`, keyed by `key`, no server UUID); `utils/categoryRequests.js` `getCategories()` never hits the network (E2E mode returns its own stub). Thumbnails resolve from `utils/categoryAssets.js`.
+- Private group categories are offline-cached stale-while-revalidate: `services/groups/groupCategoryCache.js` (AsyncStorage `groupCategories:<groupId>`) + `services/groups/groupCategoriesStore.js` (`loadGroupCategoriesOptimistic` renders cache then revalidates, replacing only on `categoryListSignature` diff; `refreshGroupCategories` writes through after owner CRUD). They keep using their UUID `category_id`; `key` is faked as `id` for display.
+- Server image calls split by scope: public feed/upload/prefetch filter/assign by `category_key` (bundled string), private by `category_id` (UUID).
 
 ## Work Guidance
 

--- a/__tests__/EnigmaOverlay.test.js
+++ b/__tests__/EnigmaOverlay.test.js
@@ -1,5 +1,3 @@
-let mockCapturedPanResponders;
-
 jest.mock('react-native', () => {
   const React = require('react');
 
@@ -7,7 +5,6 @@ jest.mock('react-native', () => {
     constructor(value) {
       this._value = value;
     }
-
     setValue = (nextValue) => {
       this._value = nextValue;
     };
@@ -29,12 +26,6 @@ jest.mock('react-native', () => {
       Value: MockAnimatedValue,
       timing: jest.fn((value, config) => buildAnimation(value, config)),
       View: ({ children, ...props }) => React.createElement('AnimatedView', props, children),
-    },
-    PanResponder: {
-      create: jest.fn((config) => {
-        mockCapturedPanResponders.push(config);
-        return { panHandlers: {} };
-      }),
     },
     Pressable: ({ children, ...props }) => React.createElement('Pressable', props, children),
     StyleSheet: {
@@ -62,23 +53,10 @@ import EnigmaOverlay from '../components/Picture/Descriptions/EnigmaOverlay';
 const DESCRIPTION = 'Solve the riddle to find the spot';
 const SCREEN_HEIGHT = 640;
 
-function handlePanResponder() {
-  return mockCapturedPanResponders[0];
-}
-
-function dismissPanResponder() {
-  return mockCapturedPanResponders[1];
-}
-
-describe('EnigmaOverlay', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockCapturedPanResponders = [];
-  });
-
-  async function renderOverlay(props = {}) {
+describe('EnigmaOverlay (controlled)', () => {
+  function renderOverlay(props = {}) {
     let renderer;
-    await act(async () => {
+    act(() => {
       renderer = create(
         <EnigmaOverlay
           description={DESCRIPTION}
@@ -90,144 +68,68 @@ describe('EnigmaOverlay', () => {
     return renderer;
   }
 
-  it('renders the enigma text in the open panel', async () => {
-    const renderer = await renderOverlay({ defaultOpen: true });
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the panel + scrim + description text when isOpen=true', () => {
+    const renderer = renderOverlay({ isOpen: true });
 
     expect(renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toBeTruthy();
-    expect(renderer.root.findByProps({ testID: 'guess.enigma.text' }).props.children).toBe(DESCRIPTION);
-  });
-
-  it('shows "No description" when the description is empty', async () => {
-    const renderer = await renderOverlay({ description: '', defaultOpen: true });
-
-    expect(renderer.root.findByProps({ testID: 'guess.enigma.text' }).props.children).toBe('No description');
-  });
-
-  it('starts closed when defaultOpen is falsy (panel absent, handle present)', async () => {
-    const renderer = await renderOverlay();
-
-    expect(renderer.root.findByProps({ testID: 'guess.enigma.handle' })).toBeTruthy();
-    expect(() => renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toThrow();
-  });
-
-  it('starts open when defaultOpen is true and shows the description', async () => {
-    const renderer = await renderOverlay({ defaultOpen: true });
-
-    expect(renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toBeTruthy();
-    expect(renderer.root.findByProps({ testID: 'guess.enigma.text' }).props.children).toBe(DESCRIPTION);
-  });
-
-  it('opens when defaultOpen flips from false to true on an existing instance', async () => {
-    const renderer = await renderOverlay({ defaultOpen: false });
-
-    expect(() => renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toThrow();
-
-    await act(async () => {
-      renderer.update(
-        <EnigmaOverlay
-          description={DESCRIPTION}
-          screenHeight={SCREEN_HEIGHT}
-          defaultOpen={true}
-        />
-      );
-    });
-
-    expect(renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toBeTruthy();
-    expect(renderer.root.findByProps({ testID: 'guess.enigma.text' }).props.children).toBe(DESCRIPTION);
-  });
-
-  it('opens when the handle sees an up-swipe', async () => {
-    const renderer = await renderOverlay();
-
-    await act(async () => {
-      handlePanResponder().onPanResponderRelease(null, { dx: 0, dy: -60 });
-    });
-
-    expect(renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toBeTruthy();
-  });
-
-  it('does NOT open on a horizontal swipe', async () => {
-    const renderer = await renderOverlay();
-
-    await act(async () => {
-      handlePanResponder().onPanResponderRelease(null, { dx: 80, dy: -10 });
-    });
-
-    expect(() => renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toThrow();
-  });
-
-  it('does NOT open on a tap', async () => {
-    const renderer = await renderOverlay();
-
-    await act(async () => {
-      handlePanResponder().onPanResponderRelease(null, { dx: 2, dy: -2 });
-    });
-
-    expect(() => renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toThrow();
-  });
-
-  it('closes when the close button is pressed', async () => {
-    const renderer = await renderOverlay({ defaultOpen: true });
-
-    await act(async () => {
-      renderer.root.findByProps({ testID: 'guess.enigma.close' }).props.onPress();
-    });
-
-    expect(() => renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toThrow();
-  });
-
-  it('closes when the panel/scrim sees a down-swipe', async () => {
-    const renderer = await renderOverlay({ defaultOpen: true });
-
-    await act(async () => {
-      dismissPanResponder().onPanResponderRelease(null, { dx: 0, dy: 60 });
-    });
-
-    expect(() => renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toThrow();
-  });
-
-  it('renders open by default when defaultOpen=true and exposes the scrim', async () => {
-    const renderer = await renderOverlay({ defaultOpen: true });
-
     expect(renderer.root.findByProps({ testID: 'guess.enigma.scrim' })).toBeTruthy();
+    expect(
+      renderer.root.findByProps({ testID: 'guess.enigma.text' }).props.children
+    ).toBe(DESCRIPTION);
   });
 
-  it('calls onClose when the panel is dismissed via the scrim', async () => {
-    const onClose = jest.fn();
-    const renderer = await renderOverlay({ defaultOpen: true, onClose });
+  it('shows "No description" when description is empty', () => {
+    const renderer = renderOverlay({ description: '', isOpen: true });
 
-    await act(async () => {
+    expect(
+      renderer.root.findByProps({ testID: 'guess.enigma.text' }).props.children
+    ).toBe('No description');
+  });
+
+  it('renders nothing (no panel, no scrim) when isOpen=false', () => {
+    const renderer = renderOverlay({ isOpen: false });
+
+    expect(() => renderer.root.findByProps({ testID: 'guess.enigma.panel' })).toThrow();
+    expect(() => renderer.root.findByProps({ testID: 'guess.enigma.scrim' })).toThrow();
+  });
+
+  it('does NOT render the legacy handle strip', () => {
+    const renderer = renderOverlay({ isOpen: false });
+    expect(() => renderer.root.findByProps({ testID: 'guess.enigma.handle' })).toThrow();
+  });
+
+  it('calls onClose when the scrim is tapped', () => {
+    const onClose = jest.fn();
+    const renderer = renderOverlay({ isOpen: true, onClose });
+
+    act(() => {
       renderer.root.findByProps({ testID: 'guess.enigma.scrim' }).props.onPress();
     });
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onClose when the close chevron is pressed', async () => {
+  it('calls onClose when the close chevron is pressed', () => {
     const onClose = jest.fn();
-    const renderer = await renderOverlay({ defaultOpen: true, onClose });
+    const renderer = renderOverlay({ isOpen: true, onClose });
 
-    await act(async () => {
+    act(() => {
       renderer.root.findByProps({ testID: 'guess.enigma.close' }).props.onPress();
     });
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('does not call onClose when onClose is not provided (no throw)', async () => {
-    const renderer = await renderOverlay({ defaultOpen: true });
-
-    await expect(
-      act(async () => {
+  it('does not throw when onClose is not provided', () => {
+    const renderer = renderOverlay({ isOpen: true });
+    expect(() => {
+      act(() => {
         renderer.root.findByProps({ testID: 'guess.enigma.scrim' }).props.onPress();
-      })
-    ).resolves.toBeUndefined();
-  });
-
-  it('renders closed (handle only) when defaultOpen=false', async () => {
-    const renderer = await renderOverlay({ defaultOpen: false });
-
-    expect(renderer.root.findByProps({ testID: 'guess.enigma.handle' })).toBeTruthy();
-    expect(() => renderer.root.findByProps({ testID: 'guess.enigma.scrim' })).toThrow();
+      });
+    }).not.toThrow();
   });
 });

--- a/__tests__/GuessExitSwipeMenu.test.js
+++ b/__tests__/GuessExitSwipeMenu.test.js
@@ -1,5 +1,3 @@
-let mockCapturedPanResponders;
-
 jest.mock('react-native', () => {
   const React = require('react');
 
@@ -7,7 +5,6 @@ jest.mock('react-native', () => {
     constructor(value) {
       this._value = value;
     }
-
     setValue = (nextValue) => {
       this._value = nextValue;
     };
@@ -19,7 +16,6 @@ jest.mock('react-native', () => {
         if (typeof config?.toValue !== 'undefined' && value?.setValue) {
           value.setValue(config.toValue);
         }
-
         callback?.();
       },
     };
@@ -40,12 +36,6 @@ jest.mock('react-native', () => {
     Dimensions: {
       get: jest.fn(() => ({ width: 320, height: 640, scale: 1, fontScale: 1 })),
     },
-    PanResponder: {
-      create: jest.fn((config) => {
-        mockCapturedPanResponders.push(config);
-        return { panHandlers: {} };
-      }),
-    },
     Pressable: ({ children, ...props }) => React.createElement('Pressable', props, children),
     StyleSheet: {
       absoluteFill: {},
@@ -57,159 +47,119 @@ jest.mock('react-native', () => {
   };
 });
 
+jest.mock('../components/Guess/SwipeHaloHint', () => {
+  const React = require('react');
+  return function MockSwipeHaloHint(props) {
+    return React.createElement('SwipeHaloHint', props);
+  };
+});
+
 import React from 'react';
 import { act, create } from 'react-test-renderer';
 
 import GuessExitSwipeMenu from '../components/Guess/GuessExitSwipeMenu';
 
-function edgePanResponder() {
-  return mockCapturedPanResponders[0];
-}
-
-function scrimPanResponder() {
-  return mockCapturedPanResponders[1];
-}
-
-describe('GuessExitSwipeMenu', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockCapturedPanResponders = [];
-  });
-
-  async function renderMenu(props = {}) {
+describe('GuessExitSwipeMenu (controlled)', () => {
+  function renderMenu(props = {}) {
     let renderer;
-
-    await act(async () => {
-      renderer = create(<GuessExitSwipeMenu onHome={jest.fn()} {...props} />);
+    act(() => {
+      renderer = create(
+        <GuessExitSwipeMenu
+          onHome={jest.fn()}
+          onClose={jest.fn()}
+          {...props}
+        />
+      );
     });
-
     return renderer;
   }
 
-  function openViaEdgeSwipe() {
-    edgePanResponder().onPanResponderRelease(null, { x0: 20, dx: 50, dy: 0 });
-  }
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
-  it('hides the panel and Home button by default', async () => {
-    const renderer = await renderMenu();
+  it('hides the panel, scrim, close, and Home when isOpen=false', () => {
+    const renderer = renderMenu({ isOpen: false });
 
-    expect(renderer.root.findByProps({ testID: 'guess.exit.edge' })).toBeTruthy();
     expect(() => renderer.root.findByProps({ testID: 'guess.exit.panel' })).toThrow();
+    expect(() => renderer.root.findByProps({ testID: 'guess.exit.scrim' })).toThrow();
+    expect(() => renderer.root.findByProps({ testID: 'guess.exit.close' })).toThrow();
     expect(() => renderer.root.findByProps({ testID: 'guess.exit.home' })).toThrow();
   });
 
-  it('opens the panel on a valid left-edge swipe-right', async () => {
-    const renderer = await renderMenu();
+  it('does NOT render the legacy edge strip', () => {
+    const renderer = renderMenu({ isOpen: false });
+    expect(() => renderer.root.findByProps({ testID: 'guess.exit.edge' })).toThrow();
+  });
 
-    expect(edgePanResponder().onStartShouldSetPanResponder(null, { x0: 20 })).toBe(true);
-
-    await act(async () => {
-      openViaEdgeSwipe();
-    });
+  it('renders scrim + panel + close + Home when isOpen=true', () => {
+    const renderer = renderMenu({ isOpen: true });
 
     expect(renderer.root.findByProps({ testID: 'guess.exit.panel' })).toBeTruthy();
+    expect(renderer.root.findByProps({ testID: 'guess.exit.scrim' })).toBeTruthy();
+    expect(renderer.root.findByProps({ testID: 'guess.exit.close' })).toBeTruthy();
     expect(renderer.root.findByProps({ testID: 'guess.exit.home' })).toBeTruthy();
   });
 
-  it('does not open on a non-edge gesture (x0 > EDGE_WIDTH)', async () => {
-    const renderer = await renderMenu();
+  it('calls onClose when the scrim is tapped', () => {
+    const onClose = jest.fn();
+    const renderer = renderMenu({ isOpen: true, onClose });
 
-    expect(edgePanResponder().onStartShouldSetPanResponder(null, { x0: 50 })).toBe(false);
-    expect(() => renderer.root.findByProps({ testID: 'guess.exit.panel' })).toThrow();
+    act(() => {
+      renderer.root.findByProps({ testID: 'guess.exit.scrim' }).props.onPress();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('does not open on a rightward swipe just under the threshold', async () => {
-    const renderer = await renderMenu();
+  it('calls onClose when the close button is pressed', () => {
+    const onClose = jest.fn();
+    const renderer = renderMenu({ isOpen: true, onClose });
 
-    expect(edgePanResponder().onStartShouldSetPanResponder(null, { x0: 20 })).toBe(true);
-
-    await act(async () => {
-      edgePanResponder().onPanResponderRelease(null, { x0: 20, dx: 39, dy: 0 });
-    });
-
-    expect(() => renderer.root.findByProps({ testID: 'guess.exit.panel' })).toThrow();
-  });
-
-  it('does not open on a mostly-vertical gesture even in the edge zone', async () => {
-    const renderer = await renderMenu();
-
-    expect(edgePanResponder().onStartShouldSetPanResponder(null, { x0: 20 })).toBe(true);
-
-    await act(async () => {
-      edgePanResponder().onPanResponderRelease(null, { x0: 20, dx: 50, dy: 80 });
-    });
-
-    expect(() => renderer.root.findByProps({ testID: 'guess.exit.panel' })).toThrow();
-  });
-
-  it('closes the panel on a swipe-left while open', async () => {
-    const renderer = await renderMenu();
-
-    await act(async () => {
-      openViaEdgeSwipe();
-    });
-
-    await act(async () => {
-      scrimPanResponder().onPanResponderRelease(null, { dx: -50, dy: 0 });
-    });
-
-    expect(() => renderer.root.findByProps({ testID: 'guess.exit.panel' })).toThrow();
-  });
-
-  it('does not close on a leftward swipe just under the close threshold', async () => {
-    const renderer = await renderMenu();
-
-    await act(async () => {
-      openViaEdgeSwipe();
-    });
-
-    await act(async () => {
-      scrimPanResponder().onPanResponderRelease(null, { dx: -39, dy: 0 });
-    });
-
-    expect(renderer.root.findByProps({ testID: 'guess.exit.panel' })).toBeTruthy();
-  });
-
-  it('closes the panel when the scrim is tapped', async () => {
-    const renderer = await renderMenu();
-
-    await act(async () => {
-      openViaEdgeSwipe();
-    });
-
-    await act(async () => {
-      scrimPanResponder().onPanResponderRelease(null, { dx: 0, dy: 0 });
-    });
-
-    expect(() => renderer.root.findByProps({ testID: 'guess.exit.panel' })).toThrow();
-  });
-
-  it('closes the panel when the Close button is pressed', async () => {
-    const renderer = await renderMenu();
-
-    await act(async () => {
-      openViaEdgeSwipe();
-    });
-
-    await act(async () => {
+    act(() => {
       renderer.root.findByProps({ testID: 'guess.exit.close' }).props.onPress();
     });
 
-    expect(() => renderer.root.findByProps({ testID: 'guess.exit.panel' })).toThrow();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onHome exactly once when the Home action is pressed', async () => {
+  it('calls onHome exactly once when the Home button is pressed', () => {
     const onHome = jest.fn();
-    const renderer = await renderMenu({ onHome });
+    const renderer = renderMenu({ isOpen: true, onHome });
 
-    await act(async () => {
-      openViaEdgeSwipe();
-    });
-
-    await act(async () => {
+    act(() => {
       renderer.root.findByProps({ testID: 'guess.exit.home' }).props.onPress();
     });
 
     expect(onHome).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onInteract when isOpen flips to true (hint dismissal)', () => {
+    const onInteract = jest.fn();
+    let renderer;
+    act(() => {
+      renderer = create(
+        <GuessExitSwipeMenu
+          isOpen={false}
+          onHome={jest.fn()}
+          onClose={jest.fn()}
+          onInteract={onInteract}
+        />
+      );
+    });
+    expect(onInteract).not.toHaveBeenCalled();
+
+    act(() => {
+      renderer.update(
+        <GuessExitSwipeMenu
+          isOpen={true}
+          onHome={jest.fn()}
+          onClose={jest.fn()}
+          onInteract={onInteract}
+        />
+      );
+    });
+
+    expect(onInteract).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/GuessPathScreen.test.js
+++ b/__tests__/GuessPathScreen.test.js
@@ -62,10 +62,13 @@ jest.mock('../utils/e2eMode', () => ({
 }));
 
 jest.mock('../services/groups/groupCategoriesApi', () => ({
-  listGroupCategories: jest.fn(),
   createGroupCategory: jest.fn(),
   updateGroupCategory: jest.fn(),
   deleteGroupCategory: jest.fn(),
+}));
+
+jest.mock('../services/groups/groupCategoriesStore', () => ({
+  loadGroupCategoriesOptimistic: jest.fn(),
 }));
 
 jest.mock('../services/groups/groupCategoryThumbnails', () => ({
@@ -105,9 +108,9 @@ import { isE2EMode } from '../utils/e2eMode';
 import {
   createGroupCategory,
   deleteGroupCategory,
-  listGroupCategories,
   updateGroupCategory,
 } from '../services/groups/groupCategoriesApi';
+import { loadGroupCategoriesOptimistic } from '../services/groups/groupCategoriesStore';
 import {
   resolveCategoryThumbnail,
   deleteCategoryThumbnailFile,
@@ -115,9 +118,16 @@ import {
 import { uploadCategoryThumbnail } from '../services/groups/categoryThumbnailUpload';
 import { fetchGroups } from '../services/groups/groupApi';
 
-const CATEGORIES = [
-  { id: '1', key: 'nature', name: 'Nature', thumbnailUrl: 'x', count: 5 },
-  { id: '2', key: 'city', name: 'City', thumbnailUrl: 'y', count: 3 },
+const BUNDLED_CATEGORY_KEYS = [
+  'other',
+  'nature',
+  'city',
+  'abstract',
+  'animals',
+  'food',
+  'vehicles',
+  'interiors',
+  'landmarks',
 ];
 
 const PRIVATE_THUMBNAIL_CATEGORIES = [
@@ -141,6 +151,14 @@ const PRIVATE_CREATED_CATEGORIES = [
   { id: 'c-new', key: 'c-new', name: 'NewCat' },
 ];
 
+function emitCategoriesViaStore(list) {
+  loadGroupCategoriesOptimistic.mockImplementation(async ({ onCategories }) => {
+    if (typeof onCategories === 'function') {
+      onCategories(list);
+    }
+  });
+}
+
 describe('GuessPathScreen', () => {
   const contextValue = { token: 'Bearer token' };
   const mountedRenderers = [];
@@ -157,8 +175,7 @@ describe('GuessPathScreen', () => {
       fontScale: 1,
     });
     isE2EMode.mockReturnValue(false);
-    getCategories.mockResolvedValue({ data: CATEGORIES });
-    listGroupCategories.mockResolvedValue({ status: 200, data: [] });
+    getCategories.mockResolvedValue({ data: [] });
     createGroupCategory.mockResolvedValue({ status: 201, data: {} });
     updateGroupCategory.mockResolvedValue({ status: 200, data: {} });
     deleteGroupCategory.mockResolvedValue({ status: 204, data: {} });
@@ -170,6 +187,7 @@ describe('GuessPathScreen', () => {
     getSessionLanguageFilter.mockResolvedValue(null);
     saveSessionLanguageFilter.mockResolvedValue(undefined);
     mockUseGroupsHub.mockReturnValue({ data: null, refresh: jest.fn() });
+    emitCategoriesViaStore([]);
     navigation = { navigate: jest.fn(), popToTop: jest.fn(), goBack: jest.fn(), setOptions: jest.fn() };
   });
 
@@ -221,10 +239,13 @@ describe('GuessPathScreen', () => {
   });
 
   function getCardPropsByKey(key) {
-    const call = mockGuessCategoryCard.mock.calls.find(
-      ([props]) => props.category.id === key
-    );
-    return call?.[0];
+    for (let i = mockGuessCategoryCard.mock.calls.length - 1; i >= 0; i -= 1) {
+      const [props] = mockGuessCategoryCard.mock.calls[i];
+      if (props.category.id === key) {
+        return props;
+      }
+    }
+    return undefined;
   }
 
   function getDetailsButtonProps() {
@@ -269,11 +290,17 @@ describe('GuessPathScreen', () => {
     return deleteButton.onPress;
   }
 
-  it('fetches categories on mount with the auth context', async () => {
+  it('renders the bundled default categories on mount without any network call', async () => {
     await renderScreen();
 
-    expect(getCategories).toHaveBeenCalledWith({ context: contextValue });
-    expect(getCategories).toHaveBeenCalledTimes(1);
+    expect(getCategories).not.toHaveBeenCalled();
+    expect(loadGroupCategoriesOptimistic).not.toHaveBeenCalled();
+
+    const renderedKeys = [...new Set(mockGuessCategoryCard.mock.calls.map(
+      ([props]) => props.category.id
+    ))];
+
+    expect(renderedKeys).toEqual(['all', ...BUNDLED_CATEGORY_KEYS]);
   });
 
   it('reads the persisted session language filter on mount', async () => {
@@ -293,16 +320,6 @@ describe('GuessPathScreen', () => {
     expect(mockGuessCategoryCard.mock.calls[0][0].category).toEqual(
       expect.objectContaining({ id: 'all', key: 'all', name: 'Recent/All' })
     );
-  });
-
-  it('renders one GuessCategoryCard per category returned by the api', async () => {
-    await renderScreen();
-
-    const renderedKeys = [...new Set(mockGuessCategoryCard.mock.calls.map(
-      ([props]) => props.category.id
-    ))];
-
-    expect(renderedKeys).toEqual(['all', 'nature', 'city']);
   });
 
   it('passes the grid testID and slug-based card testIDs to the flat list', async () => {
@@ -362,10 +379,7 @@ describe('GuessPathScreen', () => {
       },
       refresh: jest.fn(),
     });
-    listGroupCategories.mockResolvedValue({
-      status: 200,
-      data: [{ id: 'c-1', key: 'c-1', name: 'Cats' }],
-    });
+    emitCategoriesViaStore([{ id: 'c-1', key: 'c-1', name: 'Cats' }]);
 
     await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
@@ -385,10 +399,7 @@ describe('GuessPathScreen', () => {
 
   it('fetches groups on press when private hub data is still missing and then threads the active-group snapshot', async () => {
     mockUseGroupsHub.mockReturnValue({ data: null, refresh: jest.fn() });
-    listGroupCategories.mockResolvedValue({
-      status: 200,
-      data: [{ id: 'c-1', key: 'c-1', name: 'Cats' }],
-    });
+    emitCategoriesViaStore([{ id: 'c-1', key: 'c-1', name: 'Cats' }]);
     fetchGroups.mockResolvedValue({
       status: 200,
       data: {
@@ -412,6 +423,58 @@ describe('GuessPathScreen', () => {
       scope: { kind: 'private', groupId: 'g-1' },
       activeGroup: { isOwnedByViewer: true, memberCount: 7 },
     });
+  });
+
+  it('renders private categories optimistically via the store onCategories callback', async () => {
+    const cachedCategories = [
+      { id: 'c-cached', key: 'c-cached', name: 'Cached' },
+    ];
+    emitCategoriesViaStore(cachedCategories);
+
+    await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    expect(loadGroupCategoriesOptimistic).toHaveBeenCalledWith(expect.objectContaining({
+      context: contextValue,
+      groupId: 'g-1',
+      onCategories: expect.any(Function),
+    }));
+
+    const renderedIds = mockGuessCategoryCard.mock.calls.map(
+      ([props]) => props.category.id
+    );
+    expect(renderedIds).toContain('c-cached');
+  });
+
+  it('replaces the optimistic list with the revalidated fresh list from the store', async () => {
+    const freshCategories = [
+      { id: 'c-fresh', key: 'c-fresh', name: 'Fresh' },
+    ];
+    let onCategoriesRef = null;
+    loadGroupCategoriesOptimistic.mockImplementation(async ({ onCategories }) => {
+      onCategoriesRef = onCategories;
+      if (typeof onCategories === 'function') {
+        onCategories([{ id: 'c-cached', key: 'c-cached', name: 'Cached' }]);
+      }
+    });
+
+    await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    expect(mockGuessCategoryCard.mock.calls.some(
+      ([props]) => props.category.id === 'c-cached'
+    )).toBe(true);
+
+    const callsBeforeFresh = mockGuessCategoryCard.mock.calls.length;
+
+    await act(async () => {
+      onCategoriesRef(freshCategories);
+      await flushEffects();
+    });
+
+    const callsAfterFresh = mockGuessCategoryCard.mock.calls.slice(callsBeforeFresh);
+    const renderedIdsAfterFresh = callsAfterFresh.map(([props]) => props.category.id);
+
+    expect(renderedIdsAfterFresh).toContain('c-fresh');
+    expect(renderedIdsAfterFresh).not.toContain('c-cached');
   });
 
   it('shows the resolved language sentinel (en) while AsyncStorage has not resolved', async () => {
@@ -468,6 +531,7 @@ describe('GuessPathScreen', () => {
 
   it('keeps the e2e home button available on the category screen', async () => {
     isE2EMode.mockReturnValue(true);
+    getCategories.mockResolvedValue({ data: [] });
 
     const renderer = await renderScreen();
 
@@ -519,9 +583,13 @@ describe('GuessPathScreen', () => {
       data: { owned: [{ id: 'g-1', role: 'owner' }] },
       refresh: jest.fn(),
     });
-    listGroupCategories
-      .mockResolvedValueOnce({ status: 200, data: [] })
-      .mockResolvedValue({ status: 200, data: PRIVATE_CREATED_CATEGORIES });
+    loadGroupCategoriesOptimistic
+      .mockImplementationOnce(async ({ onCategories }) => {
+        if (typeof onCategories === 'function') onCategories([]);
+      })
+      .mockImplementation(async ({ onCategories }) => {
+        if (typeof onCategories === 'function') onCategories(PRIVATE_CREATED_CATEGORIES);
+      });
 
     const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
@@ -558,8 +626,12 @@ describe('GuessPathScreen', () => {
       'g-1',
       { name: 'NewCat' }
     );
-    expect(listGroupCategories).toHaveBeenCalledTimes(2);
-    expect(listGroupCategories).toHaveBeenLastCalledWith(contextValue, 'g-1');
+    expect(loadGroupCategoriesOptimistic).toHaveBeenCalledTimes(2);
+    expect(loadGroupCategoriesOptimistic).toHaveBeenLastCalledWith(expect.objectContaining({
+      context: contextValue,
+      groupId: 'g-1',
+      onCategories: expect.any(Function),
+    }));
 
     const renderedKeys = mockGuessCategoryCard.mock.calls.map(
       ([props]) => props.category.id
@@ -568,10 +640,7 @@ describe('GuessPathScreen', () => {
   });
 
   it('prefers resolved local private thumbnail uris and falls back to presigned urls', async () => {
-    listGroupCategories.mockResolvedValue({
-      status: 200,
-      data: PRIVATE_THUMBNAIL_CATEGORIES,
-    });
+    emitCategoriesViaStore(PRIVATE_THUMBNAIL_CATEGORIES);
     resolveCategoryThumbnail
       .mockResolvedValueOnce('file:///cache/private-thumb-g-1-thumb-1.webp')
       .mockResolvedValueOnce(null);
@@ -616,22 +685,27 @@ describe('GuessPathScreen', () => {
     };
     let serverCategories = [initialCategory];
 
-    listGroupCategories.mockImplementation(async () => ({
-      status: 200,
-      data: serverCategories,
-    }));
+    loadGroupCategoriesOptimistic.mockImplementation(async ({ onCategories }) => {
+      if (typeof onCategories === 'function') {
+        onCategories(serverCategories);
+      }
+    });
 
     await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
-    expect(listGroupCategories).toHaveBeenCalledTimes(1);
+    expect(loadGroupCategoriesOptimistic).toHaveBeenCalledTimes(1);
     expect(getCardPropsByKey('c-2')).toBeUndefined();
 
     serverCategories = [initialCategory, newServerCategory];
 
     await triggerFocusEffects();
 
-    expect(listGroupCategories).toHaveBeenCalledTimes(2);
-    expect(listGroupCategories).toHaveBeenLastCalledWith(contextValue, 'g-1');
+    expect(loadGroupCategoriesOptimistic).toHaveBeenCalledTimes(2);
+    expect(loadGroupCategoriesOptimistic).toHaveBeenLastCalledWith(expect.objectContaining({
+      context: contextValue,
+      groupId: 'g-1',
+      onCategories: expect.any(Function),
+    }));
     expect(getCardPropsByKey('c-2')).toEqual(
       expect.objectContaining({
         category: expect.objectContaining({ id: 'c-2', name: 'Dogs' }),
@@ -675,9 +749,13 @@ describe('GuessPathScreen', () => {
       refresh: jest.fn(),
     });
     uploadCategoryThumbnail.mockResolvedValue({ imageId: 'img-7' });
-    listGroupCategories
-      .mockResolvedValueOnce({ status: 200, data: [] })
-      .mockResolvedValue({ status: 200, data: PRIVATE_CREATED_CATEGORIES });
+    loadGroupCategoriesOptimistic
+      .mockImplementationOnce(async ({ onCategories }) => {
+        if (typeof onCategories === 'function') onCategories([]);
+      })
+      .mockImplementation(async ({ onCategories }) => {
+        if (typeof onCategories === 'function') onCategories(PRIVATE_CREATED_CATEGORIES);
+      });
 
     const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
@@ -725,7 +803,7 @@ describe('GuessPathScreen', () => {
       thumbnail_image_id: 'old-thumb',
       thumbnail_url: 'https://example.com/old.webp',
     };
-    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    emitCategoriesViaStore([category]);
     resolveCategoryThumbnail.mockResolvedValue('file:///cache/old.webp');
     uploadCategoryThumbnail.mockResolvedValue({ imageId: 'img-new' });
     updateGroupCategory.mockResolvedValue({ status: 200, data: {} });
@@ -762,7 +840,7 @@ describe('GuessPathScreen', () => {
       thumbnailImageId: 'img-new',
     });
     // reloadCategories fired after successful swap.
-    expect(listGroupCategories).toHaveBeenCalledTimes(2);
+    expect(loadGroupCategoriesOptimistic).toHaveBeenCalledTimes(2);
   });
 
   it('does not render the pencil edit affordance for non-owner members', async () => {
@@ -774,7 +852,7 @@ describe('GuessPathScreen', () => {
       refresh: jest.fn(),
     });
     const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
-    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    emitCategoriesViaStore([category]);
 
     const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
@@ -790,7 +868,7 @@ describe('GuessPathScreen', () => {
       refresh: jest.fn(),
     });
     const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
-    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    emitCategoriesViaStore([category]);
 
     const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
@@ -811,7 +889,7 @@ describe('GuessPathScreen', () => {
       refresh: jest.fn(),
     });
     const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
-    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    emitCategoriesViaStore([category]);
 
     const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
@@ -849,7 +927,7 @@ describe('GuessPathScreen', () => {
       refresh: jest.fn(),
     });
     const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
-    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    emitCategoriesViaStore([category]);
 
     const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
@@ -878,9 +956,13 @@ describe('GuessPathScreen', () => {
       name: 'Cats',
       thumbnail_image_id: 'thumb-1',
     };
-    listGroupCategories
-      .mockResolvedValueOnce({ status: 200, data: [category] })
-      .mockResolvedValue({ status: 200, data: [] });
+    loadGroupCategoriesOptimistic
+      .mockImplementationOnce(async ({ onCategories }) => {
+        if (typeof onCategories === 'function') onCategories([category]);
+      })
+      .mockImplementation(async ({ onCategories }) => {
+        if (typeof onCategories === 'function') onCategories([]);
+      });
     deleteGroupCategory.mockResolvedValue({ status: 204, data: {} });
 
     const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
@@ -911,7 +993,7 @@ describe('GuessPathScreen', () => {
 
     expect(deleteGroupCategory).toHaveBeenCalledWith(contextValue, 'g-1', 'c-1');
     expect(deleteCategoryThumbnailFile).toHaveBeenCalledWith('g-1', 'thumb-1');
-    expect(listGroupCategories).toHaveBeenCalledTimes(2);
+    expect(loadGroupCategoriesOptimistic).toHaveBeenCalledTimes(2);
   });
 
   it('delete error branch: reload NOT called and Alert error path triggered', async () => {
@@ -920,12 +1002,12 @@ describe('GuessPathScreen', () => {
       refresh: jest.fn(),
     });
     const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
-    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    emitCategoriesViaStore([category]);
     deleteGroupCategory.mockResolvedValue({ status: 500, data: {} });
 
     const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
-    const initialCalls = listGroupCategories.mock.calls.length;
+    const initialCalls = loadGroupCategoriesOptimistic.mock.calls.length;
 
     await act(async () => {
       getManageButtonProps().onPress();
@@ -952,7 +1034,7 @@ describe('GuessPathScreen', () => {
     });
 
     expect(deleteGroupCategory).toHaveBeenCalledWith(contextValue, 'g-1', 'c-1');
-    expect(listGroupCategories).toHaveBeenCalledTimes(initialCalls);
+    expect(loadGroupCategoriesOptimistic).toHaveBeenCalledTimes(initialCalls);
     expect(Alert.alert).toHaveBeenLastCalledWith(
       'Error 500',
       'Could not delete category.'
@@ -968,7 +1050,7 @@ describe('GuessPathScreen', () => {
       refresh: jest.fn(),
     });
     const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
-    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    emitCategoriesViaStore([category]);
 
     await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
@@ -983,7 +1065,7 @@ describe('GuessPathScreen', () => {
       refresh: jest.fn(),
     });
     const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
-    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    emitCategoriesViaStore([category]);
 
     const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
@@ -1025,7 +1107,7 @@ describe('GuessPathScreen', () => {
       refresh: jest.fn(),
     });
     const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
-    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    emitCategoriesViaStore([category]);
 
     const renderer = await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
 
@@ -1054,7 +1136,7 @@ describe('GuessPathScreen', () => {
       refresh: jest.fn(),
     });
     const category = { id: 'c-1', key: 'c-1', name: 'Cats' };
-    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    emitCategoriesViaStore([category]);
 
     let resolveFirstDelete;
     deleteGroupCategory.mockImplementation(

--- a/__tests__/GuessPicture.test.js
+++ b/__tests__/GuessPicture.test.js
@@ -1,16 +1,50 @@
 const mockGameInstructions = jest.fn(() => null);
 const mockShowPicture = jest.fn(() => null);
 
-let capturedPanResponder;
-
 jest.mock('react-native', () => ({
-  PanResponder: {
-    create: jest.fn((config) => {
-      capturedPanResponder = config;
-      return { panHandlers: { testID: 'mock-target-pan-handlers' } };
-    }),
+  AppState: {
+    addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  },
+  Dimensions: {
+    get: jest.fn(() => ({ width: 320, height: 640, scale: 1, fontScale: 1 })),
   },
 }));
+
+let mockCapturedGestureCallbacks;
+let mockCapturedGesture;
+
+jest.mock('react-native-gesture-handler', () => {
+  const React = jest.requireActual('react');
+
+  function makeChainable() {
+    const record = { __type: 'pan', calls: [] };
+    const handler = {
+      get(_t, prop) {
+        if (prop in record) return record[prop];
+        return (...args) => {
+          record.calls.push({ method: prop, args });
+          return proxy;
+        };
+      },
+    };
+    const proxy = new Proxy(record, handler);
+    mockCapturedGesture = proxy;
+    mockCapturedGestureCallbacks = record;
+    return proxy;
+  }
+  return {
+    Gesture: {
+      Pan: () => makeChainable(),
+      Race: (...gs) => ({ __type: 'race', gestures: gs }),
+      Exclusive: (...gs) => ({ __type: 'exclusive', gestures: gs }),
+      Simultaneous: (...gs) => ({ __type: 'sim', gestures: gs }),
+    },
+    GestureDetector: ({ children, ...props }) =>
+      React.createElement('GestureDetector', props, children),
+    GestureHandlerRootView: ({ children, ...props }) =>
+      React.createElement('GestureHandlerRootView', props, children),
+  };
+});
 
 jest.mock('../components/Instructions/GameInstructions', () => {
   return function MockGameInstructions(props) {
@@ -108,7 +142,8 @@ describe('GuessPicture', () => {
     });
     buildCenteredTarget.mockReturnValue(centeredSelection);
     buildSelectionFromPixels.mockReturnValue(draggedSelection);
-    capturedPanResponder = undefined;
+    mockCapturedGestureCallbacks = undefined;
+    mockCapturedGesture = undefined;
   });
 
   const activeRenderers = [];
@@ -158,25 +193,22 @@ describe('GuessPicture', () => {
     const pictureProps = getLatestShowPictureProps();
     expect(pictureProps.touchLocation).toEqual({ x: '0.50', y: '0.50' });
     expect(pictureProps.target).toEqual(centeredSelection.target);
-    expect(pictureProps.targetPanHandlers).toEqual({ testID: 'mock-target-pan-handlers' });
+    expect(pictureProps.targetGesture).toBeTruthy();
+    expect(mockCapturedGestureCallbacks.__type).toBe('pan');
   });
 
-  it('in non-e2e mode, the target PanResponder claims the touch on the capture phase so the wrapped Pressable child cannot steal it', async () => {
+  it('in non-e2e mode, moves the target when the drag gesture onUpdate fires with translationX=10', async () => {
     isE2EMode.mockReturnValue(false);
 
     await renderToPicture();
 
-    expect(capturedPanResponder.onStartShouldSetPanResponderCapture()).toBe(true);
-  });
-
-  it('in non-e2e mode, moves the target when the drag handler updates the location', async () => {
-    isE2EMode.mockReturnValue(false);
-
-    await renderToPicture();
+    const record = mockCapturedGestureCallbacks;
+    const onBegin = record.calls.find((c) => c.method === 'onBegin').args[0];
+    const onUpdate = record.calls.find((c) => c.method === 'onUpdate').args[0];
 
     await act(async () => {
-      capturedPanResponder.onPanResponderGrant(null, { dx: 0, dy: 0 });
-      capturedPanResponder.onPanResponderMove(null, { dx: 10, dy: 0 });
+      onBegin();
+      onUpdate({ translationX: 10, translationY: 0 });
     });
 
     expect(buildSelectionFromPixels).toHaveBeenCalledWith({
@@ -198,9 +230,13 @@ describe('GuessPicture', () => {
 
     await renderToPicture({ toAdScreen });
 
+    const record = mockCapturedGestureCallbacks;
+    const onBegin = record.calls.find((c) => c.method === 'onBegin').args[0];
+    const onUpdate = record.calls.find((c) => c.method === 'onUpdate').args[0];
+
     await act(async () => {
-      capturedPanResponder.onPanResponderGrant(null, { dx: 0, dy: 0 });
-      capturedPanResponder.onPanResponderMove(null, { dx: 10, dy: 0 });
+      onBegin();
+      onUpdate({ translationX: 10, translationY: 0 });
     });
 
     await act(async () => {
@@ -224,9 +260,13 @@ describe('GuessPicture', () => {
 
     expect(getLatestShowPictureProps().showModal).toBe(false);
 
+    const record = mockCapturedGestureCallbacks;
+    const onBegin = record.calls.find((c) => c.method === 'onBegin').args[0];
+    const onFinalize = record.calls.find((c) => c.method === 'onFinalize').args[0];
+
     await act(async () => {
-      capturedPanResponder.onPanResponderGrant(null, { dx: 0, dy: 0 });
-      capturedPanResponder.onPanResponderRelease(null, { dx: 2, dy: 2 });
+      onBegin();
+      onFinalize({ translationX: 2, translationY: 2 });
     });
 
     expect(getLatestShowPictureProps().showModal).toBe(true);
@@ -237,10 +277,15 @@ describe('GuessPicture', () => {
 
     await renderToPicture();
 
+    const record = mockCapturedGestureCallbacks;
+    const onBegin = record.calls.find((c) => c.method === 'onBegin').args[0];
+    const onUpdate = record.calls.find((c) => c.method === 'onUpdate').args[0];
+    const onFinalize = record.calls.find((c) => c.method === 'onFinalize').args[0];
+
     await act(async () => {
-      capturedPanResponder.onPanResponderGrant(null, { dx: 0, dy: 0 });
-      capturedPanResponder.onPanResponderMove(null, { dx: 30, dy: 0 });
-      capturedPanResponder.onPanResponderRelease(null, { dx: 30, dy: 0 });
+      onBegin();
+      onUpdate({ translationX: 30, translationY: 0 });
+      onFinalize({ translationX: 30, translationY: 0 });
     });
 
     expect(getLatestShowPictureProps().showModal).toBe(false);
@@ -265,7 +310,7 @@ describe('GuessPicture', () => {
     expect(after.touchLocation).toEqual({ x: '0.50', y: '0.50' });
   });
 
-  it('in e2e mode, initializes target as null, attaches no panHandlers, and leaves the surface tap to reach handlePress', async () => {
+  it('in e2e mode, initializes target as null, attaches no target gesture, and leaves the surface tap to reach handlePress', async () => {
     await renderToPicture();
 
     expect(buildCenteredTarget).not.toHaveBeenCalled();
@@ -273,7 +318,7 @@ describe('GuessPicture', () => {
     const pictureProps = getLatestShowPictureProps();
     expect(pictureProps.touchLocation).toBeNull();
     expect(pictureProps.target).toBeNull();
-    expect(pictureProps.targetPanHandlers).toBeUndefined();
+    expect(pictureProps.targetGesture).toBeUndefined();
 
     await act(async () => {
       getLatestShowPictureProps().handlePress();
@@ -326,25 +371,25 @@ describe('GuessPicture', () => {
     // was silently dropped (omitted from GuessPictureProps), so the screen's
     // `disabled={advance.state !== 'idle'}` had no effect.
 
-    it('disabled=true → useTargetDrag enabled=false → ShowPicture receives no targetPanHandlers', async () => {
+    it('disabled=true → useTargetDrag enabled=false → ShowPicture receives no targetGesture', async () => {
       isE2EMode.mockReturnValue(false);
       await renderToPicture({ disabled: true });
 
-      expect(getLatestShowPictureProps().targetPanHandlers).toBeUndefined();
+      expect(getLatestShowPictureProps().targetGesture).toBeUndefined();
     });
 
-    it('disabled=false (default) → useTargetDrag enabled=true → ShowPicture receives targetPanHandlers', async () => {
+    it('disabled=false (default) → useTargetDrag enabled=true → ShowPicture receives targetGesture', async () => {
       isE2EMode.mockReturnValue(false);
       await renderToPicture();
 
-      expect(getLatestShowPictureProps().targetPanHandlers).toEqual({ testID: 'mock-target-pan-handlers' });
+      expect(getLatestShowPictureProps().targetGesture).toBeTruthy();
     });
 
-    it('disabled=true + e2e mode → still no panHandlers (e2e path keeps its own surface-tap wiring)', async () => {
+    it('disabled=true + e2e mode → still no targetGesture (e2e path keeps its own surface-tap wiring)', async () => {
       isE2EMode.mockReturnValue(true);
       await renderToPicture({ disabled: true });
 
-      expect(getLatestShowPictureProps().targetPanHandlers).toBeUndefined();
+      expect(getLatestShowPictureProps().targetGesture).toBeUndefined();
     });
   });
 
@@ -423,8 +468,11 @@ describe('GuessPicture', () => {
           jest.advanceTimersByTime(600);
         });
         act(() => {
-          capturedPanResponder.onPanResponderGrant(null, { dx: 0, dy: 0 });
-          capturedPanResponder.onPanResponderRelease(null, { dx: 2, dy: 2 });
+          const record = mockCapturedGestureCallbacks;
+          const onBegin = record.calls.find((c) => c.method === 'onBegin').args[0];
+          const onFinalize = record.calls.find((c) => c.method === 'onFinalize').args[0];
+          onBegin();
+          onFinalize({ translationX: 2, translationY: 2 });
         });
         act(() => {
           getLatestShowPictureProps().handleConfirm();
@@ -548,8 +596,11 @@ describe('GuessPicture', () => {
       expect(getLatestShowPictureProps().speedRingActive).toBe(true);
 
       act(() => {
-        capturedPanResponder.onPanResponderGrant(null, { dx: 0, dy: 0 });
-        capturedPanResponder.onPanResponderRelease(null, { dx: 2, dy: 2 });
+        const record = mockCapturedGestureCallbacks;
+        const onBegin = record.calls.find((c) => c.method === 'onBegin').args[0];
+        const onFinalize = record.calls.find((c) => c.method === 'onFinalize').args[0];
+        onBegin();
+        onFinalize({ translationX: 2, translationY: 2 });
       });
       act(() => {
         getLatestShowPictureProps().handleConfirm();

--- a/__tests__/GuessScreen.test.tsx
+++ b/__tests__/GuessScreen.test.tsx
@@ -3216,8 +3216,8 @@ describe('GuessScreen', () => {
   });
 
   describe('private exit routing', () => {
-    it('private scope: exit-menu Home calls navigation.popTo("PrivateHomeScreen") and does NOT call popToTop', async () => {
-      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn(), popTo: jest.fn() };
+    it('private scope: exit-menu Home resets stack to [HomeScreen, PrivateHomeScreen(scope)] and does NOT call popToTop', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn(), reset: jest.fn() };
       const route = {
         params: {
           ...PUBLIC_ROUTE_PARAMS,
@@ -3233,12 +3233,18 @@ describe('GuessScreen', () => {
         lastMenuProps().onHome();
       });
 
-      expect(navigation.popTo).toHaveBeenCalledWith('PrivateHomeScreen');
+      expect(navigation.reset).toHaveBeenCalledWith({
+        index: 1,
+        routes: [
+          { name: 'HomeScreen' },
+          { name: 'PrivateHomeScreen', params: { scope: { kind: 'private', groupId: 'g-1' } } },
+        ],
+      });
       expect(navigation.popToTop).not.toHaveBeenCalled();
     });
 
-    it('public scope (no scope): exit-menu Home calls navigation.popToTop and does NOT call popTo', async () => {
-      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn(), popTo: jest.fn() };
+    it('public scope (no scope): exit-menu Home calls navigation.popToTop and does NOT call reset', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn(), reset: jest.fn() };
       const route = { params: { ...PUBLIC_ROUTE_PARAMS } };
 
       await act(async () => {
@@ -3250,16 +3256,16 @@ describe('GuessScreen', () => {
       });
 
       expect(navigation.popToTop).toHaveBeenCalledTimes(1);
-      expect(navigation.popTo).not.toHaveBeenCalled();
+      expect(navigation.reset).not.toHaveBeenCalled();
     });
 
-    it('private scope: exhausted-panel onLeave calls navigation.popTo("PrivateHomeScreen") and does NOT call popToTop', async () => {
+    it('private scope: exhausted-panel onLeave resets stack to [HomeScreen, PrivateHomeScreen(scope)] and does NOT call popToTop', async () => {
       resolveNextCardWithServerFallback.mockResolvedValue({ next: null, reason: 'empty' });
       const navigation = {
         replace: jest.fn(),
         setParams: jest.fn(),
         popToTop: jest.fn(),
-        popTo: jest.fn(),
+        reset: jest.fn(),
         navigate: jest.fn(),
         goBack: jest.fn(),
         addListener: jest.fn(() => () => {}),
@@ -3284,7 +3290,13 @@ describe('GuessScreen', () => {
         panelProps.onLeave();
       });
 
-      expect(navigation.popTo).toHaveBeenCalledWith('PrivateHomeScreen');
+      expect(navigation.reset).toHaveBeenCalledWith({
+        index: 1,
+        routes: [
+          { name: 'HomeScreen' },
+          { name: 'PrivateHomeScreen', params: { scope: { kind: 'private', groupId: 'g-1' } } },
+        ],
+      });
       expect(navigation.popToTop).not.toHaveBeenCalled();
     });
   });

--- a/__tests__/GuessScreen.test.tsx
+++ b/__tests__/GuessScreen.test.tsx
@@ -3,6 +3,7 @@ type MockPictureProps = {
   pulseTarget: boolean;
   onInteract: () => void;
   disabled?: boolean;
+  onEdgeSwipe?: () => void;
   [key: string]: unknown;
 };
 type MockOverlayProps = {
@@ -14,9 +15,11 @@ type MockOverlayProps = {
   [key: string]: unknown;
 };
 type MockMenuProps = {
+  isOpen: boolean;
   showHints: boolean;
   onInteract: () => void;
   onHome: () => void;
+  onClose: () => void;
   [key: string]: unknown;
 };
 
@@ -74,6 +77,18 @@ let mockOverlayDismissDelayMs: number | null = null;
 function setMockOverlayDismissDelayMs(ms: number | null): void {
   mockOverlayDismissDelayMs = ms;
 }
+
+// GuessScreen renders a localized <GestureHandlerRootView> as the host for the
+// nested GestureDetectors in ShowPicture. RNGH's real root calls a native
+// `install()` unavailable under jest; stub the root to render children so the
+// rest of the screen renders under test.
+jest.mock('react-native-gesture-handler', () => {
+  const React = jest.requireActual('react');
+  return {
+    GestureHandlerRootView: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('GestureHandlerRootView', null, children),
+  };
+});
 
 jest.mock('../components/Picture/GuessPicture', () => {
   const React = jest.requireActual('react');
@@ -296,6 +311,9 @@ import { applySuccessSideEffects as applySuccessSideEffectsImpl, resolveNextGues
 import { navigateToNextGuess as navigateToNextGuessImpl } from '../utils/guessNavigation';
 import { prefetchIfLow as prefetchIfLowImpl } from '../services/cardPrefetcher';
 import { warmAllDeckIfNeeded as warmAllDeckIfNeededImpl } from '../services/cardPrefetcher';
+import { createFallbackAdSource as createFallbackAdSourceImpl } from '../services/ads/FallbackAdSource';
+import { createAdMobInterstitialSource as createAdMobInterstitialSourceImpl } from '../services/ads/AdMobInterstitialSource';
+import { createInternalProAdSource as createInternalProAdSourceImpl } from '../services/ads/InternalProAdSource';
 import { consumeAdSlot as consumeAdSlotImpl } from '../utils/adCadence';
 import { shouldSuppressAds as shouldSuppressAdsImpl } from '../services/billing/adPolicy';
 import { resolveNextCardWithServerFallback as resolveNextCardWithServerFallbackImpl } from '../utils/nextCardAdvancer';
@@ -309,6 +327,9 @@ const resolveNextGuessParams = resolveNextGuessParamsImpl as jest.MockedFunction
 const navigateToNextGuess = navigateToNextGuessImpl as jest.MockedFunction<typeof navigateToNextGuessImpl>;
 const prefetchIfLow = prefetchIfLowImpl as jest.MockedFunction<typeof prefetchIfLowImpl>;
 const warmAllDeckIfNeeded = warmAllDeckIfNeededImpl as jest.MockedFunction<typeof warmAllDeckIfNeededImpl>;
+const createFallbackAdSource = createFallbackAdSourceImpl as jest.MockedFunction<typeof createFallbackAdSourceImpl>;
+const createAdMobInterstitialSource = createAdMobInterstitialSourceImpl as jest.MockedFunction<typeof createAdMobInterstitialSourceImpl>;
+const createInternalProAdSource = createInternalProAdSourceImpl as jest.MockedFunction<typeof createInternalProAdSourceImpl>;
 const consumeAdSlot = consumeAdSlotImpl as jest.MockedFunction<typeof consumeAdSlotImpl>;
 const shouldSuppressAds = shouldSuppressAdsImpl as jest.MockedFunction<typeof shouldSuppressAdsImpl>;
 const resolveNextCardWithServerFallback = resolveNextCardWithServerFallbackImpl as jest.MockedFunction<typeof resolveNextCardWithServerFallbackImpl>;
@@ -360,6 +381,22 @@ describe('GuessScreen', () => {
     isE2EMode.mockReturnValue(false);
     consumeAdSlot.mockReturnValue({ showAd: false, nextCount: 1 });
     shouldSuppressAds.mockReturnValue(false);
+    createAdMobInterstitialSource.mockReturnValue({
+      isReady: () => false,
+      show: async () => undefined,
+      renderSurface: () => null,
+    });
+    createInternalProAdSource.mockReturnValue({
+      isReady: () => true,
+      show: async () => undefined,
+      renderSurface: () => null,
+      _continue: () => undefined,
+    });
+    createFallbackAdSource.mockReturnValue({
+      isReady: () => true,
+      show: async () => undefined,
+      renderSurface: () => null,
+    });
     // Reset the outer resolver mock to its default (actual implementation)
     // so per-test mockResolvedValue overrides don't leak across tests.
     resolveNextCardWithServerFallback.mockImplementation(advanceModuleActual.resolveNextCardWithServerFallback);
@@ -789,6 +826,46 @@ describe('GuessScreen', () => {
 
     expect(lastPictureProps().pulseTarget).toBe(false);
     expect(lastMenuProps().showHints).toBe(false);
+  });
+
+  it('controlled exit menu: starts closed (isOpen=false), edge-swipe via GuessPicture.onEdgeSwipe flips it open, onClose closes', async () => {
+    const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn() };
+    const route = {
+      params: {
+        imageFile: 'file:///waldo.jpg',
+        pictureId: 'image-1',
+        description: 'Find Waldo',
+        imageHeight: 1200,
+        imageWidth: 800,
+        isPortrait: true,
+        hiddenLocation: { x: 0.5, y: 0.5 },
+        listId: 3,
+        isTutorial: false,
+        category: { id: 'cat-1', key: 'nature' },
+        language: 'fr',
+      },
+    };
+
+    await act(async () => {
+      create(<GuessScreen navigation={navigation} route={route} />);
+    });
+
+    expect(lastMenuProps().isOpen).toBe(false);
+
+    const pictureProps = lastPictureProps();
+    expect(typeof pictureProps.onEdgeSwipe).toBe('function');
+
+    await act(async () => {
+      pictureProps.onEdgeSwipe?.();
+    });
+
+    expect(lastMenuProps().isOpen).toBe(true);
+
+    await act(async () => {
+      lastMenuProps().onClose();
+    });
+
+    expect(lastMenuProps().isOpen).toBe(false);
   });
 
   it('on success: calls streak.onWin and passes streakTier (tier >= 0) to SuccessOverlay', async () => {
@@ -3135,6 +3212,80 @@ describe('GuessScreen', () => {
       expect(mockNextCardImageWarmer).toHaveBeenCalled();
       const warmerCall = mockNextCardImageWarmer.mock.calls[mockNextCardImageWarmer.mock.calls.length - 1][0];
       expect(warmerCall.uris).toEqual([]);
+    });
+  });
+
+  describe('private exit routing', () => {
+    it('private scope: exit-menu Home calls navigation.popTo("PrivateHomeScreen") and does NOT call popToTop', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn(), popTo: jest.fn() };
+      const route = {
+        params: {
+          ...PUBLIC_ROUTE_PARAMS,
+          scope: { kind: 'private', groupId: 'g-1' },
+        },
+      };
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={route} />);
+      });
+
+      await act(async () => {
+        lastMenuProps().onHome();
+      });
+
+      expect(navigation.popTo).toHaveBeenCalledWith('PrivateHomeScreen');
+      expect(navigation.popToTop).not.toHaveBeenCalled();
+    });
+
+    it('public scope (no scope): exit-menu Home calls navigation.popToTop and does NOT call popTo', async () => {
+      const navigation = { replace: jest.fn(), setParams: jest.fn(), popToTop: jest.fn(), popTo: jest.fn() };
+      const route = { params: { ...PUBLIC_ROUTE_PARAMS } };
+
+      await act(async () => {
+        create(<GuessScreen navigation={navigation} route={route} />);
+      });
+
+      await act(async () => {
+        lastMenuProps().onHome();
+      });
+
+      expect(navigation.popToTop).toHaveBeenCalledTimes(1);
+      expect(navigation.popTo).not.toHaveBeenCalled();
+    });
+
+    it('private scope: exhausted-panel onLeave calls navigation.popTo("PrivateHomeScreen") and does NOT call popToTop', async () => {
+      resolveNextCardWithServerFallback.mockResolvedValue({ next: null, reason: 'empty' });
+      const navigation = {
+        replace: jest.fn(),
+        setParams: jest.fn(),
+        popToTop: jest.fn(),
+        popTo: jest.fn(),
+        navigate: jest.fn(),
+        goBack: jest.fn(),
+        addListener: jest.fn(() => () => {}),
+      };
+      const route = {
+        params: {
+          ...PUBLIC_ROUTE_PARAMS,
+          scope: { kind: 'private', groupId: 'g-1' },
+        },
+      };
+      isOnTarget.mockReturnValue(true);
+      applySuccessSideEffects.mockResolvedValue(undefined);
+
+      await act(async () => { create(<GuessScreen navigation={navigation} route={route} />); });
+      await act(async () => { lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 } }); });
+      await act(async () => { lastOverlayProps().onDone(); });
+
+      expect(mockGuessExhaustedPanel).toHaveBeenCalled();
+      const panelProps = mockGuessExhaustedPanel.mock.calls[mockGuessExhaustedPanel.mock.calls.length - 1][0];
+
+      await act(async () => {
+        panelProps.onLeave();
+      });
+
+      expect(navigation.popTo).toHaveBeenCalledWith('PrivateHomeScreen');
+      expect(navigation.popToTop).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/GuessScreen.test.tsx
+++ b/__tests__/GuessScreen.test.tsx
@@ -622,9 +622,9 @@ describe('GuessScreen', () => {
     expect(navigateToNextGuess).not.toHaveBeenCalled();
     // Regression (T4): prefetch fired during success path but did not block overlay/setParams.
     expect(prefetchIfLow).toHaveBeenCalledTimes(1);
+    // B2: PUBLIC scope threads categoryKey only; categoryId is NOT forwarded.
     expect(prefetchIfLow).toHaveBeenCalledWith({
       categoryKey: 'nature',
-      categoryId: 'cat-1',
       language: 'fr',
       scope: undefined,
       authContext: expect.objectContaining({ userId: '' }),
@@ -1236,9 +1236,9 @@ describe('GuessScreen', () => {
       // kicks the resolve off at tap, so it may already have fired by here.
       // The observable invariant is prefetchIfLow's call shape on tap.
       expect(prefetchIfLow).toHaveBeenCalledTimes(1);
+      // B2: PUBLIC scope threads categoryKey only; categoryId is NOT forwarded.
       expect(prefetchIfLow).toHaveBeenCalledWith({
         categoryKey: 'nature',
-        categoryId: 'cat-1',
         language: 'fr',
         scope: undefined,
         authContext: expect.objectContaining({ userId: '' }),
@@ -1357,10 +1357,12 @@ describe('GuessScreen', () => {
       });
 
       expect(prefetchIfLow).toHaveBeenCalledTimes(1);
+      // B2: PUBLIC scope + null category → categoryKey 'all', no categoryId.
       expect(prefetchIfLow).toHaveBeenCalledWith(expect.objectContaining({
         categoryKey: 'all',
-        categoryId: undefined,
       }));
+      const nullCatCall = prefetchIfLow.mock.calls[prefetchIfLow.mock.calls.length - 1][0] as { categoryId?: unknown };
+      expect(nullCatCall.categoryId).toBeUndefined();
     });
 
     it('T7: prefetch rejection does not break the success flow (overlay still shows, setParams still fires onDone)', async () => {
@@ -1913,10 +1915,12 @@ describe('GuessScreen', () => {
       });
 
       expect(prefetchIfLow).toHaveBeenCalledTimes(1);
+      // B2: PUBLIC scope + category.key === 'all' threads categoryKey only.
       expect(prefetchIfLow).toHaveBeenCalledWith(expect.objectContaining({
         categoryKey: 'all',
-        categoryId: 'cat-all',
       }));
+      const allCall = prefetchIfLow.mock.calls[prefetchIfLow.mock.calls.length - 1][0] as { categoryId?: unknown };
+      expect(allCall.categoryId).toBeUndefined();
     });
   });
 

--- a/__tests__/GuessScreenFreeTierAdRegression.test.tsx
+++ b/__tests__/GuessScreenFreeTierAdRegression.test.tsx
@@ -1,0 +1,239 @@
+// Regression test for the "no ads at all" symptom reported after the gesture
+// refactor. Unlike GuessScreen.test.tsx (which mocks consumeAdSlot/adPolicy/
+// ad sources), this suite uses the REAL consumeAdSlot (utils/adCadence) and
+// REAL ad sources (InternalProAdSource + FallbackAdSource) so a regression in
+// the cadence/source wiring surfaces as a failing assertion here, not a green
+// test against a stub.
+//
+// Scope: a free-tier user (paidTier 0, not e2e, not adFree) who wins 3
+// consecutive times MUST see adPhase === 'showing' with <AdInterstitial>
+// mounted AND adSource.renderSurface() returning the internal pro panel.
+//
+// Platform: forced to 'android' inside an isolateModules boundary so the
+// documented HEAD free-tier behavior (Android-only cadence) is exercised.
+// useAdCadence's IS_ANDROID is captured at module load, so GuessScreen must
+// be required AFTER the Platform.OS swap.
+
+type MockPictureProps = {
+  toAdScreen: (target: { location: { x: number; y: number }; elapsedMs?: number }) => void | Promise<void>;
+  [key: string]: unknown;
+};
+type MockOverlayProps = {
+  visible: boolean;
+  onDone: () => void | Promise<void>;
+  [key: string]: unknown;
+};
+type MockAdInterstitialProps = {
+  adSource: { renderSurface(): unknown };
+  onDone: () => void;
+  [key: string]: unknown;
+};
+
+const mockGuessPicture = jest.fn((_props: MockPictureProps) => null);
+const mockSuccessOverlay = jest.fn((_props: MockOverlayProps) => null);
+let mockAdMountCount = 0;
+let lastAdInterstitialPropsValue: MockAdInterstitialProps | null = null;
+const mockAdInterstitial = jest.fn((props: MockAdInterstitialProps) => null);
+
+jest.mock('../components/Picture/GuessPicture', () => {
+  return function MockGuessPicture(props: MockPictureProps) {
+    mockGuessPicture(props);
+    return null;
+  };
+});
+
+jest.mock('../components/Guess/SuccessOverlay', () => {
+  return function MockSuccessOverlay(props: MockOverlayProps) {
+    mockSuccessOverlay(props);
+    return null;
+  };
+});
+
+jest.mock('../components/Ads/AdInterstitial', () => {
+  const React = jest.requireActual('react');
+  return function MockAdInterstitial(props: MockAdInterstitialProps) {
+    React.useEffect(() => {
+      mockAdMountCount += 1;
+      lastAdInterstitialPropsValue = props;
+      mockAdInterstitial(props);
+      return () => { mockAdMountCount -= 1; };
+    }, []);
+    return null;
+  };
+});
+
+jest.mock('../components/Guess/GuessExitSwipeMenu', () => () => null);
+jest.mock('../components/Guess/GuessExhaustedPanel', () => () => null);
+jest.mock('../components/Guess/GuessAdvanceLoader', () => () => null);
+jest.mock('../components/Picture/NextCardImageWarmer', () => () => null);
+jest.mock('../components/UI/TutorialOverlay', () => () => null);
+
+// GuessScreen renders a localized <GestureHandlerRootView>; stub the root so
+// the screen renders under jest (RNGH's real root calls a native install()).
+jest.mock('react-native-gesture-handler', () => {
+  const React = jest.requireActual('react');
+  return {
+    GestureHandlerRootView: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('GestureHandlerRootView', null, children),
+  };
+});
+
+jest.mock('../utils/targetLocation', () => ({ isOnTarget: jest.fn() }));
+
+jest.mock('../utils/handleGuessOutcome', () => ({
+  applySuccessSideEffects: jest.fn().mockResolvedValue(undefined),
+  resolveNextGuessParams: jest.fn(),
+}));
+
+jest.mock('../services/cardDeck', () => ({
+  fetchCardBatch: jest.fn().mockResolvedValue({ images: [] }),
+  appendCardBatch: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../utils/nextCardAdvancer', () => ({
+  resolveNextCardWithServerFallback: jest.fn(),
+}));
+
+jest.mock('../utils/guessNavigation', () => ({
+  navigateToNextGuess: jest.fn(),
+}));
+
+jest.mock('../services/cardPrefetcher', () => ({
+  prefetchIfLow: jest.fn().mockResolvedValue(undefined),
+  warmAllDeckIfNeeded: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../utils/storageDatum', () => ({
+  getNextImagesForScope: jest.fn().mockResolvedValue([]),
+  clearExhaustedCategory: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../utils/e2eMode', () => ({
+  isE2EMode: jest.fn(() => false),
+}));
+
+import { act, create as reactCreate } from 'react-test-renderer';
+import { AppState, Platform } from 'react-native';
+
+import { isOnTarget as isOnTargetImpl } from '../utils/targetLocation';
+import { applySuccessSideEffects as applySuccessSideEffectsImpl } from '../utils/handleGuessOutcome';
+import { resolveNextGuessParams as resolveNextGuessParamsImpl } from '../utils/handleGuessOutcome';
+import { resolveNextCardWithServerFallback as resolveNextCardWithServerFallbackImpl } from '../utils/nextCardAdvancer';
+
+const isOnTarget = isOnTargetImpl as jest.MockedFunction<typeof isOnTargetImpl>;
+const applySuccessSideEffects = applySuccessSideEffectsImpl as jest.MockedFunction<typeof applySuccessSideEffectsImpl>;
+const resolveNextGuessParams = resolveNextGuessParamsImpl as jest.MockedFunction<typeof resolveNextGuessParamsImpl>;
+const resolveNextCardWithServerFallback = resolveNextCardWithServerFallbackImpl as jest.MockedFunction<typeof resolveNextCardWithServerFallbackImpl>;
+
+type LooseGuessScreenProps = { navigation: unknown; route: { params: Record<string, unknown> } };
+type GuessScreenComp = React.FC<LooseGuessScreenProps>;
+
+const mountedRenderers: Array<ReturnType<typeof reactCreate>> = [];
+function create(...args: Parameters<typeof reactCreate>): ReturnType<typeof reactCreate> {
+  const renderer = reactCreate(...args);
+  mountedRenderers.push(renderer);
+  return renderer;
+}
+
+// GuessScreen is require()'d lazily inside beforeAll AFTER Platform.OS has been
+// swapped to 'android', so the module-load-time IS_ANDROID capture in
+// useAdCadence (HEAD) sees android. The require runs exactly once and shares
+// the test file's React instance (no isolateModules duplication).
+let GuessScreen: GuessScreenComp;
+const ORIGINAL_PLATFORM_OS = Platform.OS;
+
+const PUBLIC_ROUTE_PARAMS = {
+  imageFile: 'file:///waldo.jpg',
+  pictureId: 'image-1',
+  description: 'Find Waldo',
+  imageHeight: 1200, imageWidth: 800, isPortrait: true,
+  hiddenLocation: { x: 0.5, y: 0.5 },
+  listId: 3, isTutorial: false,
+  category: { id: 'cat-1', key: 'nature' }, language: 'fr',
+};
+
+function makeNav() {
+  return {
+    replace: jest.fn(),
+    setParams: jest.fn(),
+    popToTop: jest.fn(),
+    popTo: jest.fn(),
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    setOptions: jest.fn(),
+    addListener: jest.fn(() => () => {}),
+  };
+}
+
+function lastPictureProps(): MockPictureProps {
+  return mockGuessPicture.mock.calls[mockGuessPicture.mock.calls.length - 1][0];
+}
+
+function lastOverlayProps(): MockOverlayProps {
+  return mockSuccessOverlay.mock.calls[mockSuccessOverlay.mock.calls.length - 1][0];
+}
+
+describe('GuessScreen free-tier ad regression (real cadence + real sources)', () => {
+  beforeAll(() => {
+    // Force Platform.OS = 'android' BEFORE GuessScreen is required so the
+    // module-load-time IS_ANDROID capture in useAdCadence (HEAD) sees android
+    // — the documented HEAD free-tier platform. The require runs once, against
+    // the same React instance as the test file (no isolateModules duplication).
+    Object.defineProperty(Platform, 'OS', { value: 'android', configurable: true });
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    GuessScreen = require('../screens/GuessScreens/GuessScreen').default as GuessScreenComp;
+  });
+
+  afterAll(() => {
+    Object.defineProperty(Platform, 'OS', { value: ORIGINAL_PLATFORM_OS, configurable: true });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAdMountCount = 0;
+    lastAdInterstitialPropsValue = null;
+    isOnTarget.mockReturnValue(true);
+    applySuccessSideEffects.mockResolvedValue(undefined);
+    resolveNextGuessParams.mockResolvedValue({ params: { listId: 4 } });
+    resolveNextCardWithServerFallback.mockResolvedValue({ next: { params: { listId: 4 } }, reason: 'ok' });
+    jest.spyOn(AppState, 'addEventListener').mockImplementation(() => ({ remove: jest.fn() }) as any);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      while (mountedRenderers.length > 0) {
+        mountedRenderers.pop()?.unmount();
+      }
+      await Promise.resolve();
+    });
+    jest.restoreAllMocks();
+  });
+
+  it('free-tier (paidTier 0) user: 3 consecutive wins → AdInterstitial mounts AND adSource.renderSurface() is non-null', async () => {
+    const navigation = makeNav();
+    await act(async () => {
+      create(<GuessScreen navigation={navigation} route={{ params: PUBLIC_ROUTE_PARAMS }} />);
+    });
+
+    // Drive 3 consecutive wins through the picture's toAdScreen → success path.
+    // Each win: tap (toAdScreen) kicks off WIN+resolve; SuccessOverlay's onDone
+    // (handleOverlayDone) drains the deferred ad / dispatches RESOLVED.
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        lastPictureProps().toAdScreen({ location: { x: 0.5, y: 0.5 }, elapsedMs: 1000 });
+      });
+      await act(async () => {
+        lastOverlayProps().onDone();
+      });
+    }
+
+    // The 3rd win's consumeAdSlot fires showAd=true → setAdPhase('showing') →
+    // AdInterstitial mounts. Assert the mount + a non-null surface (the internal
+    // pro panel JSX), exercising the real FallbackAdSource → InternalProAdSource
+    // renderSurface chain.
+    expect(mockAdMountCount).toBe(1);
+    expect(lastAdInterstitialPropsValue).not.toBeNull();
+    const surface = lastAdInterstitialPropsValue!.adSource.renderSurface();
+    expect(surface).not.toBeNull();
+  });
+});

--- a/__tests__/SetInstructionScreen.test.js
+++ b/__tests__/SetInstructionScreen.test.js
@@ -8,6 +8,7 @@ const mockDeleteLocalImage = jest.fn();
 const mockRequestPermission = jest.fn();
 const mockUsePermissions = jest.fn();
 const mockOpenSettings = jest.fn();
+const mockUseGroupsHub = jest.fn();
 
 jest.mock('expo-file-system', () => {
   const File = jest.fn().mockImplementation(function MockFile(uri) {
@@ -129,6 +130,14 @@ jest.mock('../utils/categoryRequests', () => ({
   getCategories: jest.fn(),
 }));
 
+jest.mock('../services/groups/groupCategoriesStore', () => ({
+  loadGroupCategoriesOptimistic: jest.fn(),
+}));
+
+jest.mock('../hooks/useGroupsHub', () => ({
+  useGroupsHub: (...args) => mockUseGroupsHub(...args),
+}));
+
 jest.mock('../utils/languageDefaults', () => ({
   resolveDefaultLanguage: jest.fn(),
 }));
@@ -141,6 +150,7 @@ import SetInstructionsScreen from '../screens/SetInstructionScreen';
 import { AuthContext } from '../store/auth-context';
 import { checkSecureStoreItem } from '../utils/auth';
 import { getCategories } from '../utils/categoryRequests';
+import { getDefaultCategories } from '../constants/defaultCategories';
 import { buildE2EHiddenGuessPayload, isE2EMode } from '../utils/e2eMode';
 import { imageUploader } from '../utils/fileUploader';
 import { handleContentLength, handleImageType, isTypeValid } from '../utils/imageInfos';
@@ -148,6 +158,7 @@ import { performImageUpload, prepareImageUpload, saveImageInfos } from '../utils
 import { resolveDefaultLanguage } from '../utils/languageDefaults';
 import { handleOrientation } from '../utils/orientation';
 import { getPreferredLanguage, saveE2EHiddenGuessCard } from '../utils/storageDatum';
+import { loadGroupCategoriesOptimistic } from '../services/groups/groupCategoriesStore';
 
 describe('SetInstructionScreen', () => {
   const navigation = {
@@ -180,6 +191,19 @@ describe('SetInstructionScreen', () => {
     { id: 'cat-2', key: 'nature', name: 'Nature' },
     { id: 'cat-3', key: 'city', name: 'City' },
   ];
+  const privateScope = { kind: 'private', groupId: 'group-7' };
+  const privateCategoriesFixture = [
+    { id: 'grp-cat-1', key: 'nature', name: 'Nature', thumbnailUrl: 'https://example.com/nature.webp' },
+    { id: 'grp-cat-2', key: 'city', name: 'City', thumbnailUrl: 'https://example.com/city.webp' },
+  ];
+
+  function emitCategoriesViaStore(list) {
+    loadGroupCategoriesOptimistic.mockImplementation(async ({ onCategories }) => {
+      if (typeof onCategories === 'function') {
+        onCategories(list);
+      }
+    });
+  }
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -193,6 +217,7 @@ describe('SetInstructionScreen', () => {
       },
       mockRequestPermission,
     ]);
+    mockUseGroupsHub.mockReturnValue({ data: null, refresh: jest.fn() });
     checkSecureStoreItem.mockResolvedValue('user-42');
     handleContentLength.mockResolvedValue(4096);
     handleImageType.mockReturnValue('png');
@@ -213,6 +238,7 @@ describe('SetInstructionScreen', () => {
     getPreferredLanguage.mockResolvedValue('en');
     getCategories.mockResolvedValue({ data: categoriesFixture });
     resolveDefaultLanguage.mockReturnValue('en');
+    loadGroupCategoriesOptimistic.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -399,7 +425,7 @@ describe('SetInstructionScreen', () => {
         xLocation: 0.3,
         yLocation: 0.7,
         language: 'en',
-        categoryId: null,
+        categoryKey: null,
       },
       context: expect.objectContaining(tutorialContext),
     });
@@ -573,52 +599,56 @@ describe('SetInstructionScreen', () => {
     expect(getHideDescriptionProps().language).toBe('de');
   });
 
-  it('renders every category returned by getCategories through CategoryChips', async () => {
+  it('renders the bundled default categories without any category network fetch', async () => {
     await renderScreen();
 
-    expect(getCategories).toHaveBeenCalledWith({ context: expect.any(Object) });
-    expect(getHideDescriptionProps().categories).toEqual([
-      { id: 'cat-2', key: 'nature', name: 'Nature' },
-      { id: 'cat-3', key: 'city', name: 'City' },
+    expect(getCategories).not.toHaveBeenCalled();
+    expect(loadGroupCategoriesOptimistic).not.toHaveBeenCalled();
+    expect(getHideDescriptionProps().categories).toEqual(getDefaultCategories().data);
+    expect(getHideDescriptionProps().categories.map((category) => category.key)).toEqual([
+      'other',
+      'nature',
+      'city',
+      'abstract',
+      'animals',
+      'food',
+      'vehicles',
+      'interiors',
+      'landmarks',
     ]);
+    expect(getHideDescriptionProps().categoriesError).toBeNull();
   });
 
-  it('passes the category load failure message to HideDescription when category hydration fails', async () => {
-    getCategories.mockResolvedValueOnce({
-      isError: true,
-      message: 'Categories unavailable right now',
+  it('loads private group categories optimistically through the store', async () => {
+    emitCategoriesViaStore(privateCategoriesFixture);
+
+    await renderScreen({ params: { scope: privateScope } });
+
+    expect(loadGroupCategoriesOptimistic).toHaveBeenCalledWith({
+      context: expect.any(Object),
+      groupId: 'group-7',
+      onCategories: expect.any(Function),
     });
-
-    await renderScreen();
-
-    expect(getHideDescriptionProps().categories).toEqual([]);
-    expect(getHideDescriptionProps().categoriesError).toBe('Categories unavailable right now');
-    expect(typeof getHideDescriptionProps().onRetryCategories).toBe('function');
+    expect(getCategories).not.toHaveBeenCalled();
+    expect(getHideDescriptionProps().categories).toEqual(privateCategoriesFixture);
+    expect(getHideDescriptionProps().categoriesError).toBeNull();
   });
 
-  it('retries category hydration and clears the inline error after a successful retry', async () => {
-    getCategories
-      .mockResolvedValueOnce({
-        isError: true,
-        message: 'Categories unavailable right now',
-      })
-      .mockResolvedValueOnce({ data: categoriesFixture });
+  it('refreshes private group categories through the retry handler', async () => {
+    emitCategoriesViaStore(privateCategoriesFixture);
 
-    await renderScreen();
+    await renderScreen({ params: { scope: privateScope } });
 
-    expect(getHideDescriptionProps().categoriesError).toBe('Categories unavailable right now');
+    emitCategoriesViaStore([privateCategoriesFixture[0]]);
 
     await act(async () => {
       await getHideDescriptionProps().onRetryCategories();
       await flushEffects();
     });
 
-    expect(getCategories).toHaveBeenCalledTimes(2);
+    expect(loadGroupCategoriesOptimistic).toHaveBeenCalledTimes(2);
+    expect(getHideDescriptionProps().categories).toEqual([privateCategoriesFixture[0]]);
     expect(getHideDescriptionProps().categoriesError).toBeNull();
-    expect(getHideDescriptionProps().categories).toEqual([
-      { id: 'cat-2', key: 'nature', name: 'Nature' },
-      { id: 'cat-3', key: 'city', name: 'City' },
-    ]);
   });
 
   it('updates the selected category when a chip is pressed', async () => {
@@ -692,7 +722,7 @@ describe('SetInstructionScreen', () => {
     expect(getHideDescriptionProps().language).toBe('fr');
   });
 
-  it('includes the resolved category_id in the upload payload when a chip is selected', async () => {
+  it('sends the selected category key in the public upload payload when a chip is selected', async () => {
     await renderScreen();
 
     await act(async () => {
@@ -715,13 +745,52 @@ describe('SetInstructionScreen', () => {
     expect(imageUploader).toHaveBeenCalledWith({
       imageInfos: expect.objectContaining({
         language: 'fr',
-        categoryId: 'cat-2',
+        categoryKey: 'nature',
       }),
       context: expect.any(Object),
     });
+
+    const [{ imageInfos }] = imageUploader.mock.calls[0];
+    expect(imageInfos).not.toHaveProperty('categoryId');
+    expect(imageInfos.scope).toBeUndefined();
   });
 
-  it('treats forced pseudo-category selections as unset and omits category_id from uploads', async () => {
+  it('sends the resolved category id in the private upload payload when a chip is selected', async () => {
+    emitCategoriesViaStore(privateCategoriesFixture);
+
+    await renderScreen({ params: { scope: privateScope } });
+
+    await act(async () => {
+      mockHideDescription.mock.calls[0][0].onCategorySelect('nature');
+    });
+
+    await act(async () => {
+      mockHideDescription.mock.calls[0][0].onLanguageChange('fr');
+    });
+
+    await act(async () => {
+      mockHideDescription.mock.calls[0][0].onSubmit('Look near the river');
+    });
+
+    await act(async () => {
+      await getModalProps().onPress();
+      await flushEffects();
+    });
+
+    expect(imageUploader).toHaveBeenCalledWith({
+      imageInfos: expect.objectContaining({
+        language: 'fr',
+        categoryId: 'grp-cat-1',
+      }),
+      context: expect.any(Object),
+      scope: privateScope,
+    });
+
+    const [{ imageInfos }] = imageUploader.mock.calls[0];
+    expect(imageInfos).not.toHaveProperty('categoryKey');
+  });
+
+  it('treats forced pseudo-category selections as unset and omits the category from uploads', async () => {
     await renderScreen();
 
     await act(async () => {
@@ -746,7 +815,7 @@ describe('SetInstructionScreen', () => {
     expect(imageUploader).toHaveBeenCalledWith({
       imageInfos: expect.objectContaining({
         language: 'fr',
-        categoryId: null,
+        categoryKey: null,
       }),
       context: expect.any(Object),
     });
@@ -781,9 +850,10 @@ describe('SetInstructionScreen', () => {
 
     expect(imagesInfos).toEqual(expect.objectContaining({
       language: 'fr',
-      category_id: 'cat-2',
+      category_key: 'nature',
     }));
     expect(imagesInfos).not.toHaveProperty('categoryId');
+    expect(imagesInfos).not.toHaveProperty('categoryKey');
   });
 
   it('lets e2e mode bypass the language requirement while still rendering the selectors', async () => {

--- a/__tests__/ShowPicture.test.js
+++ b/__tests__/ShowPicture.test.js
@@ -1,200 +1,258 @@
+const mockEnigmaOverlay = jest.fn(() => null);
+const mockIconButton = jest.fn(() => null);
+const mockSpeedRing = jest.fn(() => null);
+const mockCenteredModal = jest.fn(() => null);
+
+jest.mock('react-native', () => {
+  const React = require('react');
+
+  class MockAnimatedValue {
+    constructor(value) {
+      this._value = value;
+    }
+    setValue = (nextValue) => {
+      this._value = nextValue;
+    };
+  }
+
+  function buildAnimation(value, config) {
+    return {
+      start: (callback) => {
+        if (typeof config?.toValue !== 'undefined' && value?.setValue) {
+          value.setValue(config.toValue);
+        }
+        callback?.();
+      },
+    };
+  }
+
+  return {
+    Animated: {
+      Value: MockAnimatedValue,
+      timing: jest.fn((value, config) => buildAnimation(value, config)),
+      loop: jest.fn((anim) => ({
+        start: () => {},
+        stop: () => {},
+        reset: () => {},
+      })),
+      parallel: jest.fn((animations) => ({
+        start: (cb) => {
+          animations.forEach((a) => a?.start?.());
+          cb?.();
+        },
+      })),
+      sequence: jest.fn((animations) => ({
+        start: (cb) => {
+          animations.forEach((a) => a?.start?.());
+          cb?.();
+        },
+      })),
+      View: ({ children, ...props }) => React.createElement('AnimatedView', props, children),
+    },
+    ImageBackground: ({ children, ...props }) =>
+      React.createElement('ImageBackground', props, children),
+    Pressable: ({ children, ...props }) => React.createElement('Pressable', props, children),
+    StyleSheet: {
+      absoluteFill: {},
+      absoluteFillObject: {},
+      create: (styles) => styles,
+    },
+    View: ({ children, ...props }) => React.createElement('View', props, children),
+  };
+});
+
+jest.mock('react-native-gesture-handler', () => {
+  const React = jest.requireActual('react');
+  return {
+    Gesture: {
+      Pan: () => makeChainable(),
+      Race: (...gs) => ({ __type: 'race', gestures: gs }),
+      Exclusive: (...gs) => ({ __type: 'exclusive', gestures: gs }),
+      Simultaneous: (...gs) => ({ __type: 'sim', gestures: gs }),
+    },
+    GestureDetector: ({ children, ...props }) =>
+      React.createElement('GestureDetector', props, children),
+    GestureHandlerRootView: ({ children, ...props }) =>
+      React.createElement('GestureHandlerRootView', props, children),
+  };
+
+  function makeChainable() {
+    const obj = function ChainableGesture() {};
+    const proxy = new Proxy(obj, {
+      get(_t, prop) {
+        if (prop === 'then') return undefined;
+        return (..._args) => proxy;
+      },
+    });
+    return proxy;
+  }
+});
+
+jest.mock('../components/Picture/Descriptions/EnigmaOverlay', () => {
+  return function MockEnigmaOverlay(props) {
+    mockEnigmaOverlay(props);
+    return null;
+  };
+});
+
 jest.mock('../components/UI/IconButton', () => {
   return function MockIconButton(props) {
+    mockIconButton(props);
     return null;
   };
 });
 
 jest.mock('../components/UI/CenteredModal', () => {
+  const React = require('react');
   return function MockCenteredModal(props) {
-    return null;
+    mockCenteredModal(props);
+    return React.createElement('View', { testID: props.testIDPrefix });
   };
 });
 
-jest.mock('../components/Picture/Descriptions/EnigmaOverlay', () => {
-  return function MockEnigmaOverlay(props) {
+jest.mock('../components/Guess/SpeedRing', () => {
+  return function MockSpeedRing(props) {
+    mockSpeedRing(props);
     return null;
   };
-});
-
-jest.mock('react-native', () => {
-  const actualRN = jest.requireActual('react-native');
-  const noopAnimation = { start: () => {}, stop: () => {}, reset: () => {} };
-  actualRN.Animated.loop = () => noopAnimation;
-  actualRN.Animated.parallel = () => noopAnimation;
-  actualRN.Animated.sequence = () => noopAnimation;
-  actualRN.Animated.timing = () => noopAnimation;
-  actualRN.Animated.delay = () => noopAnimation;
-  return actualRN;
 });
 
 import React from 'react';
-import { StyleSheet } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
 import ShowPicture from '../components/Picture/ShowPicture';
 
+function findByTestID(renderer, testID) {
+  return renderer.root.findByProps({ testID });
+}
+
+function findAllByType(renderer, type) {
+  return renderer.root.findAllByType(type);
+}
+
 describe('ShowPicture', () => {
   const baseProps = {
-    uri: 'file:///fixture.jpg',
-    guess: false,
-    description: 'Look near the tree.',
-    touchLocation: null,
+    uri: 'file:///pic.jpg',
+    guess: true,
+    description: 'Find it',
+    touchLocation: { x: '0.5', y: '0.5' },
     handlePress: jest.fn(),
     handleLongPress: jest.fn(),
-    target: null,
+    target: {
+      targetSize: 16,
+      dragSize: 32,
+      dragStyle: { position: 'absolute', left: 100, top: 50, width: 32, height: 32 },
+    },
     handleIconPress: jest.fn(),
     showModal: false,
     handleConfirm: jest.fn(),
     onCancel: jest.fn(),
-    imageDimensionStyle: { width: 240, height: 160 },
+    imageDimensionStyle: { width: 200, height: 400 },
+    targetGesture: { __id: 'target-pan-gesture' },
+    defaultOpen: false,
+    onDescriptionClosed: jest.fn(),
+    onEdgeSwipe: jest.fn(),
   };
 
+  function renderShowPicture(overrides = {}) {
+    let renderer;
+    act(() => {
+      renderer = create(<ShowPicture {...baseProps} {...overrides} />);
+    });
+    return renderer;
+  }
+
   beforeEach(() => {
-    jest.useFakeTimers();
     jest.clearAllMocks();
   });
 
-  afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
+  it('wraps the picture surface in a GestureDetector carrying the Race(edgeSwipe, handleSwipe) surface gesture', () => {
+    const renderer = renderShowPicture();
+    const detectors = findAllByType(renderer, 'GestureDetector');
+    expect(detectors.length).toBeGreaterThanOrEqual(2);
+
+    // The OUTER detector wraps the surface (pressable); its gesture is a Race.
+    const surfaceDetector = detectors.find((d) => {
+      const g = d.props.gesture;
+      return g && g.__type === 'race';
+    });
+    expect(surfaceDetector).toBeTruthy();
+    const race = surfaceDetector.props.gesture;
+    expect(race.gestures.length).toBe(2);
   });
 
-  it('keeps the clear icon hidden until a point has been selected', async () => {
-    let renderer;
+  it('wraps the target circle in an INNER GestureDetector carrying the target drag gesture from props', () => {
+    const renderer = renderShowPicture();
+    const detectors = findAllByType(renderer, 'GestureDetector');
+    const targetDetector = detectors.find((d) => d.props.gesture === baseProps.targetGesture);
+    expect(targetDetector).toBeTruthy();
+    expect(() => findByTestID(renderer, 'game.picture.guess-target-wrap')).not.toThrow();
+  });
 
-    await act(async () => {
-      renderer = create(<ShowPicture {...baseProps} />);
+  it('preserves the e2e Pressable on the surface (onPress/onLongPress)', () => {
+    const renderer = renderShowPicture();
+    const surface = findByTestID(renderer, 'game.picture.guess-surface');
+    expect(surface.props.onPress).toBe(baseProps.handlePress);
+    expect(surface.props.onLongPress).toBe(baseProps.handleLongPress);
+  });
+
+  it('passes isOpen={enigmaOpen} and onClose to EnigmaOverlay (controlled) and starts closed by default', () => {
+    const renderer = renderShowPicture();
+    const calls = mockEnigmaOverlay.mock.calls;
+    const last = calls[calls.length - 1][0];
+    expect(last.isOpen).toBe(false);
+    expect(last.description).toBe('Find it');
+    expect(last.screenHeight).toBe(400);
+    expect(typeof last.onClose).toBe('function');
+  });
+
+  it('initial enigmaOpen mirrors defaultOpen=true', () => {
+    const renderer = renderShowPicture({ defaultOpen: true });
+    const last = mockEnigmaOverlay.mock.calls[mockEnigmaOverlay.mock.calls.length - 1][0];
+    expect(last.isOpen).toBe(true);
+  });
+
+  it('flips enigmaOpen=true when defaultOpen flips from false to true (existing-instance sync)', () => {
+    let renderer;
+    act(() => {
+      renderer = create(<ShowPicture {...baseProps} defaultOpen={false} />);
+    });
+    let last = mockEnigmaOverlay.mock.calls[mockEnigmaOverlay.mock.calls.length - 1][0];
+    expect(last.isOpen).toBe(false);
+
+    act(() => {
+      renderer.update(<ShowPicture {...baseProps} defaultOpen={true} />);
     });
 
-    expect(renderer.root.findAllByProps({ testID: 'game.picture.clear-hide' })).toHaveLength(0);
+    last = mockEnigmaOverlay.mock.calls[mockEnigmaOverlay.mock.calls.length - 1][0];
+    expect(last.isOpen).toBe(true);
   });
 
-  it('uses an image-sized press surface and forwards press handlers', async () => {
-    const handlePress = jest.fn();
-    const handleLongPress = jest.fn();
+  it('EnigmaOverlay onClose calls onDescriptionClosed AND closes (isOpen flips false)', () => {
+    const onDescriptionClosed = jest.fn();
     let renderer;
-
-    await act(async () => {
+    act(() => {
       renderer = create(
-        <ShowPicture
-          {...baseProps}
-          guess={true}
-          handlePress={handlePress}
-          handleLongPress={handleLongPress}
-          imageDimensionStyle={{ width: 320, height: 180 }}
-        />
+        <ShowPicture {...baseProps} defaultOpen={true} onDescriptionClosed={onDescriptionClosed} />,
       );
     });
+    let last = mockEnigmaOverlay.mock.calls[mockEnigmaOverlay.mock.calls.length - 1][0];
+    expect(last.isOpen).toBe(true);
 
-    const surface = renderer.root.findByProps({ testID: 'game.picture.guess-surface' });
-    const flattenedStyle = StyleSheet.flatten(surface.props.style);
-
-    expect(flattenedStyle.position).toBe('absolute');
-
-    await act(async () => {
-      surface.props.onPress();
-      surface.props.onLongPress();
+    act(() => {
+      last.onClose();
     });
 
-    expect(handlePress).toHaveBeenCalledTimes(1);
-    expect(handleLongPress).toHaveBeenCalledTimes(1);
+    expect(onDescriptionClosed).toHaveBeenCalledTimes(1);
+    last = mockEnigmaOverlay.mock.calls[mockEnigmaOverlay.mock.calls.length - 1][0];
+    expect(last.isOpen).toBe(false);
   });
 
-  it('attaches the target pan handlers to the wrapping view when a target is set', async () => {
-    const onResponderGrant = jest.fn();
-    const targetPanHandlers = { onResponderGrant };
-    const target = {
-      targetSize: 16,
-      targetStyle: { position: 'absolute', width: 16, height: 16, left: 40, top: 20 },
-      dragSize: 32,
-      dragStyle: {
-        position: 'absolute',
-        width: 32,
-        height: 32,
-        left: 32,
-        top: 12,
-        borderRadius: 16,
-        alignItems: 'center',
-        justifyContent: 'center',
-      },
-    };
-    let renderer;
-
-    await act(async () => {
-      renderer = create(
-        <ShowPicture
-          {...baseProps}
-          guess={true}
-          touchLocation={{ x: '0.50', y: '0.50' }}
-          target={target}
-          targetPanHandlers={targetPanHandlers}
-        />
-      );
-    });
-
-    const wrapper = renderer.root.findByProps({ testID: 'game.picture.guess-target-wrap' });
-    expect(wrapper.props.onResponderGrant).toBe(onResponderGrant);
-    const flattenedStyle = StyleSheet.flatten(wrapper.props.style);
-    expect(flattenedStyle.width).toBe(32);
-    expect(flattenedStyle.borderRadius).toBe(16);
-    expect(flattenedStyle.borderColor).toBe('#6528F7');
-
-    const icon = renderer.root.findByProps({ testID: 'game.picture.clear-guess' });
-    expect(icon).toBeTruthy();
-  });
-
-  it('animates the drag ring as a pulsar when pulseTarget is true and stops when false', async () => {
-    const target = {
-      targetSize: 16,
-      targetStyle: { position: 'absolute', width: 16, height: 16, left: 40, top: 20 },
-      dragSize: 32,
-      dragStyle: {
-        position: 'absolute',
-        width: 32,
-        height: 32,
-        left: 32,
-        top: 12,
-        borderRadius: 16,
-        alignItems: 'center',
-        justifyContent: 'center',
-      },
-    };
-    let renderer;
-
-    await act(async () => {
-      renderer = create(
-        <ShowPicture
-          {...baseProps}
-          guess={true}
-          touchLocation={{ x: '0.50', y: '0.50' }}
-          target={target}
-          targetPanHandlers={{}}
-          pulseTarget={true}
-        />
-      );
-    });
-
-    const wrapper = renderer.root.findByProps({ testID: 'game.picture.guess-target-wrap' });
-    const activeFlattenedStyle = StyleSheet.flatten(wrapper.props.style);
-    expect(activeFlattenedStyle.borderColor).toBe('#6528F7');
-    expect(activeFlattenedStyle.transform).toBeDefined();
-
-    await act(async () => {
-      renderer.update(
-        <ShowPicture
-          {...baseProps}
-          guess={true}
-          touchLocation={{ x: '0.50', y: '0.50' }}
-          target={target}
-          targetPanHandlers={{}}
-          pulseTarget={false}
-        />
-      );
-    });
-
-    const inactiveFlattenedStyle = StyleSheet.flatten(
-      renderer.root.findByProps({ testID: 'game.picture.guess-target-wrap' }).props.style
-    );
-    expect(inactiveFlattenedStyle.transform).toBeUndefined();
+  it('still renders the target wrap, modal, and image when guessing (testIDs preserved)', () => {
+    const renderer = renderShowPicture({ showModal: true });
+    expect(() => findByTestID(renderer, 'game.picture.guess-surface')).not.toThrow();
+    expect(() => findByTestID(renderer, 'game.picture.guess-image')).not.toThrow();
+    expect(() => findByTestID(renderer, 'game.picture.guess-target-wrap')).not.toThrow();
+    expect(() => findByTestID(renderer, 'game.picture.guess-modal')).not.toThrow();
   });
 });

--- a/__tests__/ShowPicture.test.js
+++ b/__tests__/ShowPicture.test.js
@@ -3,6 +3,9 @@ const mockIconButton = jest.fn(() => null);
 const mockSpeedRing = jest.fn(() => null);
 const mockCenteredModal = jest.fn(() => null);
 
+let mockCapturedPanRecord;
+let mockCapturedPan;
+
 jest.mock('react-native', () => {
   const React = require('react');
 
@@ -63,6 +66,25 @@ jest.mock('react-native', () => {
 
 jest.mock('react-native-gesture-handler', () => {
   const React = jest.requireActual('react');
+
+  function makeChainable() {
+    const record = { __type: 'pan', calls: [] };
+    const handler = {
+      get(_t, prop) {
+        if (prop === '__type' || prop === 'calls') return record[prop];
+        if (prop === 'then') return undefined;
+        return (...args) => {
+          record.calls.push({ method: prop, args });
+          return proxy;
+        };
+      },
+    };
+    const proxy = new Proxy(record, handler);
+    mockCapturedPanRecord = record;
+    mockCapturedPan = proxy;
+    return proxy;
+  }
+
   return {
     Gesture: {
       Pan: () => makeChainable(),
@@ -75,17 +97,6 @@ jest.mock('react-native-gesture-handler', () => {
     GestureHandlerRootView: ({ children, ...props }) =>
       React.createElement('GestureHandlerRootView', props, children),
   };
-
-  function makeChainable() {
-    const obj = function ChainableGesture() {};
-    const proxy = new Proxy(obj, {
-      get(_t, prop) {
-        if (prop === 'then') return undefined;
-        return (..._args) => proxy;
-      },
-    });
-    return proxy;
-  }
 });
 
 jest.mock('../components/Picture/Descriptions/EnigmaOverlay', () => {
@@ -164,21 +175,17 @@ describe('ShowPicture', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCapturedPanRecord = undefined;
+    mockCapturedPan = undefined;
   });
 
-  it('wraps the picture surface in a GestureDetector carrying the Race(edgeSwipe, handleSwipe) surface gesture', () => {
+  it('wraps the picture surface in a GestureDetector carrying a single Pan surface-swipe gesture', () => {
     const renderer = renderShowPicture();
     const detectors = findAllByType(renderer, 'GestureDetector');
     expect(detectors.length).toBeGreaterThanOrEqual(2);
-
-    // The OUTER detector wraps the surface (pressable); its gesture is a Race.
-    const surfaceDetector = detectors.find((d) => {
-      const g = d.props.gesture;
-      return g && g.__type === 'race';
-    });
+    const surfaceDetector = detectors.find((d) => d.props.gesture === mockCapturedPan);
     expect(surfaceDetector).toBeTruthy();
-    const race = surfaceDetector.props.gesture;
-    expect(race.gestures.length).toBe(2);
+    expect(mockCapturedPanRecord.__type).toBe('pan');
   });
 
   it('wraps the target circle in an INNER GestureDetector carrying the target drag gesture from props', () => {
@@ -254,5 +261,67 @@ describe('ShowPicture', () => {
     expect(() => findByTestID(renderer, 'game.picture.guess-image')).not.toThrow();
     expect(() => findByTestID(renderer, 'game.picture.guess-target-wrap')).not.toThrow();
     expect(() => findByTestID(renderer, 'game.picture.guess-modal')).not.toThrow();
+  });
+
+  describe('surface swipe dispatch', () => {
+    function getOnEnd() {
+      return mockCapturedPanRecord.calls.find((c) => c.method === 'onEnd').args[0];
+    }
+
+    function latestEnigmaProps() {
+      return mockEnigmaOverlay.mock.calls[mockEnigmaOverlay.mock.calls.length - 1][0];
+    }
+
+    it('up-swipe opens the enigma and does NOT trigger onEdgeSwipe', () => {
+      const onEdgeSwipe = jest.fn();
+      renderShowPicture({ defaultOpen: false, onEdgeSwipe });
+
+      const onEnd = getOnEnd();
+      act(() => {
+        onEnd({ translationX: 4, translationY: -60 }, true);
+      });
+
+      expect(latestEnigmaProps().isOpen).toBe(true);
+      expect(onEdgeSwipe).not.toHaveBeenCalled();
+    });
+
+    it('right-swipe triggers onEdgeSwipe and keeps the enigma closed', () => {
+      const onEdgeSwipe = jest.fn();
+      renderShowPicture({ defaultOpen: false, onEdgeSwipe });
+
+      const onEnd = getOnEnd();
+      act(() => {
+        onEnd({ translationX: 70, translationY: 2 }, true);
+      });
+
+      expect(onEdgeSwipe).toHaveBeenCalledTimes(1);
+      expect(latestEnigmaProps().isOpen).toBe(false);
+    });
+
+    it('unsuccessful gesture is ignored', () => {
+      const onEdgeSwipe = jest.fn();
+      renderShowPicture({ defaultOpen: false, onEdgeSwipe });
+
+      const onEnd = getOnEnd();
+      act(() => {
+        onEnd({ translationX: 70, translationY: -60 }, false);
+      });
+
+      expect(onEdgeSwipe).not.toHaveBeenCalled();
+      expect(latestEnigmaProps().isOpen).toBe(false);
+    });
+
+    it('up takes priority on a diagonal up+right swipe (regression for the reported bug)', () => {
+      const onEdgeSwipe = jest.fn();
+      renderShowPicture({ defaultOpen: false, onEdgeSwipe });
+
+      const onEnd = getOnEnd();
+      act(() => {
+        onEnd({ translationX: 80, translationY: -70 }, true);
+      });
+
+      expect(latestEnigmaProps().isOpen).toBe(true);
+      expect(onEdgeSwipe).not.toHaveBeenCalled();
+    });
   });
 });

--- a/__tests__/SwipeImage.test.js
+++ b/__tests__/SwipeImage.test.js
@@ -219,7 +219,7 @@ describe('SwipeImage', () => {
 
     await renderSwipeImage();
 
-    expect(getImages).toHaveBeenCalledWith(null, contextValue, { category_id: undefined, category_key: 'all', language: undefined });
+    expect(getImages).toHaveBeenCalledWith(null, contextValue, { language: undefined, scope: undefined });
     expect(storeImageList).toHaveBeenCalledWith([
       expect.objectContaining({ pictureId: 'img-1', listId: 5 }),
       expect.objectContaining({ pictureId: 'img-2', listId: 6 }),
@@ -239,7 +239,7 @@ describe('SwipeImage', () => {
 
     await renderSwipeImage();
 
-    expect(getImages).toHaveBeenCalledWith(null, contextValue, { category_id: undefined, category_key: 'all', language: undefined });
+    expect(getImages).toHaveBeenCalledWith(null, contextValue, { language: undefined, scope: undefined });
     expect(storeImageList).toHaveBeenCalledWith([
       expect.objectContaining({ pictureId: 'img-1', listId: 1 }),
     ], 'all', 'any');
@@ -278,7 +278,7 @@ describe('SwipeImage', () => {
     expect(getImages).toHaveBeenCalledWith(
       null,
       contextValue,
-      { category_id: undefined, category_key: 'all', language: undefined }
+      { language: undefined, scope: undefined }
     );
   });
 
@@ -1022,7 +1022,7 @@ describe('SwipeImage — deck-empty fallback to "all"', () => {
     expect(getImages).toHaveBeenCalledWith(
       null,
       expect.anything(),
-      expect.objectContaining({ category_key: 'nature', category_id: 'cat-nature' }),
+      { language: undefined, scope: undefined, category_key: 'nature' },
     );
     expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).not.toContain('all-1');
   });

--- a/__tests__/cardDeck.test.js
+++ b/__tests__/cardDeck.test.js
@@ -396,9 +396,75 @@ describe('fetchCardBatch', () => {
     expect(getImages).toHaveBeenCalledWith(
       null,
       { token: 't' },
-      expect.objectContaining({ language: undefined, category_key: 'nature', category_id: 'cat-nature' }),
+      expect.objectContaining({ language: undefined, category_key: 'nature' }),
     );
+    // B2: PUBLIC scope must NOT send category_id (bundled keys replace UUIDs).
+    expect(getImages.mock.calls[0][2]).not.toHaveProperty('category_id');
     expect(getImages.mock.calls[0][2].language).not.toBe('any');
+  });
+
+  it('B2: PUBLIC scope sends category_key only; PRIVATE scope keeps category_id', async () => {
+    // PUBLIC: categoryKey threads through as category_key; categoryId is
+    // dropped (bundled public categories carry no server UUID anymore).
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+    });
+    const publicFilters = getImages.mock.calls[0][2];
+    expect(publicFilters).toMatchObject({ category_key: 'nature' });
+    expect(publicFilters).not.toHaveProperty('category_id');
+
+    jest.clearAllMocks();
+    getLastImageUuid.mockResolvedValue(null);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+
+    // PRIVATE: categoryId threads through as category_id (UUID unchanged); no
+    // category_key leaks on the private path (byte-equivalent to pre-B2).
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-private-uuid',
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-1' },
+      authContext: { token: 't' },
+    });
+    const privateFilters = getImages.mock.calls[0][2];
+    expect(privateFilters).toMatchObject({ category_id: 'cat-private-uuid' });
+    expect(privateFilters).not.toHaveProperty('category_key');
+  });
+
+  it('private cursor round-trip: reads the persisted cursor under the private category id namespace', async () => {
+    // Regression: buildFeedFilters omits category_key for private scopes, so
+    // the write path (getImages → fetchPrivateFeedPageForGame) must derive the
+    // cursor namespace from category_id. The READ side here must query the
+    // SAME namespace (the private category id, not 'all') or the private
+    // cursor never round-trips and pagination stalls at page 1.
+    await fetchCardBatch({
+      categoryKey: 'cat-private-uuid',
+      categoryId: 'cat-private-uuid',
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-1' },
+      authContext: { token: 't' },
+    });
+
+    expect(getLastImageUuid).toHaveBeenCalledWith('cat-private-uuid', 'fr');
+    expect(getImages.mock.calls[0][2]).toMatchObject({ category_id: 'cat-private-uuid' });
+  });
+
+  it('B2: PUBLIC "all" pseudo-category sends neither category_key nor category_id', async () => {
+    await fetchCardBatch({
+      categoryKey: 'all',
+      categoryId: undefined,
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+    });
+
+    const filters = getImages.mock.calls[0][2];
+    expect(filters).not.toHaveProperty('category_key');
+    expect(filters).not.toHaveProperty('category_id');
   });
 
   it('forwards a real language code untouched', async () => {

--- a/__tests__/categoryRequests.test.js
+++ b/__tests__/categoryRequests.test.js
@@ -2,11 +2,6 @@ jest.mock('axios', () => ({
   get: jest.fn(),
 }));
 
-jest.mock('../utils/auth', () => ({
-  getBackendHeaders: jest.fn(),
-  setHeaders: jest.fn(),
-}));
-
 jest.mock('../utils/e2eMode', () => ({
   buildE2ECategories: jest.fn(),
   isE2EMode: jest.fn(),
@@ -14,71 +9,60 @@ jest.mock('../utils/e2eMode', () => ({
 
 import axios from 'axios';
 
-import { getBackendHeaders, setHeaders } from '../utils/auth';
 import { buildE2ECategories, isE2EMode } from '../utils/e2eMode';
 import { getCategories } from '../utils/categoryRequests';
+import { DEFAULT_CATEGORIES } from '../constants/defaultCategories';
+
+const EXPECTED_BUNDLED_KEYS = [
+  'other',
+  'nature',
+  'city',
+  'abstract',
+  'animals',
+  'food',
+  'vehicles',
+  'interiors',
+  'landmarks',
+];
 
 describe('categoryRequests utilities', () => {
+  const originalE2EMode = process.env.EXPO_PUBLIC_E2E_MODE;
+
   beforeEach(() => {
     jest.clearAllMocks();
     isE2EMode.mockReturnValue(false);
     buildE2ECategories.mockReturnValue([
       { id: 'e2e-default-category', key: 'all', name: 'Recent/All', thumbnailUrl: null, count: undefined },
     ]);
-    process.env.EXPO_PUBLIC_APP_BACKEND_URL = 'https://backend.example/';
-    getBackendHeaders.mockResolvedValue({
-      token: 'Bearer token',
-      userId: '42',
-      scoreId: 'score-1',
-    });
-    setHeaders.mockReturnValue({ Authorization: 'Bearer token' });
+    delete process.env.EXPO_PUBLIC_E2E_MODE;
   });
 
-  it('returns normalized camelCase categories on a successful request', async () => {
-    axios.get.mockResolvedValue({
-      status: 200,
-      data: [
-        {
-          id: 'cat-1',
-          key: 'nature',
-          name: 'Nature',
-          thumbnail_url: 'https://cdn.example/thumb.png',
-          sort_order: 3,
-        },
-      ],
-    });
+  afterAll(() => {
+    process.env.EXPO_PUBLIC_E2E_MODE = originalE2EMode;
+  });
 
+  it('returns the bundled default categories without any network call', async () => {
     const response = await getCategories({ context: { token: 'Bearer token' } });
 
-    expect(axios.get).toHaveBeenCalledWith(
-      'https://backend.example/api/v1/categories',
-      { headers: { Authorization: 'Bearer token' } }
-    );
+    expect(axios.get).not.toHaveBeenCalled();
     expect(response).toEqual({
-      data: [
-        {
-          id: 'cat-1',
-          key: 'nature',
-          name: 'Nature',
-          thumbnailUrl: 'https://cdn.example/thumb.png',
-          sortOrder: 3,
-        },
-      ],
+      data: DEFAULT_CATEGORIES.map((category) => expect.objectContaining({
+        key: category.key,
+        name: category.name,
+        sortOrder: category.sortOrder,
+        thumbnailUrl: expect.anything(),
+      })),
+    });
+    expect(response.data).toHaveLength(EXPECTED_BUNDLED_KEYS.length);
+    expect(response.data.map((category) => category.key)).toEqual(EXPECTED_BUNDLED_KEYS);
+    response.data.forEach((category) => {
+      expect(category).not.toHaveProperty('id');
     });
   });
 
-  it('maps non-2xx failures into isError without throwing', async () => {
-    axios.get.mockRejectedValue({
-      request: { status: 500 },
-      message: 'Request failed with status code 500',
-    });
-
-    const response = await getCategories({ context: { token: 'Bearer token' } });
-
-    expect(response).toEqual({
-      isError: true,
-      message: 'Request failed with status code 500',
-    });
+  it('exposes exactly the nine bundled default category keys', () => {
+    expect(DEFAULT_CATEGORIES.map((category) => category.key)).toEqual(EXPECTED_BUNDLED_KEYS);
+    expect(DEFAULT_CATEGORIES).toHaveLength(9);
   });
 
   it('returns seeded e2e categories without calling axios when e2e mode is active', async () => {
@@ -90,6 +74,7 @@ describe('categoryRequests utilities', () => {
 
     const response = await getCategories({ context: { token: 'Bearer token' } });
 
+    expect(isE2EMode).toHaveBeenCalled();
     expect(buildE2ECategories).toHaveBeenCalled();
     expect(response).toEqual({
       data: [

--- a/__tests__/fileUploader.test.js
+++ b/__tests__/fileUploader.test.js
@@ -154,6 +154,32 @@ describe('imageUploader', () => {
     expect(result).toEqual({ status: 200 });
   });
 
+  it('B2: public upload threads category_key from imageInfos.categoryKey (no category_id)', async () => {
+    // B2: public uploads switched from category_id (server UUID) to category_key
+    // (bundled string key). The imageInfos payload carries categoryKey now.
+    prepareImageUpload.mockResolvedValue({
+      status: 200,
+      data: {
+        provider: 'local_disk',
+        method: 'PUT',
+        url: 'https://example.com/upload',
+        headers: {},
+        image_key: 'waldo-image',
+      },
+    });
+    performImageUpload.mockResolvedValue({ status: 200 });
+    saveImageInfos.mockResolvedValue({ status: 200 });
+
+    await imageUploader({
+      imageInfos: { ...imageInfos, categoryKey: 'nature' },
+      context,
+    });
+
+    const saveCall = saveImageInfos.mock.calls[0][0].imagesInfos;
+    expect(saveCall.category_key).toBe('nature');
+    expect(saveCall).not.toHaveProperty('category_id');
+  });
+
   it('returns the metadata persistence failure and keeps the local file intact', async () => {
     prepareImageUpload.mockResolvedValue({
       status: 200,

--- a/__tests__/hooks/useGroupCategories.test.js
+++ b/__tests__/hooks/useGroupCategories.test.js
@@ -6,10 +6,15 @@ import { useGroupCategories } from '../../hooks/useGroupCategories';
 import { AuthContext } from '../../store/auth-context';
 
 jest.mock('../../services/groups/groupCategoriesApi', () => ({
-  listGroupCategories: jest.fn(),
   createGroupCategory: jest.fn(),
   updateGroupCategory: jest.fn(),
   deleteGroupCategory: jest.fn(),
+}));
+
+jest.mock('../../services/groups/groupCategoriesStore', () => ({
+  loadGroupCategoriesOptimistic: jest.fn(),
+  refreshGroupCategories: jest.fn(),
+  normalizePrivateCategory: jest.fn((category) => category),
 }));
 
 jest.mock('../../services/groups/groupCategoryThumbnails', () => ({
@@ -22,11 +27,14 @@ jest.mock('../../services/groups/categoryThumbnailUpload', () => ({
 }));
 
 import {
-  listGroupCategories,
   createGroupCategory,
   updateGroupCategory,
   deleteGroupCategory,
 } from '../../services/groups/groupCategoriesApi';
+import {
+  loadGroupCategoriesOptimistic,
+  refreshGroupCategories,
+} from '../../services/groups/groupCategoriesStore';
 import {
   deleteCategoryThumbnailFile,
   resolveCategoryThumbnail,
@@ -57,10 +65,18 @@ async function settle() {
   });
 }
 
+function optimisticFrom(cached, fresh) {
+  return async ({ onCategories }) => {
+    if (cached) onCategories(cached);
+    if (fresh && fresh !== cached) onCategories(fresh);
+  };
+}
+
 describe('useGroupCategories', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    resolveCategoryThumbnail.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -69,13 +85,10 @@ describe('useGroupCategories', () => {
 
   it('loads categories, seeds drafts, and resolves thumbnails only for categories with an image id', async () => {
     resolveCategoryThumbnail.mockResolvedValue('file:///cat-1.webp');
-    listGroupCategories.mockResolvedValue({
-      status: 200,
-      data: [
-        { id: 'cat-1', name: 'Nature', thumbnail_image_id: 'img-1' },
-        { id: 'cat-2', name: 'City' },
-      ],
-    });
+    loadGroupCategoriesOptimistic.mockImplementation(optimisticFrom(null, [
+      { id: 'cat-1', name: 'Nature', thumbnail_image_id: 'img-1' },
+      { id: 'cat-2', name: 'City' },
+    ]));
 
     const { result } = renderCategories();
 
@@ -83,6 +96,9 @@ describe('useGroupCategories', () => {
 
     expect(result.current.categories).toHaveLength(2);
     expect(result.current.drafts).toEqual({ 'cat-1': 'Nature', 'cat-2': 'City' });
+
+    await settle();
+
     expect(result.current.thumbnailUris).toEqual({ 'cat-1': 'file:///cat-1.webp', 'cat-2': null });
     expect(resolveCategoryThumbnail).toHaveBeenCalledTimes(1);
     expect(resolveCategoryThumbnail).toHaveBeenCalledWith(
@@ -91,23 +107,69 @@ describe('useGroupCategories', () => {
     );
   });
 
-  it('exposes the error payload and clears loading when the index request fails', async () => {
-    listGroupCategories.mockResolvedValue({ status: 500, data: { error: 'boom' } });
+  it('renders cached categories first, then replaces state when the fresh payload differs', async () => {
+    const cached = [{ id: 'cat-1', name: 'Nature' }];
+    const fresh = [
+      { id: 'cat-1', name: 'Nature' },
+      { id: 'cat-2', name: 'City' },
+    ];
+    loadGroupCategoriesOptimistic.mockImplementation(async ({ onCategories }) => {
+      onCategories(cached);
+      onCategories(fresh);
+    });
 
     const { result } = renderCategories();
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(result.current.categories).toEqual(fresh));
 
-    expect(result.current.error).toEqual({ error: 'boom' });
-    expect(result.current.categories).toEqual([]);
+    expect(result.current.categories).toEqual(fresh);
+    expect(result.current.drafts).toEqual({ 'cat-1': 'Nature', 'cat-2': 'City' });
   });
 
-  it('creates a category from the new-name draft, clears it, and reloads', async () => {
-    listGroupCategories.mockResolvedValue({ status: 200, data: [] });
-    createGroupCategory.mockResolvedValue({ status: 201, data: {} });
+  it('does not double-write state when optimistic payload equals fresh (store dedups)', async () => {
+    const same = [{ id: 'cat-1', name: 'Nature', thumbnail_image_id: 'img-1' }];
+    loadGroupCategoriesOptimistic.mockImplementation(async ({ onCategories }) => {
+      onCategories(same);
+    });
 
     const { result } = renderCategories();
+
+    await waitFor(() => expect(result.current.categories).toEqual(same));
+
+    expect(result.current.drafts).toEqual({ 'cat-1': 'Nature' });
+    expect(resolveCategoryThumbnail).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears initial loading once the first categories arrive, avoiding flicker on later reloads', async () => {
+    loadGroupCategoriesOptimistic.mockImplementation(optimisticFrom(null, [
+      { id: 'cat-1', name: 'Nature' },
+    ]));
+
+    const { result } = renderCategories();
+
     await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.loading).toBe(false);
+
+    const loadingDuringReload = result.current.loading;
+    await act(async () => {
+      await result.current.reload();
+    });
+    expect(loadingDuringReload).toBe(false);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('after a successful add, write-through refreshes via the store and updates state from its data', async () => {
+    const initial = [{ id: 'cat-1', name: 'Nature' }];
+    const afterAdd = [
+      { id: 'cat-1', name: 'Nature' },
+      { id: 'cat-2', name: 'Animals' },
+    ];
+    loadGroupCategoriesOptimistic.mockImplementation(optimisticFrom(null, initial));
+    createGroupCategory.mockResolvedValue({ status: 201, data: {} });
+    refreshGroupCategories.mockResolvedValue({ data: afterAdd });
+
+    const { result } = renderCategories();
+    await waitFor(() => expect(result.current.categories).toEqual(initial));
 
     act(() => result.current.setNewCategoryName('Animals'));
 
@@ -122,11 +184,34 @@ describe('useGroupCategories', () => {
       'g-1',
       { name: 'Animals' },
     );
+    expect(refreshGroupCategories).toHaveBeenCalledWith({ context: expect.anything(), groupId: 'g-1' });
+    expect(result.current.categories).toEqual(afterAdd);
+    expect(result.current.drafts).toEqual({ 'cat-1': 'Nature', 'cat-2': 'Animals' });
     expect(result.current.newCategoryName).toBe('');
   });
 
+  it('alerts and leaves state intact when create fails', async () => {
+    const initial = [{ id: 'cat-1', name: 'Nature' }];
+    loadGroupCategoriesOptimistic.mockImplementation(optimisticFrom(null, initial));
+    createGroupCategory.mockResolvedValue({ status: 500 });
+
+    const { result } = renderCategories();
+    await waitFor(() => expect(result.current.categories).toEqual(initial));
+
+    act(() => result.current.setNewCategoryName('Animals'));
+
+    await act(async () => {
+      await result.current.add();
+    });
+
+    expect(Alert.alert).toHaveBeenCalled();
+    expect(result.current.categories).toEqual(initial);
+    expect(refreshGroupCategories).not.toHaveBeenCalled();
+  });
+
   it('skips the PATCH when the draft equals the saved name and updates when dirty', async () => {
-    listGroupCategories.mockResolvedValue({ status: 200, data: [{ id: 'cat-1', name: 'Nature' }] });
+    const initial = [{ id: 'cat-1', name: 'Nature' }];
+    loadGroupCategoriesOptimistic.mockImplementation(optimisticFrom(null, initial));
 
     const { result } = renderCategories();
     await waitFor(() => expect(result.current.loading).toBe(false));
@@ -137,8 +222,9 @@ describe('useGroupCategories', () => {
     });
     expect(updateGroupCategory).not.toHaveBeenCalled();
 
-    // Dirty draft -> PATCH.
+    // Dirty draft -> PATCH + write-through.
     updateGroupCategory.mockResolvedValue({ status: 200, data: {} });
+    refreshGroupCategories.mockResolvedValue({ data: [{ id: 'cat-1', name: 'Nature 2' }] });
     act(() => result.current.setDraft('cat-1', 'Nature 2'));
 
     await act(async () => {
@@ -153,11 +239,14 @@ describe('useGroupCategories', () => {
       'cat-1',
       { name: 'Nature 2' },
     );
+    expect(refreshGroupCategories).toHaveBeenCalledWith({ context: expect.anything(), groupId: 'g-1' });
   });
 
-  it('deletes the category (after confirming the alert) and reloads', async () => {
-    listGroupCategories.mockResolvedValue({ status: 200, data: [{ id: 'cat-1', name: 'Nature' }] });
+  it('deletes the category (after confirming the alert) and write-through refreshes', async () => {
+    const initial = [{ id: 'cat-1', name: 'Nature' }];
+    loadGroupCategoriesOptimistic.mockImplementation(optimisticFrom(null, initial));
     deleteGroupCategory.mockResolvedValue({ status: 204 });
+    refreshGroupCategories.mockResolvedValue({ data: [] });
 
     // Auto-confirm the destructive alert button.
     Alert.alert.mockImplementation((_title, _msg, buttons) => {
@@ -175,14 +264,18 @@ describe('useGroupCategories', () => {
     });
 
     expect(deleteGroupCategory).toHaveBeenCalledWith(expect.anything(), 'g-1', 'cat-1');
-    expect(listGroupCategories).toHaveBeenCalledTimes(2);
+    expect(refreshGroupCategories).toHaveBeenCalledWith({ context: expect.anything(), groupId: 'g-1' });
+    expect(result.current.categories).toEqual([]);
   });
 
   it('swaps the thumbnail, purges the old cache file first, then updates + refreshes', async () => {
     const category = { id: 'cat-1', name: 'Nature', thumbnail_image_id: 'old-thumb' };
-    listGroupCategories.mockResolvedValue({ status: 200, data: [category] });
+    loadGroupCategoriesOptimistic.mockImplementation(optimisticFrom(null, [category]));
     uploadCategoryThumbnail.mockResolvedValue({ imageId: 'img-new' });
     updateGroupCategory.mockResolvedValue({ status: 200, data: {} });
+    refreshGroupCategories.mockResolvedValue({
+      data: [{ ...category, thumbnail_image_id: 'img-new' }],
+    });
 
     const onRefresh = jest.fn();
     const { result } = renderCategories({ onRefresh });
@@ -202,11 +295,14 @@ describe('useGroupCategories', () => {
     expect(updateGroupCategory).toHaveBeenCalledWith(expect.anything(), 'g-1', 'cat-1', {
       thumbnailImageId: 'img-new',
     });
+    expect(refreshGroupCategories).toHaveBeenCalledWith({ context: expect.anything(), groupId: 'g-1' });
     expect(onRefresh).toHaveBeenCalled();
     expect(result.current.isSwappingThumbnail).toBe(false);
   });
 
   it('does nothing when swapThumbnail receives a category without an id', async () => {
+    loadGroupCategoriesOptimistic.mockImplementation(optimisticFrom(null, []));
+
     const { result } = renderCategories();
     await waitFor(() => expect(result.current.loading).toBe(false));
 

--- a/__tests__/imagesRequests.test.js
+++ b/__tests__/imagesRequests.test.js
@@ -374,6 +374,89 @@ describe('imagesRequests utilities', () => {
     expect(saveLastImageUuid).toHaveBeenCalledWith('img-1', 'nature', 'fr');
   });
 
+  it('B2: threads category_key into the public image batch query params (no category_id)', async () => {
+    axios.get.mockResolvedValueOnce({ data: { data: [] } });
+
+    await getImages(null, { token: 'Bearer token' }, { category_key: 'nature', language: 'fr' });
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://backend.example/api/v1/users/42/get_image_batch',
+      {
+        headers: { Authorization: 'Bearer token' },
+        params: { category_key: 'nature', language: 'fr' },
+        timeout: 15000,
+      }
+    );
+    // B2: public path must NOT leak category_id when only category_key is supplied.
+    expect(axios.get.mock.calls[0][1].params).not.toHaveProperty('category_id');
+  });
+
+  it('B2: threads category_key into the next image batch body (public pagination)', async () => {
+    axios.post.mockResolvedValueOnce({ data: { data: [] } });
+
+    await getImages('first-img', { token: 'Bearer token' }, { category_key: 'nature', language: 'fr' });
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://backend.example/api/v1/users/42/next_image_batch',
+      { image: { name: 'first-img', category_key: 'nature', language: 'fr' } },
+      { headers: { Authorization: 'Bearer token' }, timeout: 15000 }
+    );
+    expect(axios.post.mock.calls[0][1].image).not.toHaveProperty('category_id');
+  });
+
+  it('B2: sends neither category_key nor category_id when filters omit them (legacy full feed)', async () => {
+    axios.get.mockResolvedValueOnce({ data: { data: [] } });
+
+    await getImages(null, { token: 'Bearer token' }, { language: 'fr' });
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://backend.example/api/v1/users/42/get_image_batch',
+      {
+        headers: { Authorization: 'Bearer token' },
+        params: { language: 'fr' },
+        timeout: 15000,
+      }
+    );
+    expect(axios.get.mock.calls[0][1].params).not.toHaveProperty('category_key');
+    expect(axios.get.mock.calls[0][1].params).not.toHaveProperty('category_id');
+  });
+
+  it('private scope: namespaces the cursor with the private category id so it round-trips with getLastImageUuid', async () => {
+    // Regression: private filters carry no category_key (server contract stays
+    // category_id), so the private delegation must derive the LOCAL cursor
+    // namespace from category_id. Writing under 'all' (the storageDatum
+    // fallback for undefined) never matched the read side
+    // (getLastImageUuid(<privateId>)) and polluted the public 'all' cursor.
+    axios.get
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { images: [{ id: 'img-1', name: 'img-1' }], next_cursor: 'cursor-9' },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { data: { url: 'https://backend.example/storage/img-1' } },
+      })
+      .mockResolvedValueOnce({ data: 'data:image/png;base64,Z29vZGJ5ZQ==' });
+
+    const response = await getImages(null, { token: 'Bearer token' }, {
+      category_id: 'cat-private-uuid',
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-3' },
+    });
+
+    expect(axios.get).toHaveBeenNthCalledWith(
+      1,
+      'https://backend.example/api/v1/private_groups/g-3/images/',
+      {
+        headers: { Authorization: 'Bearer token' },
+        params: { category_id: 'cat-private-uuid', language: 'fr' },
+      }
+    );
+    expect(response.isError).toBe(false);
+    expect(saveLastImageUuid).toHaveBeenCalledTimes(1);
+    expect(saveLastImageUuid).toHaveBeenCalledWith('cursor-9', 'cat-private-uuid', 'fr');
+  });
+
   it('leaves the request unchanged when no filters are provided (legacy full feed)', async () => {
     axios.get.mockResolvedValueOnce({ data: { data: [] } });
 

--- a/__tests__/nextCardAdvancer.test.ts
+++ b/__tests__/nextCardAdvancer.test.ts
@@ -131,11 +131,14 @@ describe('resolveNextCardWithServerFallback', () => {
     expect(result.next).toEqual(A_CARD_RESULT);
     expect(result.reason).toBe('ok');
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    // B2: PUBLIC scope threads categoryKey only; categoryId must NOT be
+    // forwarded (public categories carry no server UUID post-bundling).
     expect(fetchMock).toHaveBeenCalledWith(expect.objectContaining({
       categoryKey: 'city',
-      categoryId: 7,
       language: 'fr',
     }));
+    const fetchArgs = fetchMock.mock.calls[0][0] as { categoryId?: unknown };
+    expect(fetchArgs.categoryId).toBeUndefined();
     expect(appendMock).toHaveBeenCalledTimes(1);
     expect(resolveMock).toHaveBeenCalledTimes(3);
     // No cross-fallback to 'all' — the current category still had server cards.

--- a/__tests__/screens/privateScopeWiring.test.js
+++ b/__tests__/screens/privateScopeWiring.test.js
@@ -34,6 +34,16 @@ jest.mock('../../components/UI/LoadingOverlay', () => () => null);
 
 jest.mock('../../components/Guess/SuccessOverlay', () => () => null);
 
+// GuessScreen renders a localized <GestureHandlerRootView>; stub it so the
+// screen renders under jest (RNGH's real root calls a native install()).
+jest.mock('react-native-gesture-handler', () => {
+  const React = require('react');
+  return {
+    GestureHandlerRootView: ({ children }) =>
+      React.createElement('GestureHandlerRootView', null, children),
+  };
+});
+
 jest.mock('../../utils/handleGuessOutcome', () => ({
   applySuccessSideEffects: jest.fn(),
   resolveNextGuessParams: jest.fn(),

--- a/__tests__/services/groupCategoryCache.test.js
+++ b/__tests__/services/groupCategoryCache.test.js
@@ -1,0 +1,112 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store = new Map();
+
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn((key) => Promise.resolve(store.has(key) ? store.get(key) : null)),
+      setItem: jest.fn((key, value) => {
+        store.set(key, value);
+        return Promise.resolve();
+      }),
+      removeItem: jest.fn((key) => {
+        store.delete(key);
+        return Promise.resolve();
+      }),
+      getAllKeys: jest.fn(() => Promise.resolve(Array.from(store.keys()))),
+      multiRemove: jest.fn((keys) => {
+        for (const key of keys) store.delete(key);
+        return Promise.resolve();
+      }),
+    },
+  };
+});
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  readGroupCategoryCache,
+  writeGroupCategoryCache,
+  clearGroupCategoryCache,
+  clearAllGroupCategoryCaches,
+} from '../../services/groups/groupCategoryCache';
+
+describe('services/groups/groupCategoryCache', () => {
+  beforeEach(() => {
+    AsyncStorage.setItem.mockClear();
+    AsyncStorage.removeItem.mockClear();
+    AsyncStorage.multiRemove.mockClear();
+    AsyncStorage.getItem.mockClear();
+    AsyncStorage.getAllKeys.mockClear();
+  });
+
+  it('writeGroupCategoryCache round-trips so readGroupCategoryCache returns the same array', async () => {
+    const categories = [
+      { id: 'c-1', name: 'Nature', sort_order: 0 },
+      { id: 'c-2', name: 'Cities', sort_order: 1 },
+    ];
+
+    await writeGroupCategoryCache('g-7', categories);
+
+    const result = await readGroupCategoryCache('g-7');
+
+    expect(result).toEqual(categories);
+  });
+
+  it('writeGroupCategoryCache coerces non-arrays to []', async () => {
+    await writeGroupCategoryCache('g-7', null);
+
+    const result = await readGroupCategoryCache('g-7');
+
+    expect(result).toEqual([]);
+  });
+
+  it('readGroupCategoryCache returns null when no entry exists', async () => {
+    const result = await readGroupCategoryCache('g-missing');
+
+    expect(result).toBeNull();
+  });
+
+  it('readGroupCategoryCache returns null on bad JSON', async () => {
+    await AsyncStorage.setItem('groupCategories:g-7', '{not valid json');
+
+    const result = await readGroupCategoryCache('g-7');
+
+    expect(result).toBeNull();
+  });
+
+  it('readGroupCategoryCache returns null when stored value is not an array', async () => {
+    await AsyncStorage.setItem('groupCategories:g-7', '{"id":"c-1"}');
+
+    const result = await readGroupCategoryCache('g-7');
+
+    expect(result).toBeNull();
+  });
+
+  it('clearGroupCategoryCache removes only the target group key', async () => {
+    await writeGroupCategoryCache('g-7', [{ id: 'c-1' }]);
+    await writeGroupCategoryCache('g-9', [{ id: 'c-2' }]);
+
+    await clearGroupCategoryCache('g-7');
+
+    const keys = await AsyncStorage.getAllKeys();
+
+    expect(keys).not.toContain('groupCategories:g-7');
+    expect(keys).toContain('groupCategories:g-9');
+  });
+
+  it('clearAllGroupCategoryCaches removes every groupCategories:* key while leaving unrelated keys intact', async () => {
+    await writeGroupCategoryCache('g-7', [{ id: 'c-1' }]);
+    await writeGroupCategoryCache('g-9', [{ id: 'c-2' }]);
+    await AsyncStorage.setItem('groupFeed:g-7:all:any', '[]');
+    await AsyncStorage.setItem('public_guess_cache', 'kept');
+
+    await clearAllGroupCategoryCaches();
+
+    const keys = await AsyncStorage.getAllKeys();
+
+    expect(keys).not.toContain('groupCategories:g-7');
+    expect(keys).not.toContain('groupCategories:g-9');
+    expect(keys).toContain('groupFeed:g-7:all:any');
+    expect(keys).toContain('public_guess_cache');
+  });
+});

--- a/__tests__/services/groupCategoryStore.test.js
+++ b/__tests__/services/groupCategoryStore.test.js
@@ -1,0 +1,244 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store = new Map();
+
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn((key) => Promise.resolve(store.has(key) ? store.get(key) : null)),
+      setItem: jest.fn((key, value) => {
+        store.set(key, value);
+        return Promise.resolve();
+      }),
+      removeItem: jest.fn((key) => {
+        store.delete(key);
+        return Promise.resolve();
+      }),
+      getAllKeys: jest.fn(() => Promise.resolve(Array.from(store.keys()))),
+      multiRemove: jest.fn((keys) => {
+        for (const key of keys) store.delete(key);
+        return Promise.resolve();
+      }),
+    },
+  };
+});
+
+jest.mock('../../services/groups/groupCategoriesApi', () => ({
+  __esModule: true,
+  listGroupCategories: jest.fn(),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { listGroupCategories } from '../../services/groups/groupCategoriesApi';
+import {
+  normalizePrivateCategory,
+  categoryListSignature,
+  loadGroupCategoriesOptimistic,
+  refreshGroupCategories,
+} from '../../services/groups/groupCategoriesStore';
+
+function resetStore() {
+  return AsyncStorage.getAllKeys().then((keys) =>
+    AsyncStorage.multiRemove(keys),
+  );
+}
+
+describe('services/groups/groupCategoriesStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    return resetStore();
+  });
+
+  describe('normalizePrivateCategory', () => {
+    it('fills key from id when missing and maps snake_case thumbnail_url', () => {
+      const result = normalizePrivateCategory({
+        id: 'c-1',
+        name: 'Nature',
+        thumbnail_url: 'https://img/thumb.png',
+      });
+
+      expect(result).toEqual({
+        id: 'c-1',
+        name: 'Nature',
+        thumbnail_url: 'https://img/thumb.png',
+        key: 'c-1',
+        thumbnailUrl: 'https://img/thumb.png',
+      });
+    });
+
+    it('keeps existing key and thumbnailUrl as-is', () => {
+      const result = normalizePrivateCategory({
+        id: 'c-1',
+        key: 'nature',
+        thumbnailUrl: 'https://img/a.png',
+      });
+
+      expect(result.key).toBe('nature');
+      expect(result.thumbnailUrl).toBe('https://img/a.png');
+    });
+
+    it('returns the value unchanged when it is not an object', () => {
+      expect(normalizePrivateCategory(null)).toBeNull();
+      expect(normalizePrivateCategory(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('categoryListSignature', () => {
+    it('is identical for the same entries in a different order', () => {
+      const a = [
+        { id: 2, name: 'b', sort_order: 1, thumbnail_image_id: 22 },
+        { id: 1, name: 'a', sort_order: 0, thumbnail_image_id: 11 },
+      ];
+      const b = [
+        { id: 1, name: 'a', sort_order: 0, thumbnail_image_id: 11 },
+        { id: 2, name: 'b', sort_order: 1, thumbnail_image_id: 22 },
+      ];
+
+      expect(categoryListSignature(a)).toBe(categoryListSignature(b));
+    });
+
+    it('changes when a meaningful field changes (not thumbnailUrl)', () => {
+      const a = [{ id: 1, name: 'a', sort_order: 0, thumbnail_image_id: 11 }];
+      const b = [{ id: 1, name: 'a', sort_order: 0, thumbnail_image_id: 99 }];
+
+      expect(categoryListSignature(a)).not.toBe(categoryListSignature(b));
+    });
+  });
+
+  describe('loadGroupCategoriesOptimistic', () => {
+    it('renders cache first, then fresh when fresh differs from cache', async () => {
+      const cached = [{ id: 1, name: 'a', sort_order: 0, thumbnail_image_id: 11 }];
+      await AsyncStorage.setItem('groupCategories:g-7', JSON.stringify(cached));
+
+      const fresh = [
+        { id: 1, name: 'a-renamed', sort_order: 0, thumbnail_image_id: 11 },
+        { id: 2, name: 'b', sort_order: 1, thumbnail_image_id: 22 },
+      ];
+      listGroupCategories.mockResolvedValue({ status: 200, data: fresh });
+
+      const calls = [];
+      await loadGroupCategoriesOptimistic({
+        context: { token: 't' },
+        groupId: 'g-7',
+        onCategories: (value) => calls.push(value),
+      });
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0]).toEqual(cached);
+      expect(calls[1]).toEqual(fresh.map(normalizePrivateCategory));
+
+      const stored = await AsyncStorage.getItem('groupCategories:g-7');
+      expect(JSON.parse(stored)).toEqual(fresh.map(normalizePrivateCategory));
+    });
+
+    it('renders cache once and does NOT call onCategories again when fresh === cache', async () => {
+      const cached = [
+        { id: 1, name: 'a', sort_order: 0, thumbnail_image_id: 11, thumbnailUrl: 'https://x/a.png', key: 1 },
+      ];
+      await AsyncStorage.setItem('groupCategories:g-7', JSON.stringify(cached));
+
+      const fresh = [
+        { id: 1, name: 'a', sort_order: 0, thumbnail_image_id: 11, thumbnail_url: 'https://y/a.png' },
+      ];
+      listGroupCategories.mockResolvedValue({ status: 200, data: fresh });
+
+      const calls = [];
+      await loadGroupCategoriesOptimistic({
+        context: { token: 't' },
+        groupId: 'g-7',
+        onCategories: (value) => calls.push(value),
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(cached);
+
+      const stored = await AsyncStorage.getItem('groupCategories:g-7');
+      expect(JSON.parse(stored)).toEqual(cached);
+    });
+
+    it('calls onCategories once with cache and does not throw when the network rejects', async () => {
+      const cached = [
+        { id: 1, name: 'a', sort_order: 0, thumbnail_image_id: 11, key: 1, thumbnailUrl: null },
+      ];
+      await AsyncStorage.setItem('groupCategories:g-7', JSON.stringify(cached));
+
+      listGroupCategories.mockRejectedValue(new Error('network down'));
+
+      const calls = [];
+      await expect(
+        loadGroupCategoriesOptimistic({
+          context: { token: 't' },
+          groupId: 'g-7',
+          onCategories: (value) => calls.push(value),
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(cached);
+
+      const stored = await AsyncStorage.getItem('groupCategories:g-7');
+      expect(JSON.parse(stored)).toEqual(cached);
+    });
+
+    it('does not call onCategories when there is no cache and the request fails', async () => {
+      listGroupCategories.mockRejectedValue(new Error('offline'));
+
+      const calls = [];
+      await loadGroupCategoriesOptimistic({
+        context: { token: 't' },
+        groupId: 'g-empty',
+        onCategories: (value) => calls.push(value),
+      });
+
+      expect(calls).toHaveLength(0);
+    });
+
+    it('resolves and still fetches from the network when the cache read rejects', async () => {
+      AsyncStorage.getItem.mockRejectedValueOnce(new Error('storage unavailable'));
+      const fresh = [
+        { id: 1, name: 'a', sort_order: 0, thumbnail_image_id: 11 },
+      ];
+      listGroupCategories.mockResolvedValue({ status: 200, data: fresh });
+
+      const calls = [];
+      await expect(
+        loadGroupCategoriesOptimistic({
+          context: { token: 't' },
+          groupId: 'g-7',
+          onCategories: (value) => calls.push(value),
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(listGroupCategories).toHaveBeenCalledWith({ token: 't' }, 'g-7');
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(fresh.map(normalizePrivateCategory));
+    });
+  });
+
+  describe('refreshGroupCategories', () => {
+    it('writes the cache and returns { data } on a 200 response', async () => {
+      const fresh = [
+        { id: 1, name: 'a', sort_order: 0, thumbnail_image_id: 11 },
+        { id: 2, name: 'b', sort_order: 1, thumbnail_image_id: 22 },
+      ];
+      listGroupCategories.mockResolvedValue({ status: 200, data: fresh });
+
+      const result = await refreshGroupCategories({ context: { token: 't' }, groupId: 'g-7' });
+
+      expect(result).toEqual({ data: fresh.map(normalizePrivateCategory) });
+
+      const stored = await AsyncStorage.getItem('groupCategories:g-7');
+      expect(JSON.parse(stored)).toEqual(fresh.map(normalizePrivateCategory));
+    });
+
+    it('returns { isError } and does not write cache when the network rejects', async () => {
+      listGroupCategories.mockRejectedValue(new Error('offline'));
+
+      const result = await refreshGroupCategories({ context: { token: 't' }, groupId: 'g-7' });
+
+      expect(result).toEqual({ isError: true });
+
+      const stored = await AsyncStorage.getItem('groupCategories:g-7');
+      expect(stored).toBeNull();
+    });
+  });
+});

--- a/__tests__/useAdCadence.test.tsx
+++ b/__tests__/useAdCadence.test.tsx
@@ -1,0 +1,126 @@
+// Behavior tests for hooks/useAdCadence.
+//
+// These tests exist specifically to lock in the platform-gate removal: before
+// the fix, `isSourceReady` was `IS_ANDROID && adSource.isReady()`, which made
+// iOS always false and suppressed every free-tier ad. We mock consumeAdSlot to
+// capture the `isSourceReady` argument and assert it follows `adSource.isReady()`
+// on every platform. The default jest Platform.OS is 'ios' (jest.setup.js sets
+// EXPO_OS='ios'), so the iOS case is the regression guard.
+
+import { renderHook } from '@testing-library/react-native';
+import { Platform } from 'react-native';
+
+import { useAdCadence } from '../hooks/useAdCadence';
+import type { AdSource } from '../services/ads/AdSource';
+import type { ConsumeAdSlotResult } from '../utils/adCadence';
+
+const mockConsumeAdSlot = jest.fn((): ConsumeAdSlotResult => ({ showAd: false, nextCount: 0 }));
+const mockShouldSuppressAds = jest.fn(() => false);
+const mockIsE2EMode = jest.fn(() => false);
+
+jest.mock('../utils/adCadence', () => ({
+  __esModule: true,
+  consumeAdSlot: (...args: unknown[]) => mockConsumeAdSlot(...(args as [unknown])),
+}));
+
+jest.mock('../services/billing/adPolicy', () => ({
+  __esModule: true,
+  shouldSuppressAds: (...args: unknown[]) => mockShouldSuppressAds(...(args as [unknown])),
+}));
+
+jest.mock('../utils/e2eMode', () => ({
+  __esModule: true,
+  isE2EMode: (...args: unknown[]) => mockIsE2EMode(...(args as [])),
+}));
+
+function makeSource(isReady: boolean): AdSource {
+  return {
+    isReady: () => isReady,
+    show: jest.fn().mockResolvedValue(undefined),
+    renderSurface: () => null,
+  };
+}
+
+function lastConsumeCallArg(): Record<string, unknown> {
+  const calls = mockConsumeAdSlot.mock.calls;
+  return calls[calls.length - 1][0] as Record<string, unknown>;
+}
+
+describe('useAdCadence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConsumeAdSlot.mockReturnValue({ showAd: false, nextCount: 0 });
+    mockShouldSuppressAds.mockReturnValue(false);
+    mockIsE2EMode.mockReturnValue(false);
+  });
+
+  it('iOS, free tier: passes isSourceReady === true to consumeAdSlot (regression: was false under the old IS_ANDROID gate)', () => {
+    // Default jest Platform.OS is 'ios' — assert explicitly to document intent.
+    expect(Platform.OS).toBe('ios');
+
+    const { result } = renderHook(() =>
+      useAdCadence({
+        scope: { kind: 'public' },
+        authContext: { paidTier: 0 },
+        adSource: makeSource(true),
+      }),
+    );
+
+    result.current.consumeAdSlot();
+
+    expect(mockConsumeAdSlot).toHaveBeenCalledTimes(1);
+    expect(lastConsumeCallArg().isSourceReady).toBe(true);
+  });
+
+  it('Android, free tier: passes isSourceReady === true to consumeAdSlot', () => {
+    const original = Platform.OS;
+    Object.defineProperty(Platform, 'OS', { value: 'android', configurable: true });
+    try {
+      const { result } = renderHook(() =>
+        useAdCadence({
+          scope: { kind: 'public' },
+          authContext: { paidTier: 0 },
+          adSource: makeSource(true),
+        }),
+      );
+
+      result.current.consumeAdSlot();
+
+      expect(mockConsumeAdSlot).toHaveBeenCalledTimes(1);
+      expect(lastConsumeCallArg().isSourceReady).toBe(true);
+    } finally {
+      Object.defineProperty(Platform, 'OS', { value: original, configurable: true });
+    }
+  });
+
+  it('paid tier (shouldSuppressAds → isAdFree): forwards isAdFree === true to consumeAdSlot (paid suppression unchanged)', () => {
+    mockShouldSuppressAds.mockReturnValue(true);
+
+    const { result } = renderHook(() =>
+      useAdCadence({
+        scope: { kind: 'public' },
+        authContext: { paidTier: 1 },
+        adSource: makeSource(true),
+      }),
+    );
+
+    result.current.consumeAdSlot();
+
+    expect(mockConsumeAdSlot).toHaveBeenCalledTimes(1);
+    expect(lastConsumeCallArg().isAdFree).toBe(true);
+  });
+
+  it('isSourceReady tracks adSource.isReady() (false when the source reports not ready)', () => {
+    const { result } = renderHook(() =>
+      useAdCadence({
+        scope: { kind: 'public' },
+        authContext: { paidTier: 0 },
+        adSource: makeSource(false),
+      }),
+    );
+
+    result.current.consumeAdSlot();
+
+    expect(lastConsumeCallArg().isSourceReady).toBe(false);
+  });
+});

--- a/__tests__/useAdSource.test.tsx
+++ b/__tests__/useAdSource.test.tsx
@@ -1,0 +1,109 @@
+// Behavior tests for hooks/useAdSource.
+//
+// Verifies the composite AdSource wiring: the default factory must build AdMob
+// WITH the App-level bridge snapshot (regression: previously constructed
+// without it, so AdMobInterstitialSource.isReady() always returned false), wrap
+// it with InternalProAdSource in a FallbackAdSource, and expose the test-only
+// factory override seam.
+
+import { renderHook } from '@testing-library/react-native';
+
+import { useAdSource, _setAdSourceFactoryForTests } from '../hooks/useAdSource';
+import { adMobBridgeSnapshot } from '../services/ads/AdMobInterstitialBridge';
+import type { AdSource } from '../services/ads/AdSource';
+
+const mockAdMobSource: AdSource = {
+  isReady: () => true,
+  show: jest.fn().mockResolvedValue(undefined),
+  renderSurface: () => null,
+};
+const mockInternalSource: AdSource = {
+  isReady: () => true,
+  show: jest.fn().mockResolvedValue(undefined),
+  renderSurface: () => null,
+};
+const mockFallbackSource: AdSource = {
+  isReady: () => true,
+  show: jest.fn().mockResolvedValue(undefined),
+  renderSurface: () => null,
+};
+
+const mockCreateAdMob = jest.fn(() => mockAdMobSource);
+const mockCreateInternal = jest.fn(() => mockInternalSource);
+const mockCreateFallback = jest.fn(() => mockFallbackSource);
+
+jest.mock('../services/ads/AdMobInterstitialSource', () => ({
+  __esModule: true,
+  createAdMobInterstitialSource: (...args: unknown[]) => mockCreateAdMob(...(args as [unknown])),
+}));
+
+jest.mock('../services/ads/InternalProAdSource', () => ({
+  __esModule: true,
+  createInternalProAdSource: (...args: unknown[]) => mockCreateInternal(...(args as [])),
+}));
+
+jest.mock('../services/ads/FallbackAdSource', () => ({
+  __esModule: true,
+  createFallbackAdSource: (...args: unknown[]) =>
+    mockCreateFallback(...(args as [AdSource, AdSource])),
+}));
+
+jest.mock('../services/ads/AdMobInterstitialBridge', () => ({
+  __esModule: true,
+  adMobBridgeSnapshot: { get: () => null },
+}));
+
+describe('useAdSource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Restore the built-in default between tests so each renderHook exercises
+    // the real default factory (the test-only seam is sticky at module scope).
+    _setAdSourceFactoryForTests(undefined);
+  });
+
+  afterEach(() => {
+    _setAdSourceFactoryForTests(undefined);
+  });
+
+  it('default factory builds AdMob WITH { hookSnapshot: adMobBridgeSnapshot } (regression: was built without it)', () => {
+    renderHook(() => useAdSource());
+
+    expect(mockCreateAdMob).toHaveBeenCalledTimes(1);
+    expect(mockCreateAdMob).toHaveBeenCalledWith({ hookSnapshot: adMobBridgeSnapshot });
+  });
+
+  it('default factory returns a FallbackAdSource wrapping adMob + internal sources', () => {
+    const { result } = renderHook(() => useAdSource());
+
+    expect(mockCreateInternal).toHaveBeenCalledTimes(1);
+    expect(mockCreateFallback).toHaveBeenCalledTimes(1);
+    expect(mockCreateFallback).toHaveBeenCalledWith(mockAdMobSource, mockInternalSource);
+
+    // The composite returned IS the fallback source built by the factory.
+    expect(result.current).toBe(mockFallbackSource);
+  });
+
+  it('_setAdSourceFactoryForTests override replaces the source, and undefined restores the built-in default', () => {
+    const customSource: AdSource = {
+      isReady: () => true,
+      show: jest.fn().mockResolvedValue(undefined),
+      renderSurface: () => null,
+    };
+    const customFactory = jest.fn(() => customSource);
+
+    _setAdSourceFactoryForTests(customFactory);
+
+    const { result: first } = renderHook(() => useAdSource());
+    expect(first.current).toBe(customSource);
+    expect(customFactory).toHaveBeenCalledTimes(1);
+    // Built-in factories untouched while the override is active.
+    expect(mockCreateAdMob).not.toHaveBeenCalled();
+
+    // Restore the built-in default.
+    _setAdSourceFactoryForTests(undefined);
+
+    const { result: second } = renderHook(() => useAdSource());
+    expect(mockCreateAdMob).toHaveBeenCalledWith({ hookSnapshot: adMobBridgeSnapshot });
+    expect(second.current).toBe(mockFallbackSource);
+  });
+});

--- a/__tests__/useTargetDrag.test.ts
+++ b/__tests__/useTargetDrag.test.ts
@@ -1,27 +1,63 @@
-import React from 'react';
 import { act, create } from 'react-test-renderer';
+
+import * as React from 'react';
 
 import { useTargetDrag } from '../hooks/useTargetDrag';
 import type { UseTargetDragArgs, UseTargetDragSelection } from '../hooks/useTargetDrag';
 import { buildSelectionFromPixels } from '../utils/targetLocation';
 
-let capturedPanResponder: any;
+// RNGH mock: each Gesture.Pan() builder records method calls so tests can drive
+// the onBegin/onUpdate/onFinalize callbacks with synthetic events.
+type GestureRecord = { __type: string; calls: Array<{ method: string; args: any[] }> };
 
-jest.mock('react-native', () => ({
-  PanResponder: {
-    create: jest.fn((config: any) => {
-      capturedPanResponder = config;
-      return { panHandlers: { testID: 'mock-target-pan-handlers' } };
-    }),
-  },
-}));
+let mockCapturedGestures: GestureRecord[] = [];
+
+jest.mock('react-native-gesture-handler', () => {
+  const React = jest.requireActual('react');
+
+  function makeChainable(record: any) {
+    const handler = {
+      get(_t: any, prop: string) {
+        if (prop in record) {
+          return (record as any)[prop];
+        }
+        return (...args: any[]) => {
+          record.calls.push({ method: prop, args });
+          return proxy;
+        };
+      },
+    };
+    const proxy = new Proxy(record, handler as any);
+    return proxy;
+  }
+
+  return {
+    Gesture: {
+      Pan: () => {
+        const record = { __type: 'pan', calls: [] as Array<{ method: string; args: any[] }> };
+        mockCapturedGestures.push(record);
+        return makeChainable(record);
+      },
+      Race: (...gs: any[]) => ({ __type: 'race', gestures: gs }),
+      Exclusive: (...gs: any[]) => ({ __type: 'exclusive', gestures: gs }),
+      Simultaneous: (...gs: any[]) => ({ __type: 'sim', gestures: gs }),
+    },
+    GestureDetector: ({ children }: any) =>
+      React.createElement('GestureDetector', null, children),
+    GestureHandlerRootView: ({ children }: any) =>
+      React.createElement('GestureHandlerRootView', null, children),
+  };
+});
 
 jest.mock('../utils/targetLocation', () => ({
   buildSelectionFromPixels: jest.fn(),
 }));
 
 const mockedBuildSelectionFromPixels = buildSelectionFromPixels as unknown as jest.Mock;
-const mockedPanResponderCreate = (require('react-native') as any).PanResponder.create as jest.Mock;
+
+function findCall(record: GestureRecord | undefined, method: string) {
+  return record?.calls.find((c) => c.method === method);
+}
 
 let captured: any;
 
@@ -83,7 +119,7 @@ describe('useTargetDrag', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     captured = undefined;
-    capturedPanResponder = undefined;
+    mockCapturedGestures.length = 0;
     renderer = undefined;
     mockedBuildSelectionFromPixels.mockReturnValue(draggedSelection);
   });
@@ -97,15 +133,15 @@ describe('useTargetDrag', () => {
     }
   });
 
-  it('returns panHandlers=undefined, null touchLocation, null target, and does not call PanResponder.create when enabled=false', () => {
+  it('returns gesture=undefined, null touchLocation, null target, and builds no Pan gesture when enabled=false', () => {
     act(() => {
       renderer = renderProbe(defaultProps({ enabled: false, initialSelection: null }));
     });
 
-    expect(captured.panHandlers).toBeUndefined();
+    expect(captured.gesture).toBeUndefined();
     expect(captured.touchLocation).toBeNull();
     expect(captured.target).toBeNull();
-    expect(mockedPanResponderCreate).not.toHaveBeenCalled();
+    expect(mockCapturedGestures).toHaveLength(0);
   });
 
   it('initializes touchLocation and target from initialSelection when enabled=true', () => {
@@ -115,18 +151,58 @@ describe('useTargetDrag', () => {
 
     expect(captured.touchLocation).toEqual({ x: '0.50', y: '0.50' });
     expect(captured.target).toEqual(centeredSelection.target);
-    expect(captured.panHandlers).toEqual({ testID: 'mock-target-pan-handlers' });
-    expect(mockedPanResponderCreate).toHaveBeenCalledTimes(1);
+    expect(mockCapturedGestures).toHaveLength(1);
+    expect(mockCapturedGestures[0].__type).toBe('pan');
   });
 
-  it('on grant + move(dx=10, dy=0) calls buildSelectionFromPixels with clamp(dragStart.x + 10, 0, dims.width) and clamp(dragStart.y + 0, 0, dims.height)', () => {
+  it('configures the Pan gesture with .enabled(true) and onBegin/onUpdate/onFinalize handlers', () => {
     act(() => {
       renderer = renderProbe(defaultProps());
     });
 
+    const record = mockCapturedGestures[0];
+    expect(findCall(record, 'enabled')?.args[0]).toBe(true);
+    expect(findCall(record, 'onBegin')).toBeTruthy();
+    expect(findCall(record, 'onUpdate')).toBeTruthy();
+    expect(findCall(record, 'onFinalize')).toBeTruthy();
+  });
+
+  it('exposes the RNGH-built Pan gesture object on the returned hook result', () => {
     act(() => {
-      capturedPanResponder.onPanResponderGrant(null, { dx: 0, dy: 0 });
-      capturedPanResponder.onPanResponderMove(null, { dx: 10, dy: 0 });
+      renderer = renderProbe(defaultProps());
+    });
+
+    expect(captured.gesture).toBeTruthy();
+    expect((captured.gesture as GestureRecord).__type).toBe('pan');
+  });
+
+  it('onBegin sets dragStart from current target center and calls onInteract', () => {
+    const onInteract = jest.fn();
+    act(() => {
+      renderer = renderProbe(defaultProps({ onInteract }));
+    });
+
+    const onBegin = findCall(mockCapturedGestures[0], 'onBegin')!.args[0];
+
+    act(() => {
+      onBegin();
+    });
+
+    expect(onInteract).toHaveBeenCalledTimes(1);
+  });
+
+  it('onUpdate(translationX=10, translationY=0) calls buildSelectionFromPixels with clamp(dragStart.x + 10, 0, dims.width)', () => {
+    act(() => {
+      renderer = renderProbe(defaultProps());
+    });
+
+    const record = mockCapturedGestures[0];
+    const onBegin = findCall(record, 'onBegin')!.args[0];
+    const onUpdate = findCall(record, 'onUpdate')!.args[0];
+
+    act(() => {
+      onBegin();
+      onUpdate({ translationX: 10, translationY: 0 });
     });
 
     expect(mockedBuildSelectionFromPixels).toHaveBeenCalledWith({
@@ -140,61 +216,40 @@ describe('useTargetDrag', () => {
     expect(captured.target).toEqual(draggedSelection.target);
   });
 
-  it('on grant + release(dx=2, dy=2) calls onTap (moved < TAP_THRESHOLD=8)', () => {
+  it('onFinalize(translationX=2, translationY=2) calls onTap (moved < TAP_THRESHOLD=8)', () => {
     const onTap = jest.fn();
     act(() => {
       renderer = renderProbe(defaultProps({ onTap }));
     });
 
+    const record = mockCapturedGestures[0];
+    const onBegin = findCall(record, 'onBegin')!.args[0];
+    const onFinalize = findCall(record, 'onFinalize')!.args[0];
+
     act(() => {
-      capturedPanResponder.onPanResponderGrant(null, { dx: 0, dy: 0 });
-      capturedPanResponder.onPanResponderRelease(null, { dx: 2, dy: 2 });
+      onBegin();
+      onFinalize({ translationX: 2, translationY: 2 });
     });
 
     expect(onTap).toHaveBeenCalledTimes(1);
   });
 
-  it('on grant + release(dx=30, dy=0) does NOT call onTap (moved >= TAP_THRESHOLD)', () => {
+  it('onFinalize(translationX=30, translationY=0) does NOT call onTap (moved >= TAP_THRESHOLD)', () => {
     const onTap = jest.fn();
     act(() => {
       renderer = renderProbe(defaultProps({ onTap }));
     });
 
+    const record = mockCapturedGestures[0];
+    const onBegin = findCall(record, 'onBegin')!.args[0];
+    const onFinalize = findCall(record, 'onFinalize')!.args[0];
+
     act(() => {
-      capturedPanResponder.onPanResponderGrant(null, { dx: 0, dy: 0 });
-      capturedPanResponder.onPanResponderRelease(null, { dx: 30, dy: 0 });
+      onBegin();
+      onFinalize({ translationX: 30, translationY: 0 });
     });
 
     expect(onTap).not.toHaveBeenCalled();
-  });
-
-  it('onPanResponderGrant calls onInteract when provided', () => {
-    const onInteract = jest.fn();
-    act(() => {
-      renderer = renderProbe(defaultProps({ onInteract }));
-    });
-
-    act(() => {
-      capturedPanResponder.onPanResponderGrant(null, { dx: 0, dy: 0 });
-    });
-
-    expect(onInteract).toHaveBeenCalledTimes(1);
-  });
-
-  it('onStartShouldSetPanResponderCapture returns true', () => {
-    act(() => {
-      renderer = renderProbe(defaultProps());
-    });
-
-    expect(capturedPanResponder.onStartShouldSetPanResponderCapture()).toBe(true);
-  });
-
-  it('onPanResponderTerminationRequest returns false', () => {
-    act(() => {
-      renderer = renderProbe(defaultProps());
-    });
-
-    expect(capturedPanResponder.onPanResponderTerminationRequest()).toBe(false);
   });
 
   it('resets to a new initialSelection when it changes before any user interaction', () => {
@@ -217,9 +272,13 @@ describe('useTargetDrag', () => {
       renderer = renderProbe(defaultProps({ initialSelection: centeredSelection }));
     });
 
+    const record = mockCapturedGestures[0];
+    const onBegin = findCall(record, 'onBegin')!.args[0];
+    const onUpdate = findCall(record, 'onUpdate')!.args[0];
+
     act(() => {
-      capturedPanResponder.onPanResponderGrant(null, { dx: 0, dy: 0 });
-      capturedPanResponder.onPanResponderMove(null, { dx: 10, dy: 0 });
+      onBegin();
+      onUpdate({ translationX: 10, translationY: 0 });
     });
 
     expect(captured.touchLocation).toEqual({ x: '0.55', y: '0.50' });

--- a/components/Guess/GuessExitSwipeMenu.js
+++ b/components/Guess/GuessExitSwipeMenu.js
@@ -1,119 +1,45 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
-import { Animated, PanResponder, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useEffect } from 'react';
+import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { GlobalStyle } from '../../constants/theme';
 import { OverlayZIndex } from '../../constants/overlayZIndex';
 import SwipeHaloHint from './SwipeHaloHint';
 
-const EDGE_WIDTH = 36;
-const SWIPE_THRESHOLD_PX = 40;
-const TAP_THRESHOLD = 8;
 const PANEL_WIDTH = 160;
 
-export default function GuessExitSwipeMenu({ onHome, showHints = false, onInteract }) {
-  const [isOpen, setIsOpen] = useState(false);
-  const translateX = useRef(new Animated.Value(-PANEL_WIDTH)).current;
-  const panelOpacity = useRef(new Animated.Value(0)).current;
-
-  const openPanel = useCallback(() => {
-    onInteract?.();
-    setIsOpen(true);
-    Animated.parallel([
-      Animated.timing(translateX, {
-        toValue: 0,
-        duration: 180,
-        useNativeDriver: true,
-      }),
-      Animated.timing(panelOpacity, {
-        toValue: 1,
-        duration: 180,
-        useNativeDriver: true,
-      }),
-    ]).start();
-  }, [translateX, panelOpacity, onInteract]);
-
-  const closePanel = useCallback(() => {
-    Animated.parallel([
-      Animated.timing(translateX, {
-        toValue: -PANEL_WIDTH,
-        duration: 140,
-        useNativeDriver: true,
-      }),
-      Animated.timing(panelOpacity, {
-        toValue: 0,
-        duration: 140,
-        useNativeDriver: true,
-      }),
-    ]).start(() => {
-      setIsOpen(false);
-    });
-  }, [translateX, panelOpacity]);
-
-  const edgePanResponder = useMemo(
-    () =>
-      PanResponder.create({
-        onStartShouldSetPanResponder: (_e, gs) => gs.x0 <= EDGE_WIDTH,
-        onStartShouldSetPanResponderCapture: () => false,
-        onMoveShouldSetPanResponder: () => false,
-        onMoveShouldSetPanResponderCapture: () => false,
-        onPanResponderRelease: (_e, gs) => {
-          if (gs.dx >= SWIPE_THRESHOLD_PX && Math.abs(gs.dx) > Math.abs(gs.dy)) {
-            openPanel();
-          }
-        },
-        onPanResponderTerminationRequest: () => false,
-      }),
-    [openPanel]
-  );
-
-  const scrimPanResponder = useMemo(
-    () =>
-      PanResponder.create({
-        onStartShouldSetPanResponder: () => true,
-        onStartShouldSetPanResponderCapture: () => false,
-        onMoveShouldSetPanResponder: () => false,
-        onMoveShouldSetPanResponderCapture: () => false,
-        onPanResponderRelease: (_e, gs) => {
-          const isSwipeLeft =
-            gs.dx <= -SWIPE_THRESHOLD_PX && Math.abs(gs.dx) > Math.abs(gs.dy);
-          const isTap =
-            Math.abs(gs.dx) < TAP_THRESHOLD && Math.abs(gs.dy) < TAP_THRESHOLD;
-          if (isSwipeLeft || isTap) {
-            closePanel();
-          }
-        },
-        onPanResponderTerminationRequest: () => false,
-      }),
-    [closePanel]
-  );
+// Controlled exit menu. The legacy PanResponder-based edge strip lived in this
+// separate higher-zIndex subtree, where it intercepted touches in the left
+// 36px and the target circle's responder chain was never consulted there. The
+// edge strip is removed; the right-edge swipe now lives in the picture subtree
+// (ShowPicture's nested RNGH surface detector) and drives `isOpen` from the
+// parent. This component is purely presentational.
+export default function GuessExitSwipeMenu({ isOpen, onClose, onHome, showHints = false, onInteract }) {
+  useEffect(() => {
+    if (isOpen) {
+      onInteract?.();
+    }
+  }, [isOpen, onInteract]);
 
   return (
     <View pointerEvents="box-none" style={[StyleSheet.absoluteFill, { zIndex: OverlayZIndex.EXIT_MENU_ROOT, elevation: OverlayZIndex.EXIT_MENU_ROOT }]}>
-      <View
-        testID="guess.exit.edge"
-        {...edgePanResponder.panHandlers}
-        style={styles.edge}
-      />
-
       {isOpen ? (
         <>
           <Pressable
             accessibilityLabel="Close exit panel"
             accessibilityRole="button"
-            onPress={closePanel}
-            {...scrimPanResponder.panHandlers}
+            onPress={onClose}
             style={styles.scrim}
             testID="guess.exit.scrim"
           />
           <Animated.View
-            style={[styles.panel, { transform: [{ translateX }] }, { opacity: panelOpacity }]}
+            style={[styles.panel]}
             testID="guess.exit.panel"
           >
             <View style={styles.panelHeader}>
               <Pressable
                 accessibilityLabel="Close exit panel"
                 accessibilityRole="button"
-                onPress={closePanel}
+                onPress={onClose}
                 style={styles.closeButton}
                 testID="guess.exit.close"
               >
@@ -138,16 +64,6 @@ export default function GuessExitSwipeMenu({ onHome, showHints = false, onIntera
 }
 
 const styles = StyleSheet.create({
-  edge: {
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-    left: 0,
-    width: EDGE_WIDTH,
-    backgroundColor: 'transparent',
-    zIndex: OverlayZIndex.EXIT_MENU_EDGE,
-    elevation: OverlayZIndex.EXIT_MENU_EDGE,
-  },
   scrim: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.28)',

--- a/components/Picture/Descriptions/EnigmaOverlay.js
+++ b/components/Picture/Descriptions/EnigmaOverlay.js
@@ -1,15 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Animated, PanResponder, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Animated } from 'react-native';
 
 import IconButton from '../../UI/IconButton';
 import { OverlayZIndex } from '../../../constants/overlayZIndex';
 import { GlobalStyle } from '../../../constants/theme';
 
-const SWIPE_THRESHOLD_PX = 40;
-const TAP_THRESHOLD = 8;
 const PANEL_HEIGHT_RATIO = 0.35;
 const PANEL_MIN_HEIGHT = 120;
-const HANDLE_HEIGHT = 28;
 const CLOSE_ICON_SIZE = 24;
 
 function buildPanelHeight(screenHeight) {
@@ -17,146 +14,50 @@ function buildPanelHeight(screenHeight) {
   return Math.max(computed, PANEL_MIN_HEIGHT);
 }
 
-export default function EnigmaOverlay({ description, screenHeight, defaultOpen, onClose }) {
+// Controlled enigma overlay. The legacy PanResponder-based handle lived in this
+// separate higher-zIndex subtree, where it intercepted touches in the bottom
+// 28px and the target circle's responder chain was never consulted there. The
+// handle is removed; the open-surface up-swipe now lives in the picture subtree
+// (ShowPicture's nested RNGH surface detector) and drives `isOpen` from the
+// parent. This component is purely presentational.
+export default function EnigmaOverlay({ description, screenHeight, isOpen, onClose }) {
   const panelHeight = buildPanelHeight(screenHeight);
-  const [isOpen, setIsOpen] = useState(!!defaultOpen);
-  const translateY = useRef(new Animated.Value(defaultOpen ? 0 : panelHeight)).current;
-  const previousDefaultOpenRef = useRef(!!defaultOpen);
-
-  useEffect(() => {
-    const previousDefaultOpen = previousDefaultOpenRef.current;
-    if (previousDefaultOpen === !!defaultOpen) {
-      return;
-    }
-
-    previousDefaultOpenRef.current = !!defaultOpen;
-    if (defaultOpen) {
-      setIsOpen(true);
-      translateY.setValue(0);
-      return;
-    }
-
-    translateY.setValue(panelHeight);
-    setIsOpen(false);
-  }, [defaultOpen, panelHeight, translateY]);
-
-  const openPanel = useCallback(() => {
-    setIsOpen(true);
-    Animated.timing(translateY, {
-      toValue: 0,
-      duration: 180,
-      useNativeDriver: true,
-    }).start();
-  }, [translateY]);
-
-  const closePanel = useCallback(() => {
-    onClose?.();
-    Animated.timing(translateY, {
-      toValue: panelHeight,
-      duration: 140,
-      useNativeDriver: true,
-    }).start(() => {
-      setIsOpen(false);
-    });
-  }, [translateY, panelHeight, onClose]);
-
-  const handlePanResponder = useMemo(
-    () =>
-      PanResponder.create({
-        onStartShouldSetPanResponder: () => true,
-        onStartShouldSetPanResponderCapture: () => false,
-        onMoveShouldSetPanResponder: () => false,
-        onMoveShouldSetPanResponderCapture: () => false,
-        onPanResponderRelease: (_e, gs) => {
-          const isUpSwipe = gs.dy <= -SWIPE_THRESHOLD_PX && Math.abs(gs.dy) > Math.abs(gs.dx);
-          if (isUpSwipe) {
-            openPanel();
-          }
-        },
-        onPanResponderTerminationRequest: () => false,
-      }),
-    [openPanel]
-  );
-
-  const dismissPanResponder = useMemo(
-    () =>
-      PanResponder.create({
-        onStartShouldSetPanResponder: () => true,
-        onStartShouldSetPanResponderCapture: () => false,
-        onMoveShouldSetPanResponder: () => false,
-        onMoveShouldSetPanResponderCapture: () => false,
-        onPanResponderRelease: (_e, gs) => {
-          const isDownSwipe = gs.dy >= SWIPE_THRESHOLD_PX && Math.abs(gs.dy) > Math.abs(gs.dx);
-          const isTap = Math.abs(gs.dx) < TAP_THRESHOLD && Math.abs(gs.dy) < TAP_THRESHOLD;
-          if (isDownSwipe || isTap) {
-            closePanel();
-          }
-        },
-        onPanResponderTerminationRequest: () => false,
-      }),
-    [closePanel]
-  );
-
   const text = description && description !== '' ? description : 'No description';
+
+  if (!isOpen) {
+    return null;
+  }
 
   return (
     <View pointerEvents="box-none" style={[StyleSheet.absoluteFill, { zIndex: OverlayZIndex.ENIGMA_ROOT, elevation: OverlayZIndex.ENIGMA_ROOT }]}>
-      {!isOpen ? (
-        <View
-          {...handlePanResponder.panHandlers}
-          style={styles.handle}
-          testID="guess.enigma.handle"
-        />
-      ) : null}
-
-      {isOpen ? (
-        <>
-          <Pressable
+      <Pressable
+        accessibilityLabel="Close enigma"
+        accessibilityRole="button"
+        onPress={() => onClose?.()}
+        style={styles.scrim}
+        testID="guess.enigma.scrim"
+      />
+      <Animated.View
+        style={[styles.panel, { height: panelHeight }]}
+        testID="guess.enigma.panel"
+      >
+        <View style={styles.panelHeader}>
+          <IconButton
             accessibilityLabel="Close enigma"
-            accessibilityRole="button"
-            onPress={closePanel}
-            {...dismissPanResponder.panHandlers}
-            style={styles.scrim}
-            testID="guess.enigma.scrim"
+            color="white"
+            icon="chevron-down"
+            onPress={() => onClose?.()}
+            size={CLOSE_ICON_SIZE}
+            testID="guess.enigma.close"
           />
-          <Animated.View
-            style={[styles.panel, { height: panelHeight, transform: [{ translateY }] }]}
-            testID="guess.enigma.panel"
-            {...dismissPanResponder.panHandlers}
-          >
-            <View style={styles.panelHeader}>
-              <IconButton
-                accessibilityLabel="Close enigma"
-                color="white"
-                icon="chevron-down"
-                onPress={closePanel}
-                size={CLOSE_ICON_SIZE}
-                testID="guess.enigma.close"
-              />
-            </View>
-            <Text style={styles.text} testID="guess.enigma.text">{text}</Text>
-          </Animated.View>
-        </>
-      ) : null}
+        </View>
+        <Text style={styles.text} testID="guess.enigma.text">{text}</Text>
+      </Animated.View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  handle: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    height: HANDLE_HEIGHT,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: GlobalStyle.color.primaryColor900,
-    borderTopLeftRadius: 12,
-    borderTopRightRadius: 12,
-    zIndex: OverlayZIndex.ENIGMA_HANDLE,
-    elevation: OverlayZIndex.ENIGMA_HANDLE,
-  },
   scrim: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.28)',

--- a/components/Picture/GuessPicture.tsx
+++ b/components/Picture/GuessPicture.tsx
@@ -66,6 +66,12 @@ type GuessPictureProps = {
   // tap/drag confirmation so toAdScreen cannot double-fire during a resolve.
   // Forwards to useTargetDrag via `enabled: !disabled && !isE2EMode()`.
   disabled?: boolean;
+  // Edge-swipe (left 36px) opened the exit menu in a separate higher-zIndex
+  // subtree that intercepted touches in that zone, starving the target's drag.
+  // Detection now lives in the picture subtree (ShowPicture's nested RNGH
+  // surface detector); this callback fires when the surface recognizes the
+  // rightward swipe so the parent (GuessScreen) can open the exit menu.
+  onEdgeSwipe?: () => void;
 };
 
 const GuessPicture: FC<GuessPictureProps> = ({
@@ -81,6 +87,7 @@ const GuessPicture: FC<GuessPictureProps> = ({
   pulseTarget = false,
   onInteract,
   disabled = false,
+  onEdgeSwipe,
 }) => {
   const [dismissed, setDismissed] = useState(false);
   const showFilter = !skipInstructions && !dismissed;
@@ -111,7 +118,7 @@ const GuessPicture: FC<GuessPictureProps> = ({
   const {
     touchLocation,
     target,
-    panHandlers: targetPanHandlers,
+    gesture: targetGesture,
     setSelection,
   } = useTargetDrag({
     // PB2: gate input while the advance state machine is mid-cycle so a
@@ -197,12 +204,13 @@ const GuessPicture: FC<GuessPictureProps> = ({
         handleConfirm={handleConfirm}
         onCancel={onCancel}
         imageDimensionStyle={imageDimensionStyle}
-        targetPanHandlers={targetPanHandlers}
+        targetGesture={targetGesture}
         defaultOpen={skipInstructions === true}
         pulseTarget={pulseTarget}
         speedRingActive={!showFilter && !showModal && graceDone && !isE2EMode()}
         speedDurationMs={SPEED_WINDOW_MS}
         onDescriptionClosed={markClosed}
+        onEdgeSwipe={onEdgeSwipe}
       />
     );
   };

--- a/components/Picture/ShowPicture.js
+++ b/components/Picture/ShowPicture.js
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, View, Pressable, StyleSheet, ImageBackground } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 import IconButton from '../UI/IconButton';
 import CenteredModal from '../UI/CenteredModal';
@@ -16,9 +17,37 @@ const PULSE_OPACITY_MIN = 0.55;
 const PULSE_OPACITY_MAX = 1;
 const PULSE_NATIVE_DRIVER = { useNativeDriver: true };
 
-export default function ShowPicture({ uri, guess, description, touchLocation, handlePress, handleLongPress, target, handleIconPress, showModal, handleConfirm,  onCancel, imageDimensionStyle, targetPanHandlers, defaultOpen, onDescriptionClosed, pulseTarget = false, speedRingActive = false, speedDurationMs = SPEED_WINDOW_MS }) {
+// Surface swipe thresholds for the nested RNGH detectors. The legacy responder
+// versions of these detectors lived in separate higher-zIndex subtrees that
+// physically intercepted touches in the left 36px / bottom 28px — starving the
+// target's drag. Moving detection INTO the picture subtree (the same subtree
+// the target circle lives in) eliminates that cross-subtree barrier.
+const EDGE_SWIPE_ACTIVE_X = 40;
+const EDGE_SWIPE_FAIL_X = -10;
+const EDGE_SWIPE_FAIL_Y = 40;
+const HANDLE_SWIPE_ACTIVE_Y = -40;
+const HANDLE_SWIPE_FAIL_Y = 10;
+
+export default function ShowPicture({ uri, guess, description, touchLocation, handlePress, handleLongPress, target, handleIconPress, showModal, handleConfirm,  onCancel, imageDimensionStyle, targetGesture, defaultOpen, onDescriptionClosed, onEdgeSwipe, pulseTarget = false, speedRingActive = false, speedDurationMs = SPEED_WINDOW_MS }) {
   const pulseScale = useRef(new Animated.Value(PULSE_SCALE_MIN)).current;
   const pulseOpacity = useRef(new Animated.Value(PULSE_OPACITY_MAX)).current;
+
+  const [enigmaOpen, setEnigmaOpen] = useState(!!defaultOpen);
+  const previousDefaultOpenRef = useRef(!!defaultOpen);
+
+  // Controlled enigma: defaultOpen is the parent's signal (e.g. skipInstructions
+  // for reading-grace). When it flips, mirror into local open state so the
+  // surface handle-swipe can later re-open after the user closes it.
+  useEffect(() => {
+    const previous = previousDefaultOpenRef.current;
+    if (previous === !!defaultOpen) {
+      return;
+    }
+    previousDefaultOpenRef.current = !!defaultOpen;
+    if (defaultOpen) {
+      setEnigmaOpen(true);
+    }
+  }, [defaultOpen]);
 
   useEffect(() => {
     if (!pulseTarget) {
@@ -63,53 +92,106 @@ export default function ShowPicture({ uri, guess, description, touchLocation, ha
     ? { opacity: pulseOpacity, transform: [{ scale: pulseScale }] }
     : null;
 
+  // Edge right-swipe → open exit menu. failOffsetX/Y ensure taps, vertical
+  // swipes, and leftward swipes do NOT trigger the menu.
+  const edgeSwipe = useMemo(
+    () =>
+      Gesture.Pan()
+        .activeOffsetX(EDGE_SWIPE_ACTIVE_X)
+        .failOffsetX(EDGE_SWIPE_FAIL_X)
+        .failOffsetY(EDGE_SWIPE_FAIL_Y)
+        .onEnd((_event, success) => {
+          if (success) {
+            onEdgeSwipe?.();
+          }
+        }),
+    [onEdgeSwipe],
+  );
+
+  // Bottom up-swipe → open enigma. failOffsetY ensures taps and downward /
+  // horizontal swipes do NOT trigger.
+  const handleSwipe = useMemo(
+    () =>
+      Gesture.Pan()
+        .activeOffsetY(HANDLE_SWIPE_ACTIVE_Y)
+        .failOffsetY(HANDLE_SWIPE_FAIL_Y)
+        .onEnd((_event, success) => {
+          if (success) {
+            setEnigmaOpen(true);
+          }
+        }),
+    [],
+  );
+
+  const surfaceGesture = useMemo(
+    () => Gesture.Race(edgeSwipe, handleSwipe),
+    [edgeSwipe, handleSwipe],
+  );
+
+  const handleEnigmaClose = () => {
+    onDescriptionClosed?.();
+    setEnigmaOpen(false);
+  };
+
+  // When the target gesture is undefined (e2e mode or advance-state gating),
+  // render the circle plain — GestureDetector accepts no gesture prop and
+  // passes touches through to the Pressable underneath.
+  const targetWrap = touchLocation && target?.dragStyle && (
+    <Animated.View
+      style={[target.dragStyle, styles.dragRing, pulseStyle]}
+      testID={guess ? 'game.picture.guess-target-wrap' : 'game.picture.hide-target-wrap'}
+    >
+      <IconButton accessibilityLabel="Clear selected point" icon={"close-circle-outline"} color={"white"} size={target.targetSize} onPress={handleIconPress} testID={guess ? 'game.picture.clear-guess' : 'game.picture.clear-hide'}/>
+      {guess && speedRingActive && target?.dragSize > 0 && (
+        <View style={[StyleSheet.absoluteFill, styles.speedRingWrap]} pointerEvents="none">
+          <SpeedRing size={target.dragSize} durationMs={speedDurationMs} active={speedRingActive} />
+        </View>
+      )}
+    </Animated.View>
+  );
+
   return (
     <View style={styles.container} >
-      <View style={[styles.pressable, imageDimensionStyle]}>
-        <Pressable
-          accessibilityLabel={guess ? 'Guess picture surface' : 'Hide picture surface'}
-          onPress={handlePress}
-          onLongPress={handleLongPress}
-          style={StyleSheet.absoluteFill}
-          testID={guess ? 'game.picture.guess-surface' : 'game.picture.hide-surface'}
-        >
-          <ImageBackground
-            accessibilityLabel={guess ? 'Guess picture image' : 'Hide picture image'}
-            source={{uri : uri}}
-            resizeMode='stretch'
-            style={styles.image}
-            testID={guess ? 'game.picture.guess-image' : 'game.picture.hide-image'}
+      <GestureDetector gesture={surfaceGesture}>
+        <View style={[styles.pressable, imageDimensionStyle]}>
+          <Pressable
+            accessibilityLabel={guess ? 'Guess picture surface' : 'Hide picture surface'}
+            onPress={handlePress}
+            onLongPress={handleLongPress}
+            style={StyleSheet.absoluteFill}
+            testID={guess ? 'game.picture.guess-surface' : 'game.picture.hide-surface'}
           >
+            <ImageBackground
+              accessibilityLabel={guess ? 'Guess picture image' : 'Hide picture image'}
+              source={{uri : uri}}
+              resizeMode='stretch'
+              style={styles.image}
+              testID={guess ? 'game.picture.guess-image' : 'game.picture.hide-image'}
+            >
 {/* target not showing for guessscreen */}
-            { guess ? (
-              <EnigmaOverlay description={description} screenHeight={imageDimensionStyle.height} defaultOpen={defaultOpen} onClose={onDescriptionClosed}/>
-            ) : null }
-          </ImageBackground>
+              { guess ? (
+                <EnigmaOverlay description={description} screenHeight={imageDimensionStyle.height} isOpen={enigmaOpen} onClose={handleEnigmaClose}/>
+              ) : null }
+            </ImageBackground>
 
-        </Pressable>
+          </Pressable>
 
 {/* no cross, when guess, if null  */}
-        {touchLocation && target?.dragStyle && (
-          <Animated.View
-            {...(targetPanHandlers || {})}
-            style={[target.dragStyle, styles.dragRing, pulseStyle]}
-            testID={guess ? 'game.picture.guess-target-wrap' : 'game.picture.hide-target-wrap'}
-          >
-            <IconButton accessibilityLabel="Clear selected point" icon={"close-circle-outline"} color={"white"} size={target.targetSize} onPress={handleIconPress} testID={guess ? 'game.picture.clear-guess' : 'game.picture.clear-hide'}/>
-            {guess && speedRingActive && target?.dragSize > 0 && (
-              <View style={[StyleSheet.absoluteFill, styles.speedRingWrap]} pointerEvents="none">
-                <SpeedRing size={target.dragSize} durationMs={speedDurationMs} active={speedRingActive} />
-              </View>
-            )}
-          </Animated.View>
-        )}
-      </View>
+          {targetGesture
+            ? (
+              <GestureDetector gesture={targetGesture}>
+                {targetWrap}
+              </GestureDetector>
+            )
+            : targetWrap}
+        </View>
+      </GestureDetector>
 
       {
         showModal &&
-          <CenteredModal 
-            onPress={handleConfirm} 
-            onCancel={onCancel} 
+          <CenteredModal
+            onPress={handleConfirm}
+            onCancel={onCancel}
             isModalVisible={showModal}
             testIDPrefix={guess ? 'game.picture.guess-modal' : 'game.picture.hide-modal'}
           >

--- a/components/Picture/ShowPicture.js
+++ b/components/Picture/ShowPicture.js
@@ -17,11 +17,11 @@ const PULSE_OPACITY_MIN = 0.55;
 const PULSE_OPACITY_MAX = 1;
 const PULSE_NATIVE_DRIVER = { useNativeDriver: true };
 
-// Surface swipe thresholds for the nested RNGH detectors. The legacy responder
-// versions of these detectors lived in separate higher-zIndex subtrees that
-// physically intercepted touches in the left 36px / bottom 28px — starving the
-// target's drag. Moving detection INTO the picture subtree (the same subtree
-// the target circle lives in) eliminates that cross-subtree barrier.
+// Surface swipe thresholds for the single RNGH surface detector. The legacy
+// responder version lived in separate higher-zIndex subtrees that physically
+// intercepted touches in the left 36px / bottom 28px — starving the target's
+// drag. Moving detection INTO the picture subtree (the same subtree the target
+// circle lives in) eliminates that cross-subtree barrier.
 const EDGE_SWIPE_ACTIVE_X = 40;
 const EDGE_SWIPE_FAIL_X = -10;
 const EDGE_SWIPE_FAIL_Y = 40;
@@ -92,40 +92,32 @@ export default function ShowPicture({ uri, guess, description, touchLocation, ha
     ? { opacity: pulseOpacity, transform: [{ scale: pulseScale }] }
     : null;
 
-  // Edge right-swipe → open exit menu. failOffsetX/Y ensure taps, vertical
-  // swipes, and leftward swipes do NOT trigger the menu.
-  const edgeSwipe = useMemo(
+  // Surface swipe classifier. A SINGLE Pan recognizer replaces the old
+  // Race(edgeSwipe, handleSwipe): on Android that race mis-resolved a
+  // bottom-up swipe — edgeSwipe (rightward) never failed on upward movement
+  // (its failOffsetY was positive = down-only), so it lingered in BEGAN and
+  // could win the race, opening the exit menu instead of the description.
+  // One recognizer + a direction branch in onEnd removes the ambiguity: up
+  // opens the enigma, right opens the exit menu. Up takes priority so a
+  // bottom-up gesture always reaches the description even with drift.
+  const surfaceSwipe = useMemo(
     () =>
       Gesture.Pan()
         .activeOffsetX(EDGE_SWIPE_ACTIVE_X)
+        .activeOffsetY(HANDLE_SWIPE_ACTIVE_Y)
         .failOffsetX(EDGE_SWIPE_FAIL_X)
-        .failOffsetY(EDGE_SWIPE_FAIL_Y)
-        .onEnd((_event, success) => {
-          if (success) {
+        .failOffsetY(HANDLE_SWIPE_FAIL_Y)
+        .onEnd((event, success) => {
+          if (!success) {
+            return;
+          }
+          if (event.translationY <= HANDLE_SWIPE_ACTIVE_Y) {
+            setEnigmaOpen(true);
+          } else if (event.translationX >= EDGE_SWIPE_ACTIVE_X) {
             onEdgeSwipe?.();
           }
         }),
     [onEdgeSwipe],
-  );
-
-  // Bottom up-swipe → open enigma. failOffsetY ensures taps and downward /
-  // horizontal swipes do NOT trigger.
-  const handleSwipe = useMemo(
-    () =>
-      Gesture.Pan()
-        .activeOffsetY(HANDLE_SWIPE_ACTIVE_Y)
-        .failOffsetY(HANDLE_SWIPE_FAIL_Y)
-        .onEnd((_event, success) => {
-          if (success) {
-            setEnigmaOpen(true);
-          }
-        }),
-    [],
-  );
-
-  const surfaceGesture = useMemo(
-    () => Gesture.Race(edgeSwipe, handleSwipe),
-    [edgeSwipe, handleSwipe],
   );
 
   const handleEnigmaClose = () => {
@@ -152,7 +144,7 @@ export default function ShowPicture({ uri, guess, description, touchLocation, ha
 
   return (
     <View style={styles.container} >
-      <GestureDetector gesture={surfaceGesture}>
+      <GestureDetector gesture={surfaceSwipe}>
         <View style={[styles.pressable, imageDimensionStyle]}>
           <Pressable
             accessibilityLabel={guess ? 'Guess picture surface' : 'Hide picture surface'}

--- a/constants/defaultCategories.js
+++ b/constants/defaultCategories.js
@@ -1,0 +1,22 @@
+import { getCategoryAsset } from '../utils/categoryAssets';
+
+export const DEFAULT_CATEGORIES = [
+  { key: 'other', name: 'Other', sortOrder: 1 },
+  { key: 'nature', name: 'Nature', sortOrder: 2 },
+  { key: 'city', name: 'City', sortOrder: 3 },
+  { key: 'abstract', name: 'Abstract', sortOrder: 5 },
+  { key: 'animals', name: 'Animals', sortOrder: 6 },
+  { key: 'food', name: 'Food', sortOrder: 7 },
+  { key: 'vehicles', name: 'Vehicles', sortOrder: 8 },
+  { key: 'interiors', name: 'Interiors', sortOrder: 9 },
+  { key: 'landmarks', name: 'Landmarks', sortOrder: 10 },
+];
+
+export function getDefaultCategories() {
+  return {
+    data: DEFAULT_CATEGORIES.map((category) => ({
+      ...category,
+      thumbnailUrl: getCategoryAsset(category.key),
+    })),
+  };
+}

--- a/hooks/useAdCadence.ts
+++ b/hooks/useAdCadence.ts
@@ -1,5 +1,4 @@
 import { useCallback, useRef, useState } from 'react';
-import { Platform } from 'react-native';
 
 import { consumeAdSlot as resolveAdSlot } from '../utils/adCadence';
 import type { AdScope, ConsumeAdSlotResult } from '../utils/adCadence';
@@ -7,8 +6,6 @@ import { shouldSuppressAds, type ActiveGroupAdContext } from '../services/billin
 import type { AuthContextLike } from '../services/billing/entitlements';
 import { isE2EMode } from '../utils/e2eMode';
 import type { AdSource } from '../services/ads/AdSource';
-
-const IS_ANDROID = Platform.OS === 'android';
 
 type UseAdCadenceArgs = {
   scope?: AdScope;
@@ -42,12 +39,18 @@ export function useAdCadence({ scope, activeGroup, authContext, adSource }: UseA
   const isE2E = isE2EMode();
 
   const consumeCurrentAdSlot = useCallback((): ConsumeAdSlotResult => {
+    // isSourceReady is platform-agnostic: the composite adSource.isReady() is
+    // true on every platform (InternalProAdSource.isReady() is always true →
+    // fallback panel always eligible), and on Android a loaded AdMob
+    // interstitial takes precedence via the bridge snapshot. Gating on the
+    // platform here previously made iOS permanently isSourceReady=false and
+    // suppressed every ad; paid tier and e2e are still skipped by consumeAdSlot.
     const result = resolveAdSlot({
       successesSinceLastAd: successesSinceLastAdRef.current,
       scope,
       isAdFree,
       isE2E,
-      isSourceReady: IS_ANDROID && adSource.isReady(),
+      isSourceReady: adSource.isReady(),
     });
     successesSinceLastAdRef.current = result.nextCount;
     setSuccessesSinceLastAd(result.nextCount);

--- a/hooks/useAdSource.ts
+++ b/hooks/useAdSource.ts
@@ -2,20 +2,19 @@ import { useRef } from 'react';
 
 import { createFallbackAdSource } from '../services/ads/FallbackAdSource';
 import { createAdMobInterstitialSource } from '../services/ads/AdMobInterstitialSource';
+import { adMobBridgeSnapshot } from '../services/ads/AdMobInterstitialBridge';
 import { createInternalProAdSource } from '../services/ads/InternalProAdSource';
 import type { AdSource } from '../services/ads/AdSource';
 
-// On iOS the whole ad feature is a no-op (Q1): the AdMob source is never ready, and
-// the InternalProAdSource is suppressed by useAdCadence's platform gate before
-// any overlay is shown. We still construct the composite for shape parity.
-//
-// NOTE (F2/F3): GuessScreen deliberately constructs AdMob WITHOUT a hookSnapshot —
-// GuessScreen never reads AdMob readiness at runtime; it only checks the composite's
-// `isReady()` to feed `consumeAdSlot({ isSourceReady })`, which on Android reduces to
-// `true` because InternalProAdSource.isReady() is always true. The real AdMob hook
-// wiring lives in App.tsx (<AdMobInterstitialBridge />, hoisted for app lifetime).
+// Composite ad source for the free-tier ad slot. AdMob is bound to the App-level
+// bridge snapshot (mounted once for app lifetime in App.tsx via
+// <AdMobInterstitialBridge />): on Android, when the bridge has a loaded native
+// interstitial, adMob.isReady() is true and FallbackAdSource picks it; otherwise
+// the InternalProAdSource fallback panel renders on every platform (its
+// isReady() is always true). Ads fire on all platforms for the free tier —
+// paid tier and e2e are still skipped by consumeAdSlot.
 let defaultAdSourceFactory: () => AdSource = () => {
-  const adMob = createAdMobInterstitialSource();
+  const adMob = createAdMobInterstitialSource({ hookSnapshot: adMobBridgeSnapshot });
   const internal = createInternalProAdSource();
   return createFallbackAdSource(adMob, internal);
 };

--- a/hooks/useGroupCategories.js
+++ b/hooks/useGroupCategories.js
@@ -1,18 +1,21 @@
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { Alert } from 'react-native';
 
 import { AuthContext } from '../store/auth-context';
 import {
-  listGroupCategories,
   createGroupCategory,
   updateGroupCategory,
   deleteGroupCategory,
 } from '../services/groups/groupCategoriesApi';
 import {
+  loadGroupCategoriesOptimistic,
+  refreshGroupCategories,
+} from '../services/groups/groupCategoriesStore';
+import {
   deleteCategoryThumbnailFile,
   resolveCategoryThumbnail,
 } from '../services/groups/groupCategoryThumbnails';
 import { uploadCategoryThumbnail } from '../services/groups/categoryThumbnailUpload';
-import { Alert } from 'react-native';
 
 /**
  * Owns category CRUD + thumbnail management for a private group.
@@ -21,6 +24,11 @@ import { Alert } from 'react-native';
  * delete / swap-thumbnail). The view (GroupCategoriesSection) consumes this and
  * renders. Dependencies (auth context, group id, refresh callback) are injected,
  * so the hook is unit-testable in isolation.
+ *
+ * Load strategy: render from the offline cache first (optimistic), then
+ * background-revalidate from the server and replace state only when the fresh
+ * payload differs. Mutations write-through to the cache via the store. The store
+ * already swallows network errors, so this hook never throws on load.
  *
  * @param {string} groupId - active private group id
  * @param {() => void} onRefresh - refresh the group hub after mutations that
@@ -37,17 +45,14 @@ export function useGroupCategories({ groupId, onRefresh }) {
   const [newCategoryName, setNewCategoryName] = useState('');
   const [isSwappingThumbnail, setIsSwappingThumbnail] = useState(false);
 
-  const loadCategories = useCallback(async () => {
-    if (!groupId) return;
-    setLoading(true);
-    setError(null);
-    const response = await listGroupCategories(authContext, groupId);
-    setLoading(false);
-    if (response?.status === 200) {
-      const nextCategories = response.data ?? [];
-      setCategories(nextCategories);
+  const hasInitialLoad = useRef(true);
+
+  const applyCategories = useCallback(
+    (nextCategories) => {
+      const list = Array.isArray(nextCategories) ? nextCategories : [];
+      setCategories(list);
       setDrafts(
-        nextCategories.reduce((accumulator, category) => {
+        list.reduce((accumulator, category) => {
           accumulator[category.id] = category.name ?? '';
           return accumulator;
         }, {}),
@@ -55,27 +60,63 @@ export function useGroupCategories({ groupId, onRefresh }) {
       // Resolve display URIs the same way GuessPathScreen does: local cache hit
       // when available, otherwise fetch + cache (handles backend-storage auth and
       // S3 presigned URLs uniformly). Falls back to null -> initial swatch.
-      const resolved = await Promise.all(
-        nextCategories.map((category) => (
+      // Runs on both the optimistic and the fresh payload so the locally-cached
+      // file uri can enrich/override the base thumbnailUrl set by the store's
+      // normalizePrivateCategory. Fire-and-forget.
+      Promise.all(
+        list.map((category) => (
           category?.thumbnail_image_id
             ? resolveCategoryThumbnail(authContext, { groupId, category })
             : Promise.resolve(null)
         )),
-      );
-      setThumbnailUris(
-        nextCategories.reduce((accumulator, category, index) => {
-          accumulator[category.id] = resolved[index];
-          return accumulator;
-        }, {}),
-      );
-    } else {
-      setError(response?.data ?? 'Could not load categories.');
+      ).then((resolved) => {
+        setThumbnailUris(
+          list.reduce((accumulator, category, index) => {
+            accumulator[category.id] = resolved[index];
+            return accumulator;
+          }, {}),
+        );
+      });
+    },
+    [authContext, groupId],
+  );
+
+  const loadCategories = useCallback(async () => {
+    if (!groupId) return;
+    if (hasInitialLoad.current) {
+      setLoading(true);
     }
-  }, [authContext, groupId]);
+    setError(null);
+    try {
+      await loadGroupCategoriesOptimistic({
+        context: authContext,
+        groupId,
+        onCategories: (nextCategories) => {
+          applyCategories(nextCategories);
+          hasInitialLoad.current = false;
+        },
+      });
+    } catch {
+      // store already swallows network errors; never propagate to caller
+    } finally {
+      setLoading(false);
+    }
+  }, [authContext, groupId, applyCategories]);
 
   useEffect(() => {
     loadCategories();
   }, [loadCategories]);
+
+  // Write-through after a successful mutation: pull fresh server state, persist
+  // to cache, then update local state from { data }. Returns the store result so
+  // callers can detect { isError } if needed.
+  const writeThrough = useCallback(async () => {
+    const result = await refreshGroupCategories({ context: authContext, groupId });
+    if (result?.data) {
+      applyCategories(result.data);
+    }
+    return result;
+  }, [authContext, groupId, applyCategories]);
 
   const setDraft = useCallback((categoryId, value) => {
     setDrafts((current) => ({ ...current, [categoryId]: value }));
@@ -87,11 +128,11 @@ export function useGroupCategories({ groupId, onRefresh }) {
     const response = await createGroupCategory(authContext, groupId, { name: trimmed });
     if (response?.status === 200 || response?.status === 201) {
       setNewCategoryName('');
-      await loadCategories();
+      await writeThrough();
     } else {
       Alert.alert(`Error ${response?.status ?? ''}`, 'Could not add category.');
     }
-  }, [authContext, groupId, newCategoryName, loadCategories]);
+  }, [authContext, groupId, newCategoryName, writeThrough]);
 
   const saveCategory = useCallback(
     async (category) => {
@@ -101,12 +142,12 @@ export function useGroupCategories({ groupId, onRefresh }) {
         name: nextName,
       });
       if (response?.status === 200 || response?.status === 204) {
-        await loadCategories();
+        await writeThrough();
       } else {
         Alert.alert(`Error ${response?.status ?? ''}`, 'Could not update category.');
       }
     },
-    [authContext, groupId, drafts, loadCategories],
+    [authContext, groupId, drafts, writeThrough],
   );
 
   const removeCategory = useCallback(
@@ -122,7 +163,7 @@ export function useGroupCategories({ groupId, onRefresh }) {
             onPress: async () => {
               const response = await deleteGroupCategory(authContext, groupId, category.id);
               if (response?.status === 200 || response?.status === 204) {
-                await loadCategories();
+                await writeThrough();
               } else {
                 Alert.alert(`Error ${response?.status ?? ''}`, 'Could not delete category.');
               }
@@ -131,7 +172,7 @@ export function useGroupCategories({ groupId, onRefresh }) {
         ],
       );
     },
-    [authContext, groupId, loadCategories],
+    [authContext, groupId, writeThrough],
   );
 
   // Category thumbnail swap via the shared helper (same flow used by
@@ -151,7 +192,7 @@ export function useGroupCategories({ groupId, onRefresh }) {
           thumbnailImageId: uploaded.imageId,
         });
         if (updateResponse?.status === 200 || updateResponse?.status === 204) {
-          await loadCategories();
+          await writeThrough();
           Alert.alert('Uploaded', 'Category thumbnail updated.');
           onRefresh?.();
         } else {
@@ -163,7 +204,7 @@ export function useGroupCategories({ groupId, onRefresh }) {
         setIsSwappingThumbnail(false);
       }
     },
-    [authContext, groupId, loadCategories, onRefresh],
+    [authContext, groupId, writeThrough, onRefresh],
   );
 
   return {

--- a/hooks/useTargetDrag.ts
+++ b/hooks/useTargetDrag.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { PanResponder } from 'react-native';
+import { Gesture } from 'react-native-gesture-handler';
 
 import { buildSelectionFromPixels } from '../utils/targetLocation';
 
@@ -41,7 +41,7 @@ export type UseTargetDragArgs = {
 export type UseTargetDragResult = {
   touchLocation: { x: string; y: string } | null;
   target: UseTargetDragSelection['target'];
-  panHandlers: unknown;
+  gesture: unknown;
   setSelection: (selection: UseTargetDragSelection) => void;
 };
 
@@ -103,16 +103,21 @@ export function useTargetDrag(args: UseTargetDragArgs): UseTargetDragResult {
     setTarget(selection.target);
   }, []);
 
-  const panHandlers = useMemo(() => {
+  // RNGH Gesture.Pan replaces the legacy PanResponder. The legacy responder
+  // only negotiated touches along the target view's ancestor chain — a separate
+  // higher-zIndex subtree (the exit-menu edge strip / enigma handle strip)
+  // physically intercepted touches in those zones and the target's chain was
+  // never consulted. RNGH uses a single responder system rooted at
+  // GestureHandlerRootView, so a gesture on the target circle wins regardless
+  // of sibling overlays. Pan only activates past activeOffset, so taps still
+  // fall through to the Pressable below for e2e target placement.
+  const gesture = useMemo(() => {
     if (!enabled) {
       return undefined;
     }
-    return PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onStartShouldSetPanResponderCapture: () => true,
-      onMoveShouldSetPanResponder: () => false,
-      onMoveShouldSetPanResponderCapture: () => false,
-      onPanResponderGrant: () => {
+    return Gesture.Pan()
+      .enabled(true)
+      .onBegin(() => {
         onInteractRef.current?.();
         userInteractedRef.current = true;
         const { target: currentTarget } = stateRef.current;
@@ -121,15 +126,15 @@ export function useTargetDrag(args: UseTargetDragArgs): UseTargetDragResult {
           x: (currentTarget?.targetStyle?.left ?? 0) + half,
           y: (currentTarget?.targetStyle?.top ?? 0) + half,
         };
-      },
-      onPanResponderMove: (_event, gestureState) => {
+      })
+      .onUpdate((event) => {
         const {
           screenWidth: sw,
           screenHeight: sh,
           imageDimensionStyle: dims,
         } = stateRef.current;
-        const nextX = clamp(dragStartRef.current.x + gestureState.dx, 0, dims.width);
-        const nextY = clamp(dragStartRef.current.y + gestureState.dy, 0, dims.height);
+        const nextX = clamp(dragStartRef.current.x + event.translationX, 0, dims.width);
+        const nextY = clamp(dragStartRef.current.y + event.translationY, 0, dims.height);
         const selection = buildSelectionFromPixels({
           locationX: nextX,
           locationY: nextY,
@@ -139,16 +144,14 @@ export function useTargetDrag(args: UseTargetDragArgs): UseTargetDragResult {
         }) as UseTargetDragSelection;
         setTouchLocation(selection.location);
         setTarget(selection.target);
-      },
-      onPanResponderRelease: (_event, gestureState) => {
-        const moved = Math.hypot(gestureState.dx, gestureState.dy);
+      })
+      .onFinalize((event) => {
+        const moved = Math.hypot(event.translationX ?? 0, event.translationY ?? 0);
         if (moved < TAP_THRESHOLD) {
           onTapRef.current?.();
         }
-      },
-      onPanResponderTerminationRequest: () => false,
-    }).panHandlers;
+      });
   }, [enabled]);
 
-  return { touchLocation, target, panHandlers, setSelection };
+  return { touchLocation, target, gesture, setSelection };
 }

--- a/screens/GuessScreens/GuessPathScreen.js
+++ b/screens/GuessScreens/GuessPathScreen.js
@@ -19,6 +19,7 @@ import IconButton from '../../components/UI/IconButton';
 import Button from '../../components/UI/Button';
 import CenteredModal from '../../components/UI/CenteredModal';
 import { LANGUAGES } from '../../constants/languages';
+import { getDefaultCategories } from '../../constants/defaultCategories';
 import { getCategories } from '../../utils/categoryRequests';
 import {
   getPreferredLanguage,
@@ -33,9 +34,9 @@ import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../../sto
 import {
   createGroupCategory,
   deleteGroupCategory,
-  listGroupCategories,
   updateGroupCategory,
 } from '../../services/groups/groupCategoriesApi';
+import { loadGroupCategoriesOptimistic } from '../../services/groups/groupCategoriesStore';
 import {
   resolveCategoryThumbnail,
   deleteCategoryThumbnailFile,
@@ -103,45 +104,46 @@ export default function GuessPathScreen({ navigation, route }) {
   const isOwner = activeGroup?.isOwnedByViewer === true;
   const { group, theme } = useScopedPrivateGroupTheme(routeScope);
 
-  function normalizePrivateCategory(category, resolvedThumbnailUrl = null) {
-    return {
+  const enrichAndSetPrivateCategories = useCallback(async (nextCategories) => {
+    const list = Array.isArray(nextCategories) ? nextCategories : [];
+    const resolvedThumbnailUrls = await Promise.all(
+      list.map((category) => (
+        category?.thumbnail_image_id
+          ? resolveCategoryThumbnail(context, {
+            groupId: scope.groupId,
+            category,
+          })
+          : Promise.resolve(null)
+      ))
+    );
+
+    setCategories(list.map((category, index) => ({
       ...category,
-      key: category?.key ?? category?.id,
-      thumbnailUrl: resolvedThumbnailUrl
+      thumbnailUrl: resolvedThumbnailUrls[index]
         ?? category?.thumbnailUrl
         ?? category?.thumbnail_url
         ?? null,
-    };
-  }
+    })));
+  }, [context, scope?.groupId]);
 
   const reloadCategories = useCallback(async () => {
-    const response = isPrivateScope
-      ? await listGroupCategories(context, scope.groupId)
-      : await getCategories({ context });
-
-    if (response?.data) {
-      if (isPrivateScope) {
-        const privateCategories = response.data ?? [];
-        const resolvedThumbnailUrls = await Promise.all(
-          privateCategories.map((category) => (
-            category?.thumbnail_image_id
-              ? resolveCategoryThumbnail(context, {
-                groupId: scope.groupId,
-                category,
-              })
-              : Promise.resolve(null)
-          ))
-        );
-
-        setCategories(privateCategories.map((category, index) => (
-          normalizePrivateCategory(category, resolvedThumbnailUrls[index])
-        )));
-        return;
-      }
-
-      setCategories(response.data ?? []);
+    if (isPrivateScope) {
+      await loadGroupCategoriesOptimistic({
+        context,
+        groupId: scope.groupId,
+        onCategories: enrichAndSetPrivateCategories,
+      });
+      return;
     }
-  }, [context, isPrivateScope, scope?.groupId]);
+
+    if (isE2EMode()) {
+      const response = await getCategories({ context });
+      setCategories(response?.data ?? []);
+      return;
+    }
+
+    setCategories(getDefaultCategories().data);
+  }, [context, isPrivateScope, scope?.groupId, enrichAndSetPrivateCategories]);
 
   useFocusEffect(
     useCallback(() => {
@@ -389,8 +391,9 @@ export default function GuessPathScreen({ navigation, route }) {
         )}
         <FlatList
           data={gridData}
+          extraData={navigationLanguage}
           numColumns={2}
-          keyExtractor={(item) => item.id}
+          keyExtractor={(item) => item.key ?? item.id}
           columnWrapperStyle={styles.columnWrapper}
           contentContainerStyle={styles.gridContent}
           testID="guess-path.category.grid"

--- a/screens/GuessScreens/GuessScreen.tsx
+++ b/screens/GuessScreens/GuessScreen.tsx
@@ -65,7 +65,7 @@ type GuessNavigation = {
   navigate(name: 'GuessPathScreen', params?: Record<string, unknown>): void;
   replace(name: 'ResultScreen', params: Record<string, unknown>): void;
   popToTop(): void;
-  popTo(name: 'PrivateHomeScreen'): void;
+  reset(state: { index: number; routes: Array<{ name: string; params?: Record<string, unknown> }> }): void;
   addListener(event: 'beforeRemove', listener: () => void): () => void;
 };
 
@@ -397,7 +397,18 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
 
   function handleExitToHome() {
     if (isPrivate) {
-      navigation.popTo('PrivateHomeScreen');
+      // v6-compatible equivalent of v7's popTo('PrivateHomeScreen').
+      // Mirrors the reset-to-private-home pattern used by ResultChoices.js and
+      // guessNavigation.js. Carries `scope` so PrivateHomeScreen shows the
+      // correct group, and pops GuessFeedScreen/GuessPathScreen/GuessScreen —
+      // their beforeRemove listeners (useFlushOnLeave) flush unsent batches.
+      navigation.reset({
+        index: 1,
+        routes: [
+          { name: 'HomeScreen' },
+          { name: 'PrivateHomeScreen', params: { scope } },
+        ],
+      });
       return;
     }
     navigation.popToTop();

--- a/screens/GuessScreens/GuessScreen.tsx
+++ b/screens/GuessScreens/GuessScreen.tsx
@@ -322,9 +322,12 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
     // streak/score. Only the speed multiplier + overlay state commit here;
     // fire-and-forget deck prefetch is preserved (PB7 Phase 3 covers image
     // preload placement separately).
+    // B2: PUBLIC scope threads categoryKey only (bundled string keys, no
+    // server UUID); PRIVATE scope keeps categoryId (UUID). Mirrors the
+    // cardDeck.buildFeedFilters split.
     prefetchIfLow({
       categoryKey: category?.key || 'all',
-      categoryId: category?.id,
+      ...(isPrivate ? { categoryId: category?.id } : {}),
       language,
       scope,
       authContext,

--- a/screens/GuessScreens/GuessScreen.tsx
+++ b/screens/GuessScreens/GuessScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import type { FC } from 'react';
 import { AppState, useWindowDimensions, View } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import AdInterstitial from '../../components/Ads/AdInterstitial';
 import GuessExitSwipeMenu from '../../components/Guess/GuessExitSwipeMenu';
@@ -64,6 +65,7 @@ type GuessNavigation = {
   navigate(name: 'GuessPathScreen', params?: Record<string, unknown>): void;
   replace(name: 'ResultScreen', params: Record<string, unknown>): void;
   popToTop(): void;
+  popTo(name: 'PrivateHomeScreen'): void;
   addListener(event: 'beforeRemove', listener: () => void): () => void;
 };
 
@@ -105,6 +107,7 @@ type GuessPictureComponent = FC<{
   pulseTarget?: boolean;
   onInteract?: () => void;
   disabled?: boolean;
+  onEdgeSwipe?: () => void;
 }>;
 
 type TutorialOverlayComponent = FC<{
@@ -126,6 +129,12 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
   const isPrivate = scope?.kind === 'private';
 
   const [showSuccess, setShowSuccess] = useState(false);
+  // Exit-menu open state is owned here (controlled GuessExitSwipeMenu). The
+  // legacy menu detected the left-edge swipe itself in a separate higher-zIndex
+  // subtree that intercepted touches in the left 36px and starved the target's
+  // drag. Detection now lives in the picture subtree (ShowPicture's nested RNGH
+  // surface detector); the surface fires `onEdgeSwipe` → flip this state.
+  const [exitMenuOpen, setExitMenuOpen] = useState(false);
   // F4: synchronous mirror of `showSuccess` so useResolveLifecycle's no-ad
   // commit gate can read overlay visibility WITHOUT waiting for a passive
   // effect flush. Written synchronously by `applyShowSuccess` at every
@@ -387,6 +396,10 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
   }
 
   function handleExitToHome() {
+    if (isPrivate) {
+      navigation.popTo('PrivateHomeScreen');
+      return;
+    }
     navigation.popToTop();
   }
 
@@ -402,8 +415,19 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
 
   return(
     <PrivateGroupThemeProvider group={group}>
+    {/* RNGH root scoped to the guess screen subtree so it hosts the nested
+        GestureDetectors in ShowPicture (target drag + surface edge/handle
+        swipes) WITHOUT wrapping the app/navigators — an app-wide wrap broke
+        HomeScreen header touches. */}
+    <GestureHandlerRootView style={{ flex: 1 }}>
     <>
-    <GuessExitSwipeMenu onHome={handleExitToHome} showHints={hintsActive} onInteract={dismissHints} />
+    <GuessExitSwipeMenu
+      isOpen={exitMenuOpen}
+      onClose={() => setExitMenuOpen(false)}
+      onHome={handleExitToHome}
+      showHints={hintsActive}
+      onInteract={dismissHints}
+    />
     <GuessPicture
       // PB-key-collision: keying on listId alone collides when Tier 2
       // foreground-fetches a new card whose normalizeListIds-assigned listId
@@ -432,6 +456,7 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
       // PB2: input gating — disable tap/drag confirmation while the advance
       // state machine is mid-cycle so toAdScreen cannot double-fire.
       disabled={advance.state !== 'idle'}
+      onEdgeSwipe={() => setExitMenuOpen(true)}
     />
     {/*
       P3 (D1): off-screen hidden <Image> mounts that force RN to decode the
@@ -465,7 +490,8 @@ export default function GuessScreen({ navigation, route }: GuessScreenProps) {
          isPortrait={isPortrait}
         />
       }
-    </>  
+    </>
+    </GestureHandlerRootView>
     </PrivateGroupThemeProvider>
   );
 };

--- a/screens/SetInstructionScreen.js
+++ b/screens/SetInstructionScreen.js
@@ -16,15 +16,15 @@ import { handleOrientation } from '../utils/orientation';
 import { handleImageType, isTypeValid } from '../utils/imageInfos';
 import { getPreferredLanguage, saveE2EHiddenGuessCard } from '../utils/storageDatum';
 import { getCategories } from '../utils/categoryRequests';
+import { getDefaultCategories } from '../constants/defaultCategories';
 import { resolveDefaultLanguage } from '../utils/languageDefaults';
-import { listGroupCategories } from '../services/groups/groupCategoriesApi';
+import { loadGroupCategoriesOptimistic } from '../services/groups/groupCategoriesStore';
 
 import LoadingOverlay from '../components/UI/LoadingOverlay';
 import { checkSecureStoreItem } from '../utils/auth';
 import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../store/privateGroupTheme-context';
 
 const NON_UPLOAD_CATEGORY_KEYS = new Set(['all']);
-const DEFAULT_CATEGORY_LOAD_ERROR_MESSAGE = 'Unable to load categories. Please try again.';
 
 function isUploadableCategoryKey(categoryKey) {
   return typeof categoryKey === 'string' && !NON_UPLOAD_CATEGORY_KEYS.has(categoryKey);
@@ -70,32 +70,32 @@ export default function SetInstructionsScreen({ navigation, route }) {
   const { group, theme } = useScopedPrivateGroupTheme(scope);
   const selectableCategories = categories.filter((category) => isUploadableCategoryKey(category?.key));
 
-  function normalizePrivateCategory(category) {
-    return {
-      ...category,
-      key: category?.key ?? category?.id,
-      thumbnailUrl: category?.thumbnailUrl ?? category?.thumbnail_url ?? null,
-    };
-  }
-
   const loadCategories = async () => {
-    const categoriesResponse = isPrivateScope
-      ? await listGroupCategories(context, scope.groupId)
-      : await getCategories({ context });
-
-    if (!isMountedRef.current) {
+    if (isPrivateScope) {
+      await loadGroupCategoriesOptimistic({
+        context,
+        groupId: scope.groupId,
+        onCategories: (nextCategories) => {
+          setCategories(nextCategories);
+          setCategoriesError(null);
+        },
+      });
       return;
     }
 
-    if (categoriesResponse?.isError || (categoriesResponse?.status && categoriesResponse.status !== 200)) {
-      setCategories([]);
-      setCategoriesError(categoriesResponse?.message || categoriesResponse?.data?.message || DEFAULT_CATEGORY_LOAD_ERROR_MESSAGE);
+    if (isE2EMode()) {
+      const categoriesResponse = await getCategories({ context });
+
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      setCategories(categoriesResponse?.data ?? []);
+      setCategoriesError(null);
       return;
     }
 
-    setCategories((categoriesResponse?.data ?? []).map((category) => (
-      isPrivateScope ? normalizePrivateCategory(category) : category
-    )));
+    setCategories(getDefaultCategories().data);
     setCategoriesError(null);
   };
 
@@ -172,6 +172,9 @@ export default function SetInstructionsScreen({ navigation, route }) {
 
   const handleImage = async ({userId, fileExtension}) => {
     const selectedCategoryObject = selectableCategories.find((category) => category.key === selectedCategory);
+    const scopeCategoryInfos = isPrivateScope
+      ? { categoryId: selectedCategoryObject?.id ?? null }
+      : { categoryKey: selectedCategoryObject?.key ?? null };
     const imageInfos = {
       uri: uri,
       userId: userId,
@@ -185,7 +188,7 @@ export default function SetInstructionsScreen({ navigation, route }) {
       xLocation: touchLocation.x,
       yLocation: touchLocation.y,
       language: language,
-      categoryId: selectedCategoryObject?.id ?? null,
+      ...scopeCategoryInfos,
     };
 
     setIsLoading(true);

--- a/services/cardDeck.js
+++ b/services/cardDeck.js
@@ -117,12 +117,9 @@ export function fetchCardBatch({ categoryKey, categoryId, language, scope, authC
     // head; the next non-empty batch overwrites the stale key with a real uuid.
     const effectivePictureId = pictureId === PUBLIC_FEED_END_CURSOR ? null : pictureId;
 
-    return getImages(effectivePictureId, authContext, {
-      category_id: resolveCategoryId(categoryId),
-      category_key: categoryKey || 'all',
-      language: resolveServerLanguage(language),
-      scope,
-    });
+    return getImages(effectivePictureId, authContext, buildFeedFilters({
+      categoryKey, categoryId, language, scope,
+    }));
   })();
 
   fetchInFlight.set(key, p);
@@ -133,6 +130,30 @@ export function fetchCardBatch({ categoryKey, categoryId, language, scope, authC
   });
 
   return p;
+}
+
+/**
+ * Build the `getImages` filters object for the current scope. PRIVATE scopes
+ * keep using `category_id` (server UUID); PUBLIC scopes switched to
+ * `category_key` (bundled string key) and stopped sending `category_id`. The
+ * 'all' pseudo-category sends neither key nor id (backend returns all).
+ *
+ * @param {object} args - { categoryKey, categoryId, language, scope }
+ * @returns {object} filters object forwarded to getImages
+ */
+function buildFeedFilters({ categoryKey, categoryId, language, scope }) {
+  const filters = {
+    language: resolveServerLanguage(language),
+    scope,
+  };
+  if (isPrivateScope(scope)) {
+    filters.category_id = resolveCategoryId(categoryId);
+    return filters;
+  }
+  if (categoryKey && categoryKey !== 'all') {
+    filters.category_key = categoryKey;
+  }
+  return filters;
 }
 
 /**

--- a/services/groups/groupCategoriesStore.js
+++ b/services/groups/groupCategoriesStore.js
@@ -1,0 +1,90 @@
+import { listGroupCategories } from './groupCategoriesApi';
+import {
+  readGroupCategoryCache,
+  writeGroupCategoryCache,
+} from './groupCategoryCache';
+
+export function normalizePrivateCategory(category) {
+  if (!category || typeof category !== 'object') {
+    return category;
+  }
+
+  return {
+    ...category,
+    key: category?.key ?? category?.id,
+    thumbnailUrl: category?.thumbnailUrl ?? category?.thumbnail_url ?? null,
+  };
+}
+
+function toSignatureEntry(category) {
+  return {
+    id: category?.id,
+    name: category?.name,
+    sort_order: category?.sort_order,
+    thumbnail_image_id: category?.thumbnail_image_id,
+  };
+}
+
+export function categoryListSignature(categories) {
+  const list = Array.isArray(categories) ? categories : [];
+  const entries = list.map(toSignatureEntry);
+  entries.sort((a, b) => {
+    const aId = a?.id;
+    const bId = b?.id;
+    if (aId === bId) return 0;
+    if (aId === null || aId === undefined) return -1;
+    if (bId === null || bId === undefined) return 1;
+    return aId < bId ? -1 : 1;
+  });
+
+  return JSON.stringify(entries);
+}
+
+export async function loadGroupCategoriesOptimistic({ context, groupId, onCategories }) {
+  let cached = null;
+
+  try {
+    cached = await readGroupCategoryCache(groupId);
+  } catch {
+    // best-effort: treat unreadable cache as no cache
+  }
+
+  let lastCached = cached;
+
+  if (Array.isArray(cached) && typeof onCategories === 'function') {
+    onCategories(cached);
+  }
+
+  try {
+    const resp = await listGroupCategories(context, groupId);
+    if (resp?.status === 200) {
+      const fresh = (resp.data ?? []).map(normalizePrivateCategory);
+
+      if (categoryListSignature(fresh) !== categoryListSignature(lastCached)) {
+        await writeGroupCategoryCache(groupId, fresh);
+        lastCached = fresh;
+        if (typeof onCategories === 'function') {
+          onCategories(fresh);
+        }
+      }
+    }
+  } catch {
+    // best-effort: cached state stays as-is
+  }
+}
+
+export async function refreshGroupCategories({ context, groupId }) {
+  try {
+    const resp = await listGroupCategories(context, groupId);
+    if (resp?.status === 200) {
+      const fresh = (resp.data ?? []).map(normalizePrivateCategory);
+      await writeGroupCategoryCache(groupId, fresh);
+
+      return { data: fresh };
+    }
+
+    return { isError: true, status: resp?.status };
+  } catch {
+    return { isError: true };
+  }
+}

--- a/services/groups/groupCategoryCache.js
+++ b/services/groups/groupCategoryCache.js
@@ -1,0 +1,49 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const PREFIX = 'groupCategories';
+
+function groupCategoryKey(groupId) {
+  return `${PREFIX}:${groupId}`;
+}
+
+export { groupCategoryKey };
+
+export async function readGroupCategoryCache(groupId) {
+  const stored = await AsyncStorage.getItem(groupCategoryKey(groupId));
+  if (!stored) {
+    return null;
+  }
+
+  let categories;
+  try {
+    categories = JSON.parse(stored);
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(categories)) {
+    return null;
+  }
+
+  return categories;
+}
+
+export async function writeGroupCategoryCache(groupId, categories) {
+  await AsyncStorage.setItem(
+    groupCategoryKey(groupId),
+    JSON.stringify(Array.isArray(categories) ? categories : []),
+  );
+}
+
+export async function clearGroupCategoryCache(groupId) {
+  await AsyncStorage.removeItem(groupCategoryKey(groupId));
+}
+
+export async function clearAllGroupCategoryCaches() {
+  const keys = await AsyncStorage.getAllKeys();
+  const target = keys.filter((key) => typeof key === 'string' && key.startsWith(`${PREFIX}:`));
+
+  if (target.length > 0) {
+    await AsyncStorage.multiRemove(target);
+  }
+}

--- a/utils/categoryRequests.js
+++ b/utils/categoryRequests.js
@@ -1,38 +1,12 @@
-import axios from "axios";
-import { getBackendHeaders, setHeaders } from "./auth";
-import { buildE2ECategories, isE2EMode } from "./e2eMode";
+import { buildE2ECategories, isE2EMode } from './e2eMode';
+import { getDefaultCategories } from '../constants/defaultCategories';
 
-function normalizeCategory(category) {
-  const { thumbnail_url, sort_order, ...rest } = category;
-  return {
-    ...rest,
-    thumbnailUrl: thumbnail_url,
-    sortOrder: sort_order,
-  };
-}
-
+// Public default categories are bundled; no server fetch.
+// E2E mode returns its own stub.
 export async function getCategories({ context }) {
   if (isE2EMode()) {
     return { data: buildE2ECategories() };
   }
 
-  const { token } = await getBackendHeaders(context);
-  const url = `${process.env.EXPO_PUBLIC_APP_BACKEND_URL}api/v1/categories`;
-  const headers = setHeaders({ token });
-  const config = {
-    headers: headers,
-  };
-
-  const response = await axios
-    .get(url, config)
-    .then((response) => {
-      const payload = response.data;
-      const rows = Array.isArray(payload) ? payload : (Array.isArray(payload?.data) ? payload.data : []);
-      return { data: rows.map(normalizeCategory) };
-    })
-    .catch((error) => {
-      return { isError: true, message: error?.message ?? 'Failed to load categories' };
-    });
-
-  return response;
+  return getDefaultCategories();
 }

--- a/utils/fileUploader.js
+++ b/utils/fileUploader.js
@@ -50,7 +50,7 @@ const exportPictureData = async ({ imagesInfos, context }) => {
       x_location: imagesInfos.xLocation,
       y_location: imagesInfos.yLocation,
       language: imagesInfos.language,
-      category_id: imagesInfos.categoryId,
+      category_key: imagesInfos.categoryKey,
 
       /* file_type, file_size */
     },
@@ -160,7 +160,7 @@ export async function imageUploader({ imageInfos, context, scope }) {
       xLocation: imageInfos.xLocation,
       yLocation: imageInfos.yLocation,
       language: imageInfos.language,
-      categoryId: imageInfos.categoryId,
+      categoryKey: imageInfos.categoryKey,
     },
     context: context
   });

--- a/utils/imagesRequests.js
+++ b/utils/imagesRequests.js
@@ -117,7 +117,8 @@ export async function prepareImageUpload(context, { contentType, contentLength }
  * @param {Object}  params
  * @param {Object}  params.config  Axios config (headers) to merge with timeout.
  * @param {string|number} params.userId Target user id.
- * @param {Object}  [params.filters] Optional `category_id` / `language` filters.
+ * @param {Object}  [params.filters] Optional `category_id` (private UUID),
+ *   `category_key` (public bundled key), and `language` filters.
  * @returns {Promise<{data: 401} | {data: null, errorReason: GetImagesErrorReason} | import('axios').AxiosResponse>}
  */
 async function getImagesInfos({ config, userId, filters }) {
@@ -126,6 +127,7 @@ async function getImagesInfos({ config, userId, filters }) {
   const requestConfig = { ...config, timeout: 15000 };
   const params = {};
   if (filters?.category_id != null) params.category_id = filters.category_id;
+  if (filters?.category_key != null) params.category_key = filters.category_key;
   if (filters?.language != null) params.language = filters.language;
   if (Object.keys(params).length > 0) {
     requestConfig.params = { ...requestConfig.params, ...params };
@@ -155,7 +157,8 @@ async function getImagesInfos({ config, userId, filters }) {
  * @param {string|number} params.userId Target user id.
  * @param {string}  params.pictureId Keyset cursor: the `name` of the last
  *   image of the previous batch.
- * @param {Object}  [params.filters] Optional `category_id` / `language` filters.
+ * @param {Object}  [params.filters] Optional `category_id` (private UUID),
+ *   `category_key` (public bundled key), and `language` filters.
  * @returns {Promise<{data: 401} | {data: null, errorReason: GetImagesErrorReason} | import('axios').AxiosResponse>}
  */
 async function getNextImagesInfos({ config, userId, pictureId, filters }){
@@ -165,6 +168,7 @@ async function getNextImagesInfos({ config, userId, pictureId, filters }){
     name: pictureId
   };
   if (filters?.category_id != null) imageBody.category_id = filters.category_id;
+  if (filters?.category_key != null) imageBody.category_key = filters.category_key;
   if (filters?.language != null) imageBody.language = filters.language;
   const imageData = {
     image: imageBody
@@ -379,11 +383,16 @@ export async function getImages(pictureId, context, filters = {}) {
   console.log("getImages pictureId", pictureId);
 
   if (isPrivateScope(filters?.scope)) {
+    // Private cursor namespace: PRIVATE filters carry no category_key (server
+    // contract stays category_id), so derive the LOCAL cursor/exhausted
+    // namespace from the category id (or 'all'). cardDeck.fetchCardBatch reads
+    // the cursor with the same categoryKey value, so the private cursor
+    // round-trips instead of falling back to the shared public 'all' key.
     return fetchPrivateFeedPageForGame(pictureId, context, {
       groupId: filters.scope.groupId,
       categoryId: filters?.category_id,
       language: filters?.language,
-      categoryKey: filters?.category_key,
+      categoryKey: filters?.category_key ?? filters?.category_id ?? 'all',
     });
   }
 

--- a/utils/nextCardAdvancer.ts
+++ b/utils/nextCardAdvancer.ts
@@ -26,6 +26,12 @@ export type ResolveNextCardResult =
 
 type FailureReason = 'empty' | 'network' | 'server';
 
+function isPrivateScope(scope: unknown): boolean {
+  return !!scope && typeof scope === 'object' && scope !== null &&
+    (scope as { kind?: string }).kind === 'private' &&
+    !!(scope as { groupId?: unknown }).groupId;
+}
+
 export type AdvancerArgs = {
   category?: { id?: string | number | null; key?: string } | null;
   language?: string | null;
@@ -131,14 +137,19 @@ async function foregroundTopUp(
   }
 
   try {
-    const r = await fetchCardBatch({
+    // B2: PUBLIC scope threads categoryKey only (bundled string keys, no
+    // server UUID). PRIVATE scope keeps categoryId (UUID). Mirrors the
+    // cardDeck.buildFeedFilters split so the advancer never leaks a public
+    // id into the private-only category_id server param.
+    const fetchArgs: Parameters<typeof fetchCardBatch>[0] = {
       categoryKey,
-      categoryId: args.category?.id,
       language: args.language,
       scope: args.scope,
       authContext: args.authContext,
+      ...(isPrivateScope(args.scope) ? { categoryId: args.category?.id } : {}),
       ...(pictureIdOverride !== undefined ? { pictureIdOverride } : {}),
-    });
+    };
+    const r = await fetchCardBatch(fetchArgs);
     if (!r || r.isError === true) return { ok: false, reason: 'server' };
     if (!r.images || r.images.length === 0) {
       // F3a: cache the empty result so subsequent advances short-circuit at
@@ -159,7 +170,7 @@ async function foregroundTopUp(
     await appendCardBatch({
       cards: r.images,
       categoryKey,
-      categoryId: args.category?.id,
+      ...(isPrivateScope(args.scope) ? { categoryId: args.category?.id } : {}),
       language: args.language,
       scope: args.scope,
     });


### PR DESCRIPTION
This pull request refactors and modernizes the tests for `EnigmaOverlay` and `GuessExitSwipeMenu` components to use a controlled, prop-driven model instead of legacy gesture-based state. It also updates the `GuessPathScreen` tests to use a new group categories store and the latest category catalog logic. These changes improve test clarity, reliability, and alignment with the refactored components.

**Test refactoring for controlled components:**

- `__tests__/EnigmaOverlay.test.js` and `__tests__/GuessExitSwipeMenu.test.js` are rewritten to test the new controlled API, removing all gesture simulation logic and legacy PanResponder mocks. Tests now directly control the open/closed state via `isOpen` prop and verify rendering and callback behavior. [[1]](diffhunk://#diff-9da9fea0d9acd57cc40c7d54c32277f311d5be1aeb8c500ed3147d1cce86315dL1-L10) [[2]](diffhunk://#diff-9da9fea0d9acd57cc40c7d54c32277f311d5be1aeb8c500ed3147d1cce86315dL33-L38) [[3]](diffhunk://#diff-9da9fea0d9acd57cc40c7d54c32277f311d5be1aeb8c500ed3147d1cce86315dL65-R59) [[4]](diffhunk://#diff-9da9fea0d9acd57cc40c7d54c32277f311d5be1aeb8c500ed3147d1cce86315dL93-R133) [[5]](diffhunk://#diff-bedcd3d937c86bca9d38efa0eada568b59540764ceec5edcd268900ca71f5f8dL1-L10) [[6]](diffhunk://#diff-bedcd3d937c86bca9d38efa0eada568b59540764ceec5edcd268900ca71f5f8dL22) [[7]](diffhunk://#diff-bedcd3d937c86bca9d38efa0eada568b59540764ceec5edcd268900ca71f5f8dL43-L48) [[8]](diffhunk://#diff-bedcd3d937c86bca9d38efa0eada568b59540764ceec5edcd268900ca71f5f8dR50-R164)

**GuessPathScreen test updates:**

- Migrates group categories logic to use `loadGroupCategoriesOptimistic` from `groupCategoriesStore` and removes direct usage of `listGroupCategories` API. Test data is now injected via a helper that emits categories through the store mock. [[1]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfL65-R73) [[2]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfL108-R130) [[3]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfR154-R161) [[4]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfL160-R178) [[5]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfR190)
- Updates the way bundled categories are referenced and ensures tests reflect the new catalog structure.

**Documentation improvements:**

- Expands `AGENTS.md` with details on public and private category catalog logic, including offline caching and image scope rules.

**Minor test helper improvements:**

- Refactors `getCardPropsByKey` helper for more robust lookup in `GuessPathScreen` tests.

These changes ensure the tests accurately reflect the refactored, prop-driven UI logic and the latest category data flow.