### PR TITLE
Fix/image download flow guess feed

### DIFF
--- a/__tests__/GuessFeedScreen.test.js
+++ b/__tests__/GuessFeedScreen.test.js
@@ -235,7 +235,7 @@ describe('GuessFeedScreen', () => {
     const renderer = await renderScreen(navigation, route);
 
     expect(mockSwipeImage).not.toHaveBeenCalled();
-    expect(renderer.root.findByProps({ testID: 'guess-feed.filter.language.current' }).props.children).toBe('en');
+    expect(renderer.root.findByProps({ testID: 'guess-feed.filter.language.current' }).props.children).toBe('any');
 
     await act(async () => {
       deferredLanguage.resolve('fr');
@@ -250,6 +250,51 @@ describe('GuessFeedScreen', () => {
     dismissSwipeInstructions(renderer);
 
     expect(mockSwipeImage.mock.calls[mockSwipeImage.mock.calls.length - 1][0].language).toBe('fr');
+  });
+
+  it("no route language and no stored filter → SwipeImage receives language 'any' (matches GuessPathScreen navigation fallback, I6)", async () => {
+    const navigation = { navigate: jest.fn(), goBack: jest.fn() };
+    const route = makeRoute({ language: undefined });
+
+    getSessionLanguageFilter.mockResolvedValue(null);
+
+    const renderer = await renderScreen(navigation, route);
+
+    expect(renderer.root.findByProps({ testID: 'guess-feed.filter.language.current' }).props.children).toBe('any');
+
+    dismissSwipeInstructions(renderer);
+
+    expect(mockSwipeImage).toHaveBeenCalledTimes(1);
+    expect(mockSwipeImage.mock.calls[0][0].language).toBe('any');
+  });
+
+  it("startGuessing forwards 'any' — never 'en' — when unset", async () => {
+    const navigation = { navigate: jest.fn(), goBack: jest.fn() };
+    const route = makeRoute({ language: undefined });
+
+    getSessionLanguageFilter.mockResolvedValue(null);
+
+    const renderer = await renderScreen(navigation, route);
+
+    dismissSwipeInstructions(renderer);
+
+    const { startGuessing } = mockSwipeImage.mock.calls[0][0];
+
+    await act(async () => {
+      startGuessing({
+        item: {
+          pictureId: 'img-1',
+          touchLocation: { x: 0.5, y: 0.5 },
+        },
+      });
+    });
+
+    expect(navigation.navigate).toHaveBeenCalledTimes(1);
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      'GuessScreen',
+      expect.objectContaining({ language: 'any' })
+    );
+    expect(navigation.navigate.mock.calls[0][1].language).not.toBe('en');
   });
 
   it('routes startGuessing to GuessScreen carrying the swiped item, route params, category, and language', async () => {

--- a/__tests__/SettingsScreen.test.js
+++ b/__tests__/SettingsScreen.test.js
@@ -40,6 +40,11 @@ jest.mock('../utils/auth', () => ({
 jest.mock('../utils/storageDatum', () => ({
   getPreferredLanguage: jest.fn(),
   savePreferredLanguage: jest.fn(),
+  wipePublicGuessStorage: jest.fn(),
+}));
+
+jest.mock('../utils/servingCycle', () => ({
+  resetServingCycles: jest.fn(),
 }));
 
 jest.mock('../store/auth-context', () => {
@@ -57,7 +62,8 @@ import { act, create } from 'react-test-renderer';
 import SettingsScreen from '../screens/SettingsScreen';
 import { AuthContext } from '../store/auth-context';
 import { checkSecureStoreItem, deleteAccount, updateUser } from '../utils/auth';
-import { getPreferredLanguage, savePreferredLanguage } from '../utils/storageDatum';
+import { getPreferredLanguage, savePreferredLanguage, wipePublicGuessStorage } from '../utils/storageDatum';
+import { resetServingCycles } from '../utils/servingCycle';
 
 describe('SettingsScreen', () => {
   const contextValue = {
@@ -82,6 +88,8 @@ describe('SettingsScreen', () => {
     });
     getPreferredLanguage.mockResolvedValue('en');
     savePreferredLanguage.mockResolvedValue(undefined);
+    wipePublicGuessStorage.mockResolvedValue(undefined);
+    resetServingCycles.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -283,5 +291,34 @@ describe('SettingsScreen', () => {
 
     const testIDs = mockButton.mock.calls.map(([props]) => props.testID);
     expect(testIDs).not.toContain('settings.button.view-plans');
+  });
+
+  it('dev reset action calls wipePublicGuessStorage and resetServingCycles and shows success alert', async () => {
+    await renderScreen();
+
+    await act(async () => {
+      getButtonProps('settings.button.reset-guess-serving').onPress();
+      await flushEffects();
+    });
+
+    expect(wipePublicGuessStorage).toHaveBeenCalledTimes(1);
+    expect(resetServingCycles).toHaveBeenCalledTimes(1);
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Guess serving reset',
+      'Serving state cleared. Return to the category list and start fresh.'
+    );
+  });
+
+  it('action failure shows error alert, no crash', async () => {
+    wipePublicGuessStorage.mockRejectedValue(new Error('storage exploded'));
+
+    await renderScreen();
+
+    await act(async () => {
+      getButtonProps('settings.button.reset-guess-serving').onPress();
+      await flushEffects();
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith('Reset failed', 'storage exploded');
   });
 });

--- a/__tests__/ShowSuccess.test.js
+++ b/__tests__/ShowSuccess.test.js
@@ -32,6 +32,7 @@ jest.mock('../components/Results/ScoreCelebration', () => {
 });
 
 jest.mock('../utils/storageDatum', () => ({
+  addPlayedPictureId: jest.fn(() => Promise.resolve()),
   deleteImageFromStorage: jest.fn(),
   removeImageFromList: jest.fn(),
 }));

--- a/__tests__/SwipeImage.test.js
+++ b/__tests__/SwipeImage.test.js
@@ -51,6 +51,7 @@ jest.mock('../utils/ratingRequests', () => ({
 jest.mock('../utils/storageDatum', () => {
   const actual = jest.requireActual('../utils/storageDatum');
   return {
+    ...actual,
     PUBLIC_FEED_END_CURSOR: '__public_feed_end__',
     getE2EHiddenGuessCard: jest.fn(),
     getLocalImages: jest.fn(),
@@ -62,10 +63,10 @@ jest.mock('../utils/storageDatum', () => {
     // Task A (Fix 1): cardDeck persist/append call this on every non-empty
     // non-'all' batch — the component-level mock only needs it to resolve.
     clearExhaustedCategory: jest.fn(() => Promise.resolve()),
-    // Task C (Fix 2b): played-set writer + shared filter — resolving mocks;
-    // default passthrough keeps the filter a no-op until a test overrides it.
-    addPlayedPictureId: jest.fn(() => Promise.resolve()),
-    filterPlayedCards: jest.fn((cards) => Promise.resolve(cards)),
+    isCategoryExhausted: jest.fn(() => Promise.resolve(false)),
+    // Task C (Fix 2b): played-set writer + shared filter moved to
+    // utils/playedPictureIds (module extraction) — resolving mocks; default
+    // passthrough keeps the filter a no-op until a test overrides it.
     // Task D (Fix 3): delegate to the REAL implementation so the mock cannot
     // diverge from the storage-boundary numbering algorithm.
     normalizeListIds: actual.normalizeListIds,
@@ -74,6 +75,18 @@ jest.mock('../utils/storageDatum', () => {
     deleteImageFromStorage: jest.fn(),
   };
 });
+
+jest.mock('../utils/playedPictureIds', () => ({
+  addPlayedPictureId: jest.fn(() => Promise.resolve()),
+  filterPlayedCards: jest.fn((cards) => Promise.resolve(cards)),
+}));
+
+// C2: requireActual-spread keeps `isCycleExhausted` REAL (pure predicate)
+// while the storage-touching transition is pinned as a mock.
+jest.mock('../utils/servingCycle', () => ({
+  ...jest.requireActual('../utils/servingCycle'),
+  startNewServingCycle: jest.fn(() => Promise.resolve(1)),
+}));
 
 jest.mock('../services/groups/groupFeedApi', () => ({
   PRIVATE_FEED_END_CURSOR: '__private_feed_end__',
@@ -84,6 +97,14 @@ jest.mock('../services/groups/groupFeedCache', () => ({
   readGroupFeedCache: jest.fn(),
   writeGroupFeedCache: jest.fn(),
 }));
+
+jest.mock('../services/cardDeck', () => {
+  const actual = jest.requireActual('../services/cardDeck');
+  return {
+    ...actual,
+    removeCardFromGroupDeck: jest.fn(() => Promise.resolve()),
+  };
+});
 
 jest.mock('../store/auth-context', () => {
   const React = require('react');
@@ -115,21 +136,23 @@ import { buildE2EGuessCardFromPayload, buildE2EGuessCards, isE2EMode } from '../
 import { getImages } from '../utils/imagesRequests';
 import { getImageRating, getImageTags } from '../utils/ratingRequests';
 import {
-  addPlayedPictureId,
   deleteImageFromStorage,
-  filterPlayedCards,
   getE2EHiddenGuessCard,
   getLastImageId,
   getLastImageUuid,
   getLocalImages,
+  isCategoryExhausted,
   PUBLIC_FEED_END_CURSOR,
   removeImageFromList,
   saveLastImageUuid,
   storeImageList,
   updateImageList,
 } from '../utils/storageDatum';
+import { addPlayedPictureId, filterPlayedCards } from '../utils/playedPictureIds';
+import { startNewServingCycle } from '../utils/servingCycle';
+import { removeCardFromGroupDeck } from '../services/cardDeck';
 import { prefetchIfLow, warmAllDeckIfNeeded } from '../services/cardPrefetcher';
-import { readGroupFeedCache } from '../services/groups/groupFeedCache';
+import { readGroupFeedCache, writeGroupFeedCache } from '../services/groups/groupFeedCache';
 import { PRIVATE_FEED_END_CURSOR } from '../services/groups/groupFeedApi';
 
 describe('SwipeImage', () => {
@@ -241,28 +264,108 @@ describe('SwipeImage', () => {
     expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.listId)).toEqual([2, 1]);
   });
 
-  it('ignores a stale last image uuid when the local cache is missing and fetches a fresh batch', async () => {
+  it('mount serve with null deck persists the full batch but setImageList excludes played cards', async () => {
     getLocalImages.mockResolvedValue(null);
-    getLastImageUuid.mockResolvedValue('stale-image-uuid');
     getImages.mockResolvedValue({
       isError: false,
       images: [
-        { pictureId: 'img-1', imageFile: 'file:///one.jpg' },
+        { pictureId: 'null-mount-played', imageFile: 'file:///played.jpg' },
+        { pictureId: 'null-mount-fresh', imageFile: 'file:///fresh.jpg' },
       ],
     });
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cards.filter((card) => !card?.pictureId || card.pictureId !== 'null-mount-played')));
 
-    await renderSwipeImage();
+    try {
+      await renderSwipeImage();
 
-    // Fix 2a pin update: a head fetch over a stored REAL cursor now carries the
-    // { persistCursor: false } opts arg — suppressing the cursor write IS the
-    // rewind fix. The head query still fires and fresh uploads still surface.
-    expect(getImages).toHaveBeenCalledWith(null, contextValue, { language: undefined, scope: undefined }, { persistCursor: false });
-    expect(storeImageList).toHaveBeenCalledWith([
-      expect.objectContaining({ pictureId: 'img-1', listId: 1 }),
-    ], 'all', 'any');
+      // Resume truth (I5): the FULL normalized batch is persisted unfiltered.
+      expect(storeImageList).toHaveBeenCalledWith([
+        expect.objectContaining({ pictureId: 'null-mount-played', listId: 1 }),
+        expect.objectContaining({ pictureId: 'null-mount-fresh', listId: 2 }),
+      ], 'all', 'any');
+      // Once-per-cycle (I1): the serve itself runs through the played filter.
+      expect(filterPlayedCards).toHaveBeenCalledWith(expect.any(Array), 'any', undefined);
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).not.toContain('null-mount-played');
+      expect(renderedPictureIds).toContain('null-mount-fresh');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
   });
 
-  it('re-queries the server on cold mount when the exhausted sentinel is stored so new uploads surface', async () => {
+  it('mount serve where the whole batch is played returns false (no blank stack)', async () => {
+    getLocalImages.mockResolvedValue(null);
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [
+        { pictureId: 'null-mount-all-played-1', imageFile: 'file:///p1.jpg' },
+        { pictureId: 'null-mount-all-played-2', imageFile: 'file:///p2.jpg' },
+      ],
+    });
+    // Played-set covers the whole batch → filtered serve is empty.
+    filterPlayedCards.mockImplementation(async () => Promise.resolve([]));
+
+    try {
+      const { renderer } = await renderSwipeImage();
+
+      // The full batch is still persisted (resume truth, I5)...
+      expect(storeImageList).toHaveBeenCalledWith([
+        expect.objectContaining({ pictureId: 'null-mount-all-played-1', listId: 1 }),
+        expect.objectContaining({ pictureId: 'null-mount-all-played-2', listId: 2 }),
+      ], 'all', 'any');
+      // ...but no played card is ever served.
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).not.toContain('null-mount-all-played-1');
+      expect(renderedPictureIds).not.toContain('null-mount-all-played-2');
+      // The false return flows into handleImagesLoading's exhausted machinery.
+      const renderedText = renderer.root
+        .findAll((node) => node.type === 'Text')
+        .map((node) => node.props.children)
+        .flat()
+        .join(' ');
+      expect(renderedText).toContain('No more images to guess right now!');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
+  it('empty-deck mount resumes cursor-mode first; a cursor at feed-end falls back to the head probe (persistCursor suppressed)', async () => {
+    getLocalImages.mockResolvedValue(null);
+    getLastImageUuid.mockResolvedValue('stale-image-uuid');
+    getImages
+      .mockResolvedValueOnce({ isError: false, images: [] })
+      .mockResolvedValueOnce({
+        isError: false,
+        images: [
+          { pictureId: 'img-1', imageFile: 'file:///one.jpg' },
+        ],
+      });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+    await act(async () => {
+      for (let i = 0; i < 8; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await flushEffects();
+      }
+    });
+
+    // C2 pin update: the empty-deck mount now goes cursor-mode FIRST (I5
+    // resume) — the stored REAL cursor is consulted, not bypassed. Only an
+    // exhausted cursor round triggers the head probe, and that probe is a
+    // head REPLAY over the stored cursor: { persistCursor: false } keeps the
+    // rewind fix (suppressing the cursor write) while fresh uploads surface.
+    expect(getImages).toHaveBeenCalledTimes(2);
+    expect(getImages.mock.calls[0][0]).toBe('stale-image-uuid');
+    expect(getImages.mock.calls[0]).toHaveLength(3);
+    expect(getImages.mock.calls[1][0]).toBe(null);
+    expect(getImages.mock.calls[1][3]).toEqual({ persistCursor: false });
+    expect(storeImageList).toHaveBeenCalledWith([
+      expect.objectContaining({ pictureId: 'img-1', listId: 1 }),
+    ], 'nature', 'any');
+  });
+
+  it('coerces a stored exhausted sentinel to a head query on empty-deck mount so new uploads surface', async () => {
     // Regression: a stored PUBLIC_FEED_END_CURSOR used to short-circuit the
     // cold-mount load, so once a category ever returned empty it never queried
     // the server again — newly uploaded cards stayed invisible until reinstall.
@@ -275,13 +378,20 @@ describe('SwipeImage', () => {
       ],
     });
 
-    await renderSwipeImage();
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+    await act(async () => {
+      for (let i = 0; i < 8; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await flushEffects();
+      }
+    });
 
-    // Fix 2a pin update: head-over-sentinel is a head REPLAY (sentinel =
-    // "already exhausted once") — it fetches with { persistCursor: false } so
-    // persisting cannot rewind AND erase the exhausted signal. The head query
-    // still fires, so fresh uploads still surface on re-probe.
-    expect(getImages).toHaveBeenCalledWith(null, contextValue, expect.objectContaining({}), { persistCursor: false });
+    // C2 pin update: the cursor round hits the transport-boundary legacy
+    // self-heal — PUBLIC_FEED_END_CURSOR is coerced to a fresh head query
+    // (3-arg call, nothing to rewind). One round suffices when cards land.
+    expect(getImages).toHaveBeenCalledTimes(1);
+    expect(getImages.mock.calls[0][0]).toBe(null);
+    expect(getImages.mock.calls[0]).toHaveLength(3);
     expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).toContain('fresh-after-exhaust');
   });
 
@@ -770,6 +880,41 @@ describe('SwipeImage — cardPrefetcher integration', () => {
     });
   });
 
+  it('delegates private removal to removeCardFromGroupDeck instead of writing the filtered memory deck', async () => {
+    const scope = { kind: 'private', groupId: 'group-7' };
+    readGroupFeedCache.mockResolvedValue({
+      images: [
+        { listId: 1, imageFile: 'file:///1.jpg' },
+        { listId: 2, imageFile: 'file:///2.jpg' },
+        { listId: 3, imageFile: 'file:///3.jpg' },
+        { listId: 4, imageFile: 'file:///4.jpg' },
+      ],
+    });
+
+    await renderSwipeImage(jest.fn(), {
+      category: { id: 'cat-nature', key: 'nature' },
+      language: 'fr',
+      scope,
+    });
+
+    const removableCard = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+    mockSwipeableCard.mockClear();
+
+    await act(async () => {
+      await removableCard.removeCard(1);
+      await flushEffects();
+    });
+
+    expect(removeCardFromGroupDeck).toHaveBeenCalledWith({
+      groupId: 'group-7',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      listId: 1,
+    });
+    expect(removeImageFromList).not.toHaveBeenCalled();
+    expect(writeGroupFeedCache).not.toHaveBeenCalled();
+  });
+
   it('calls prefetchIfLow at most once per removeCard (component does not pre-dedupe)', async () => {
     getLocalImages.mockResolvedValue([
       { listId: 1, imageFile: 'file:///1.jpg' },
@@ -1095,6 +1240,191 @@ describe('SwipeImage — deck-empty fallback to "all"', () => {
       ([, , params]) => params?.category_key === 'nature',
     );
     expect(natureForegroundCalls.length).toBeGreaterThan(0);
+  });
+
+  it('shows the exhausted panel without a foreground load when the active category is already marked exhausted', async () => {
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        natureCallCount += 1;
+        return Promise.resolve(natureCallCount === 1 ? natureCards : []);
+      }
+      return Promise.resolve(null);
+    });
+    isCategoryExhausted.mockResolvedValueOnce(true);
+
+    const { renderer } = await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const cardPropsById = {};
+    for (const listId of [1, 2, 3, 4]) {
+      cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+    }
+
+    for (const listId of [1, 2, 3, 4]) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        await cardPropsById[listId].removeCard(listId);
+        await flushEffects();
+      });
+    }
+
+    expect(getImages).not.toHaveBeenCalled();
+    expect(isCategoryExhausted).toHaveBeenCalledWith('nature', undefined, undefined);
+
+    const renderedText = renderer.root
+      .findAll((node) => node.type === 'Text')
+      .map((node) => node.props.children)
+      .flat()
+      .join(' ');
+    expect(renderedText).toContain('No more images to guess right now!');
+  });
+
+  it('(c) F1 self-heal: marker cleared (false) + non-"all" category → step-4 foreground fetch fires', async () => {
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        natureCallCount += 1;
+        return Promise.resolve(natureCallCount === 1 ? natureCards : []);
+      }
+      return Promise.resolve(null);
+    });
+    isCategoryExhausted.mockResolvedValue(false);
+    getImages.mockResolvedValue({ isError: false, images: [{ pictureId: 'fresh-1', imageFile: 'file:///f1.jpg' }] });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const cardPropsById = {};
+    for (const listId of [1, 2, 3, 4]) {
+      cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+    }
+
+    for (const listId of [1, 2, 3, 4]) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        await cardPropsById[listId].removeCard(listId);
+        await flushEffects();
+      });
+    }
+
+    expect(isCategoryExhausted).toHaveBeenCalledWith('nature', undefined, undefined);
+    expect(getImages).toHaveBeenCalled();
+  });
+
+  it('(e) F1 private scope: refill step 4 routes the marker check to the group marker (isCategoryExhausted receives the scope)', async () => {
+    const scope = { kind: 'private', groupId: 'group-7' };
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    let natureCallCount = 0;
+    readGroupFeedCache.mockImplementation((groupId, { categoryId } = {}) => {
+      if (groupId !== 'group-7') return Promise.resolve(null);
+      if (categoryId === 'cat-nature') {
+        natureCallCount += 1;
+        return Promise.resolve({ images: natureCallCount === 1 ? natureCards : [], nextCursor: null });
+      }
+      return Promise.resolve(null);
+    });
+    isCategoryExhausted.mockResolvedValue(false);
+    getImages.mockResolvedValue({ isError: false, images: [{ pictureId: 'fresh-1', imageFile: 'file:///f1.jpg' }] });
+
+    await renderSwipeImage(jest.fn(), {
+      category: { id: 'cat-nature', key: 'nature' },
+      language: 'fr',
+      scope,
+    });
+
+    const cardPropsById = {};
+    for (const listId of [1, 2, 3, 4]) {
+      cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+    }
+
+    for (const listId of [1, 2, 3, 4]) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        await cardPropsById[listId].removeCard(listId);
+        await flushEffects();
+      });
+    }
+
+    expect(isCategoryExhausted).toHaveBeenCalledWith('nature', 'fr', scope);
+    expect(getImages).toHaveBeenCalled();
+  });
+
+  it('fails open on exhausted-marker read errors and still foreground-loads', async () => {
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        natureCallCount += 1;
+        return Promise.resolve(natureCallCount === 1 ? natureCards : []);
+      }
+      return Promise.resolve(null);
+    });
+    isCategoryExhausted.mockRejectedValueOnce(new Error('marker read failed'));
+    getImages.mockResolvedValue({ isError: false, images: [{ pictureId: 'fresh-1', imageFile: 'file:///f1.jpg' }] });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const cardPropsById = {};
+    for (const listId of [1, 2, 3, 4]) {
+      cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+    }
+
+    for (const listId of [1, 2, 3, 4]) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        await cardPropsById[listId].removeCard(listId);
+        await flushEffects();
+      });
+    }
+
+    expect(getImages).toHaveBeenCalled();
+  });
+
+  it('still foreground-loads for the "all" deck without consulting the exhausted marker', async () => {
+    let allCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'all') {
+        allCallCount += 1;
+        return Promise.resolve(allCallCount === 1
+          ? [{ listId: 1, pictureId: 'all-1', imageFile: 'file:///a1.jpg' }]
+          : []);
+      }
+      return Promise.resolve(null);
+    });
+    isCategoryExhausted.mockResolvedValueOnce(true);
+    getImages.mockResolvedValue({ isError: false, images: [{ pictureId: 'fresh-1', imageFile: 'file:///f1.jpg' }] });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'all', key: 'all' } });
+
+    const removableCard = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+    await act(async () => {
+      await removableCard.removeCard(1);
+      await flushEffects();
+    });
+
+    expect(isCategoryExhausted).not.toHaveBeenCalled();
+    expect(getImages).toHaveBeenCalled();
   });
 
   it('does not fire a foreground load when removeCard drops the deck from 4→3 (low but not empty)', async () => {
@@ -1426,8 +1756,10 @@ describe('SwipeImage — partial-deck mount cursor exhaustion (Fix 2a)', () => {
       { listId: 3, pictureId: 'played-3', imageFile: 'file:///3.jpg' },
       { listId: 4, pictureId: 'played-4', imageFile: 'file:///4.jpg' },
     ]);
-    // Played-set contains every stored pictureId → filter empties the deck.
-    filterPlayedCards.mockImplementation(async () => Promise.resolve([]));
+    // Played-set contains every stored pictureId → the MOUNT filter empties
+    // the deck (first call only). Post-C1 the fetch that lands fresh cards
+    // ALSO filters (I1) — with a passthrough there, fresh-1 serves normally.
+    filterPlayedCards.mockImplementationOnce(async () => Promise.resolve([]));
     getImages.mockResolvedValue({
       isError: false,
       images: [{ pictureId: 'fresh-1', imageFile: 'file:///f1.jpg' }],
@@ -1485,7 +1817,7 @@ describe('SwipeImage — partial-deck mount cursor exhaustion (Fix 2a)', () => {
 
     expect(getImages).toHaveBeenCalledTimes(2);
     expect(saveLastImageUuid).toHaveBeenCalledTimes(1);
-    expect(saveLastImageUuid).toHaveBeenCalledWith(PRIVATE_FEED_END_CURSOR, 'nature', 'fr');
+    expect(saveLastImageUuid).toHaveBeenCalledWith(PRIVATE_FEED_END_CURSOR, 'nature', 'fr', scope);
   });
 });
 
@@ -1608,9 +1940,99 @@ describe('SwipeImage — handleData single-writer + resurrection race (Fix 3)', 
       });
     }
 
-    const finalRender = mockSwipeableCard.mock.calls.slice(-2).map(([props]) => [props.item.pictureId, props.item.listId]);
-    expect(finalRender).toEqual([['bg-numbered', 9], ['nat-4', 4]]);
-    expect(new Set(finalRender.map(([, listId]) => listId)).size).toBe(finalRender.length);
+    const latestByPictureId = new Map(
+      mockSwipeableCard.mock.calls.map(([props]) => [props.item.pictureId, props.item.listId]),
+    );
+    expect(latestByPictureId.get('bg-numbered')).toBe(9);
+    expect(latestByPictureId.get('nat-4')).toBe(4);
+    expect(new Set([latestByPictureId.get('bg-numbered'), latestByPictureId.get('nat-4')]).size).toBe(2);
+  });
+
+  it('logs the append-branch message only when handleData receives non-empty data', async () => {
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        natureCallCount += 1;
+        return Promise.resolve(natureCallCount === 1 ? natureCards : []);
+      }
+      return Promise.resolve(null);
+    });
+    getImages.mockResolvedValue({ isError: false, images: [{ pictureId: 'fresh-1', imageFile: 'file:///f1.jpg' }] });
+    updateImageList.mockResolvedValue([
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+      { listId: 9, pictureId: 'fresh-1', imageFile: 'file:///f1.jpg' },
+    ]);
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      const cardPropsById = {};
+      for (const listId of [1, 2, 3, 4]) {
+        cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+      }
+      for (const listId of [1, 2, 3, 4]) {
+        // eslint-disable-next-line no-await-in-loop
+        await act(async () => {
+          await cardPropsById[listId].removeCard(listId);
+          await flushEffects();
+        });
+      }
+
+      const appendLogs = logSpy.mock.calls.filter(([message]) => message === 'updatedImageList handleData imageList !== null');
+      expect(appendLogs).toHaveLength(1);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('does not log the append-branch message when handleData receives an empty batch', async () => {
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        natureCallCount += 1;
+        return Promise.resolve(natureCallCount === 1 ? natureCards : []);
+      }
+      return Promise.resolve(null);
+    });
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      const cardPropsById = {};
+      for (const listId of [1, 2, 3, 4]) {
+        cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+      }
+      for (const listId of [1, 2, 3, 4]) {
+        // eslint-disable-next-line no-await-in-loop
+        await act(async () => {
+          await cardPropsById[listId].removeCard(listId);
+          await flushEffects();
+        });
+      }
+
+      const appendLogs = logSpy.mock.calls.filter(([message]) => message === 'updatedImageList handleData imageList !== null');
+      expect(appendLogs).toHaveLength(0);
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   it('(h) incoming batch whose pictureId is already in the deck does not duplicate imageList', async () => {
@@ -1662,6 +2084,80 @@ describe('SwipeImage — handleData single-writer + resurrection race (Fix 3)', 
     const finalRender = mockSwipeableCard.mock.calls.slice(-2).map(([props]) => [props.item.pictureId, props.item.listId]);
     expect(finalRender).toEqual([['fresh-1', 9], ['nat-4', 4]]);
     expect(finalRender.filter(([pid]) => pid === 'nat-4')).toHaveLength(1);
+  });
+
+  it('(j) PIN removeCard→imageListRef sync: reconciliation before any re-render excludes the just-removed pictureId', async () => {
+    const deck = [
+      { listId: 1, pictureId: 'pin-a', imageFile: 'file:///1.jpg' },
+      { listId: 2, pictureId: 'pin-b', imageFile: 'file:///2.jpg' },
+      { listId: 3, pictureId: 'fill-1', imageFile: 'file:///3.jpg' },
+      { listId: 4, pictureId: 'fill-2', imageFile: 'file:///4.jpg' },
+    ];
+    let deckCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        deckCallCount += 1;
+        return Promise.resolve(deckCallCount === 1 ? deck : []);
+      }
+      return Promise.resolve(null);
+    });
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [{ pictureId: 'pin-new', imageFile: 'file:///new.jpg' }],
+    });
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      const cardPropsById = {};
+      for (const listId of [1, 2, 3, 4]) {
+        cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+      }
+      for (const listId of [2, 3, 4]) {
+        // eslint-disable-next-line no-await-in-loop
+        await act(async () => {
+          await cardPropsById[listId].removeCard(listId);
+          await flushEffects();
+        });
+      }
+
+      // Slow append: the storage RMW read the deck PRE-removal, so its merged
+      // result still contains pin-a (and pin-b).
+      const appendGate = createDeferred();
+      updateImageList.mockClear();
+      updateImageList.mockReturnValueOnce(appendGate.promise);
+      mockSwipeableCard.mockClear();
+
+      // Remove the last card OUTSIDE act: no re-render (and therefore no
+      // render-phase ref sync) may commit before the append resolves — only
+      // removeCard's synchronous imageListRef assignment can feed the
+      // reconciliation a fresh list.
+      const removalPromise = cardPropsById[1].removeCard(1);
+      for (let i = 0; i < 3; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      expect(updateImageList).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        appendGate.resolve([
+          { listId: 1, pictureId: 'pin-a', imageFile: 'file:///1.jpg' },
+          { listId: 2, pictureId: 'pin-b', imageFile: 'file:///2.jpg' },
+          { listId: 3, pictureId: 'pin-new', imageFile: 'file:///new.jpg' },
+        ]);
+        await flushMount();
+      });
+      await act(async () => {
+        await removalPromise;
+        await flushEffects();
+      });
+
+      const finalRender = mockSwipeableCard.mock.calls.slice(-1).map(([props]) => props.item.pictureId);
+      expect(finalRender).toEqual(['pin-new']);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it('(i) RESURRECTION RACE: a card swiped before a slow appendCardBatch RMW resolves stays removed; pictureId-less legacy card survives', async () => {
@@ -1740,5 +2236,670 @@ describe('SwipeImage — handleData single-writer + resurrection race (Fix 3)', 
     expect(finalPictureIds).not.toContain('race-a');
     expect(finalPictureIds).not.toContain('race-b');
     expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.imageFile)).toContain('file:///legacy.jpg');
+  });
+});
+
+describe('SwipeImage — empty-deck mount resume + cycle recovery (C2)', () => {
+  const contextValue = {
+    token: 'token',
+    uid: 'waldo@example.com',
+    expiry: '123',
+    access_token: 'access-token',
+    client: 'client-id',
+    userId: '42',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isE2EMode.mockReturnValue(false);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    getImageTags.mockResolvedValue({ data: [] });
+    getImageRating.mockResolvedValue({ data: undefined });
+    getE2EHiddenGuessCard.mockResolvedValue(null);
+    buildE2EGuessCardFromPayload.mockImplementation((payload) => (
+      payload ? { listId: 1, pictureId: payload.pictureId, imageFile: payload.uri } : null
+    ));
+    buildE2EGuessCards.mockReturnValue([{ listId: 1, pictureId: 'e2e-guess-card', imageFile: 'file:///e2e.jpg' }]);
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    getLastImageId.mockResolvedValue(0);
+    getLastImageUuid.mockResolvedValue(null);
+    updateImageList.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  // The empty-deck branch chains up to two fetch rounds plus the recovery
+  // deck re-read — mirror the partial-deck describe's deeper flush.
+  async function flushMount() {
+    for (let i = 0; i < 8; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushEffects();
+    }
+  }
+
+  async function renderSwipeImage(startGuessing = jest.fn(), { category, language, scope } = {}) {
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <AuthContext.Provider value={contextValue}>
+          <SwipeImage
+            screenWidth={320}
+            screenHeight={640}
+            startGuessing={startGuessing}
+            category={category}
+            language={language}
+            scope={scope}
+          />
+        </AuthContext.Provider>,
+      );
+
+      await flushMount();
+    });
+
+    return { renderer, startGuessing };
+  }
+
+  it('empty-deck mount with a stored real cursor fetches cursor-mode FIRST (resume, I5)', async () => {
+    getLocalImages.mockResolvedValue(null);
+    getLastImageUuid.mockResolvedValue('stored-real-cursor');
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [{ pictureId: 'resume-1', imageFile: 'file:///r1.jpg' }],
+    });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    // ONE fetch, cursor-mode (3-arg, cursor as pictureId) — the persisted
+    // keyset cursor resumes the feed after the last served card. No head
+    // probe fires when the cursor round lands cards.
+    expect(getImages).toHaveBeenCalledTimes(1);
+    expect(getImages.mock.calls[0]).toHaveLength(3);
+    expect(getImages.mock.calls[0][0]).toBe('stored-real-cursor');
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).toContain('resume-1');
+    expect(startNewServingCycle).not.toHaveBeenCalled();
+  });
+
+  it('empty-deck mount with no cursor falls back to head fetch', async () => {
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key !== 'nature') return Promise.resolve(null);
+      natureCallCount += 1;
+      // Call 1: empty deck on mount. Call 2: recovery re-read — the head
+      // probe's FULL batch is what persistCardBatch wrote to storage.
+      return Promise.resolve(natureCallCount === 1
+        ? []
+        : [{ listId: 1, pictureId: 'head-fresh', imageFile: 'file:///hf.jpg' }]);
+    });
+    getLastImageUuid.mockResolvedValue(null);
+    getImages
+      .mockResolvedValueOnce({ isError: false, images: [] })
+      .mockResolvedValueOnce({
+        isError: false,
+        images: [{ pictureId: 'head-fresh', imageFile: 'file:///hf.jpg' }],
+      });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    // Cursor round (no stored cursor → head-shaped query), then the head
+    // probe. No stored cursor → no persistCursor suppression arg (3-arg).
+    expect(getImages).toHaveBeenCalledTimes(2);
+    expect(getImages.mock.calls[0][0]).toBe(null);
+    expect(getImages.mock.calls[1][0]).toBe(null);
+    expect(getImages.mock.calls[1]).toHaveLength(3);
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).toContain('head-fresh');
+    // Landed card is unplayed → the recovery proof fails → no transition.
+    expect(startNewServingCycle).not.toHaveBeenCalled();
+  });
+
+  it('empty-deck mount with cursor AND head both empty writes the scope-correct sentinel', async () => {
+    getLocalImages.mockResolvedValue(null);
+    getLastImageUuid.mockResolvedValue('stored-cursor-9');
+    getImages.mockResolvedValue({ isError: false, images: [] });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    expect(getImages).toHaveBeenCalledTimes(2);
+    expect(saveLastImageUuid).toHaveBeenCalledTimes(1);
+    expect(saveLastImageUuid).toHaveBeenCalledWith(PUBLIC_FEED_END_CURSOR, 'nature', 'any');
+    // Nothing landed → the deck head is empty → NOT cycle exhaustion.
+    expect(startNewServingCycle).not.toHaveBeenCalled();
+  });
+
+  it('mount head probe lands cards but all are played → startNewServingCycle once, then serves deck head (cycle restart on mount, I4)', async () => {
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key !== 'nature') return Promise.resolve(null);
+      natureCallCount += 1;
+      return Promise.resolve(natureCallCount === 1
+        ? []
+        : [
+            { listId: 1, pictureId: 'cycle-played-1', imageFile: 'file:///c1.jpg' },
+            { listId: 2, pictureId: 'cycle-played-2', imageFile: 'file:///c2.jpg' },
+          ]);
+    });
+    getLastImageUuid.mockResolvedValue(null);
+    getImages
+      .mockResolvedValueOnce({ isError: false, images: [] })
+      .mockResolvedValueOnce({
+        isError: false,
+        images: [
+          { pictureId: 'cycle-played-1', imageFile: 'file:///c1.jpg' },
+          { pictureId: 'cycle-played-2', imageFile: 'file:///c2.jpg' },
+        ],
+      });
+    // Pre-transition: the played-set covers the whole head batch.
+    // Post-transition (startNewServingCycle clears the played-set): the same
+    // filter serves the full deck head.
+    let cycleRestarted = false;
+    startNewServingCycle.mockImplementationOnce(async () => {
+      cycleRestarted = true;
+      return 1;
+    });
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cycleRestarted
+        ? cards
+        : cards.filter((card) => !card?.pictureId || !card.pictureId.startsWith('cycle-played-'))));
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      expect(startNewServingCycle).toHaveBeenCalledTimes(1);
+      expect(startNewServingCycle).toHaveBeenCalledWith('any', undefined);
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).toContain('cycle-played-1');
+      expect(renderedPictureIds).toContain('cycle-played-2');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
+  it('head probe fails (error) with persisted fully-played deck → NO startNewServingCycle (I7)', async () => {
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key !== 'nature') return Promise.resolve(null);
+      natureCallCount += 1;
+      // Call 1: empty deck on mount. Call 2: recovery re-read would see a
+      // persisted, fully-played deck — but the errored probe must gate the
+      // whole recovery block off (I7: fetch failures never mutate cycle).
+      return Promise.resolve(natureCallCount === 1
+        ? []
+        : [
+            { listId: 1, pictureId: 'err-played-1', imageFile: 'file:///e1.jpg' },
+            { listId: 2, pictureId: 'err-played-2', imageFile: 'file:///e2.jpg' },
+          ]);
+    });
+    getLastImageUuid.mockResolvedValue(null);
+    getImages
+      // Cursor round: empty batch (false) → head probe fires.
+      .mockResolvedValueOnce({ isError: false, images: [] })
+      // Head probe: network/server failure ('error').
+      .mockResolvedValueOnce({ isError: true, title: 'Server error', message: 'Please retry later' });
+    // Played-set covers the whole persisted deck → the (gated) proof would
+    // otherwise pass: isCycleExhausted(2, 0) === true.
+    filterPlayedCards.mockImplementation(async () => Promise.resolve([]));
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      expect(getImages).toHaveBeenCalledTimes(2);
+      expect(Alert.alert).toHaveBeenCalledWith('Server error', 'Please retry later');
+      expect(startNewServingCycle).not.toHaveBeenCalled();
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
+  it('mount head probe genuinely empty (no cards landed) → NO startNewServingCycle, exhausted flow', async () => {
+    getLocalImages.mockResolvedValue(null);
+    getLastImageUuid.mockResolvedValue(null);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+
+    const { renderer } = await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    expect(getImages).toHaveBeenCalledTimes(2);
+    expect(startNewServingCycle).not.toHaveBeenCalled();
+
+    const renderedText = renderer.root
+      .findAll((node) => node.type === 'Text')
+      .map((node) => node.props.children)
+      .flat()
+      .join(' ');
+    expect(renderedText).toContain('No more images to guess right now!');
+  });
+
+  it('private mount recovery writes/reads private namespaces only', async () => {
+    const scope = { kind: 'private', groupId: 'group-7' };
+    let cacheCallCount = 0;
+    readGroupFeedCache.mockImplementation((groupId, { categoryId } = {}) => {
+      if (groupId !== 'group-7' || categoryId !== 'cat-nature') return Promise.resolve(null);
+      cacheCallCount += 1;
+      return Promise.resolve(cacheCallCount === 1
+        ? { images: [], nextCursor: null }
+        : {
+            images: [
+              { listId: 1, pictureId: 'priv-played-1', imageFile: 'file:///p1.jpg' },
+              { listId: 2, pictureId: 'priv-played-2', imageFile: 'file:///p2.jpg' },
+            ],
+            nextCursor: null,
+          });
+    });
+    getLastImageUuid.mockResolvedValue('priv-cursor');
+    getImages
+      .mockResolvedValueOnce({ isError: false, images: [] })
+      .mockResolvedValueOnce({
+        isError: false,
+        images: [
+          { pictureId: 'priv-played-1', imageFile: 'file:///p1.jpg' },
+          { pictureId: 'priv-played-2', imageFile: 'file:///p2.jpg' },
+        ],
+      });
+    let cycleRestarted = false;
+    startNewServingCycle.mockImplementationOnce(async () => {
+      cycleRestarted = true;
+      return 1;
+    });
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cycleRestarted
+        ? cards
+        : cards.filter((card) => !card?.pictureId || !card.pictureId.startsWith('priv-played-'))));
+
+    try {
+      await renderSwipeImage(jest.fn(), {
+        category: { id: 'cat-nature', key: 'nature' },
+        language: 'fr',
+        scope,
+      });
+
+      // Private sentinel + private transition scope; public deck storage
+      // never touched (private cache is the only deck read).
+      expect(saveLastImageUuid).toHaveBeenCalledTimes(1);
+      expect(saveLastImageUuid).toHaveBeenCalledWith(PRIVATE_FEED_END_CURSOR, 'nature', 'fr', scope);
+      expect(startNewServingCycle).toHaveBeenCalledTimes(1);
+      expect(startNewServingCycle).toHaveBeenCalledWith('fr', scope);
+      expect(getLocalImages).not.toHaveBeenCalled();
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).toContain('priv-played-1');
+      expect(renderedPictureIds).toContain('priv-played-2');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+});
+
+describe('SwipeImage — mount recovery across all deck branches (M1/M2)', () => {
+  const contextValue = {
+    token: 'token',
+    uid: 'waldo@example.com',
+    expiry: '123',
+    access_token: 'access-token',
+    client: 'client-id',
+    userId: '42',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isE2EMode.mockReturnValue(false);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    getImageTags.mockResolvedValue({ data: [] });
+    getImageRating.mockResolvedValue({ data: undefined });
+    getE2EHiddenGuessCard.mockResolvedValue(null);
+    buildE2EGuessCardFromPayload.mockImplementation((payload) => (
+      payload ? { listId: 1, pictureId: payload.pictureId, imageFile: payload.uri } : null
+    ));
+    buildE2EGuessCards.mockReturnValue([{ listId: 1, pictureId: 'e2e-guess-card', imageFile: 'file:///e2e.jpg' }]);
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    getLastImageId.mockResolvedValue(0);
+    getLastImageUuid.mockResolvedValue(null);
+    updateImageList.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function flushMount() {
+    for (let i = 0; i < 8; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushEffects();
+    }
+  }
+
+  async function renderSwipeImage(startGuessing = jest.fn(), { category, language, scope } = {}) {
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <AuthContext.Provider value={contextValue}>
+          <SwipeImage
+            screenWidth={320}
+            screenHeight={640}
+            startGuessing={startGuessing}
+            category={category}
+            language={language}
+            scope={scope}
+          />
+        </AuthContext.Provider>,
+      );
+
+      await flushMount();
+    });
+
+    return { renderer, startGuessing };
+  }
+
+  function renderedText(renderer) {
+    return renderer.root
+      .findAll((node) => node.type === 'Text')
+      .map((node) => node.props.children)
+      .flat()
+      .join(' ');
+  }
+
+  it('empty-deck mount, cursor round errors → error panel, no infinite loading (I7)', async () => {
+    getLocalImages.mockResolvedValue(null);
+    getImages.mockResolvedValue({
+      isError: true,
+      title: 'Server error',
+      message: 'Please retry later',
+    });
+
+    const { renderer } = await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    expect(Alert.alert).toHaveBeenCalledWith('Server error', 'Please retry later');
+    // The errored cursor round never ran handleData — the serve state must be
+    // coerced to [] (not left null) or the loading overlay pins forever.
+    expect(renderedText(renderer)).toContain('The list is not there');
+    // I7: no probe cascade, no cycle mutation after a failed fetch.
+    expect(getImages).toHaveBeenCalledTimes(1);
+    expect(startNewServingCycle).not.toHaveBeenCalled();
+  });
+
+  it('full-deck mount, all cards played, head probe lands played cards → startNewServingCycle once, then serves deck head (I4)', async () => {
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key !== 'nature') return Promise.resolve(null);
+      natureCallCount += 1;
+      // Call 1: full all-played deck on mount. Call 2: recovery re-read — the
+      // head probe's FULL batch is what persistCardBatch wrote to storage.
+      return Promise.resolve(natureCallCount === 1
+        ? [
+            { listId: 1, pictureId: 'cyc-full-1', imageFile: 'file:///f1.jpg' },
+            { listId: 2, pictureId: 'cyc-full-2', imageFile: 'file:///f2.jpg' },
+            { listId: 3, pictureId: 'cyc-full-3', imageFile: 'file:///f3.jpg' },
+            { listId: 4, pictureId: 'cyc-full-4', imageFile: 'file:///f4.jpg' },
+          ]
+        : [
+            { listId: 1, pictureId: 'cyc-full-1', imageFile: 'file:///f1.jpg' },
+            { listId: 2, pictureId: 'cyc-full-2', imageFile: 'file:///f2.jpg' },
+          ]);
+    });
+    getImages
+      .mockResolvedValueOnce({ isError: false, images: [] })
+      .mockResolvedValueOnce({
+        isError: false,
+        images: [
+          { pictureId: 'cyc-full-1', imageFile: 'file:///f1.jpg' },
+          { pictureId: 'cyc-full-2', imageFile: 'file:///f2.jpg' },
+        ],
+      });
+    let cycleRestarted = false;
+    startNewServingCycle.mockImplementationOnce(async () => {
+      cycleRestarted = true;
+      return 1;
+    });
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cycleRestarted
+        ? cards
+        : cards.filter((card) => !card?.pictureId || !card.pictureId.startsWith('cyc-full-'))));
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      expect(startNewServingCycle).toHaveBeenCalledTimes(1);
+      expect(startNewServingCycle).toHaveBeenCalledWith('any', undefined);
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).toContain('cyc-full-1');
+      expect(renderedPictureIds).toContain('cyc-full-2');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
+  it('partial-deck mount (1-3 left), all played after probe → recovery fires once', async () => {
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key !== 'nature') return Promise.resolve(null);
+      natureCallCount += 1;
+      return Promise.resolve([
+        { listId: 1, pictureId: 'part-cyc-1', imageFile: 'file:///p1.jpg' },
+        { listId: 2, pictureId: 'part-cyc-2', imageFile: 'file:///p2.jpg' },
+      ]);
+    });
+    getLastImageUuid.mockResolvedValue('stored-cursor-9');
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    let cycleRestarted = false;
+    startNewServingCycle.mockImplementationOnce(async () => {
+      cycleRestarted = true;
+      return 1;
+    });
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cycleRestarted
+        ? cards
+        : cards.filter((card) => !card?.pictureId || !card.pictureId.startsWith('part-cyc-'))));
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      expect(getImages).toHaveBeenCalledTimes(2);
+      expect(saveLastImageUuid).toHaveBeenCalledWith(PUBLIC_FEED_END_CURSOR, 'nature', 'any');
+      expect(startNewServingCycle).toHaveBeenCalledTimes(1);
+      expect(startNewServingCycle).toHaveBeenCalledWith('any', undefined);
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).toContain('part-cyc-1');
+      expect(renderedPictureIds).toContain('part-cyc-2');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
+  it('full-deck mount, genuinely empty server → NO transition, exhausted panel', async () => {
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key !== 'nature') return Promise.resolve(null);
+      natureCallCount += 1;
+      // Call 2: the head probe persisted an empty batch → deck empty.
+      return Promise.resolve(natureCallCount === 1
+        ? [
+            { listId: 1, pictureId: 'gen-played-1', imageFile: 'file:///1.jpg' },
+            { listId: 2, pictureId: 'gen-played-2', imageFile: 'file:///2.jpg' },
+            { listId: 3, pictureId: 'gen-played-3', imageFile: 'file:///3.jpg' },
+            { listId: 4, pictureId: 'gen-played-4', imageFile: 'file:///4.jpg' },
+          ]
+        : []);
+    });
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cards.filter((card) => !card?.pictureId || !card.pictureId.startsWith('gen-played-'))));
+
+    try {
+      const { renderer } = await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      expect(startNewServingCycle).not.toHaveBeenCalled();
+      expect(renderedText(renderer)).toContain('No more images to guess right now!');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
+  it('new cycle serves despite stale cursor/END sentinel/exhausted marker (mount path)', async () => {
+    // §5 composite: cursor parked at the old feed end AS the END sentinel +
+    // an exhausted marker + a fully-played deck. The mount recovery must
+    // still prove exhaustion, transition ONCE, and re-serve a NON-empty
+    // deck head. Behavior-level note: the played-set clear is simulated by
+    // flipping the filterPlayedCards mock at the transition (this seam mocks
+    // playedPictureIds; no AsyncStorage played-store exists here), and the
+    // exhausted marker is pinned present via isCategoryExhausted (the mount
+    // path must ignore it either way).
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key !== 'nature') return Promise.resolve(null);
+      natureCallCount += 1;
+      return Promise.resolve(natureCallCount === 1
+        ? [
+            { listId: 1, pictureId: 'comp-1', imageFile: 'file:///c1.jpg' },
+            { listId: 2, pictureId: 'comp-2', imageFile: 'file:///c2.jpg' },
+            { listId: 3, pictureId: 'comp-3', imageFile: 'file:///c3.jpg' },
+            { listId: 4, pictureId: 'comp-4', imageFile: 'file:///c4.jpg' },
+          ]
+        : [
+            { listId: 1, pictureId: 'comp-1', imageFile: 'file:///c1.jpg' },
+            { listId: 2, pictureId: 'comp-2', imageFile: 'file:///c2.jpg' },
+          ]);
+    });
+    getLastImageUuid.mockResolvedValue(PUBLIC_FEED_END_CURSOR);
+    isCategoryExhausted.mockResolvedValue(true);
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [
+        { pictureId: 'comp-1', imageFile: 'file:///c1.jpg' },
+        { pictureId: 'comp-2', imageFile: 'file:///c2.jpg' },
+      ],
+    });
+    let cycleRestarted = false;
+    startNewServingCycle.mockImplementationOnce(async () => {
+      cycleRestarted = true;
+      return 1;
+    });
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cycleRestarted
+        ? cards
+        : cards.filter((card) => !card?.pictureId || !card.pictureId.startsWith('comp-'))));
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      expect(startNewServingCycle).toHaveBeenCalledTimes(1);
+      expect(startNewServingCycle).toHaveBeenCalledWith('any', undefined);
+      // Post-transition serve uses the deck head and is NON-empty.
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).toContain('comp-1');
+      expect(renderedPictureIds).toContain('comp-2');
+      expect(saveLastImageUuid).toHaveBeenCalledWith(PUBLIC_FEED_END_CURSOR, 'nature', 'any');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+});
+
+describe('SwipeImage — scoped mount sentinel seam (F1/F2)', () => {
+  const contextValue = {
+    token: 'token',
+    uid: 'waldo@example.com',
+    expiry: '123',
+    access_token: 'access-token',
+    client: 'client-id',
+    userId: '42',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isE2EMode.mockReturnValue(false);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    getImageTags.mockResolvedValue({ data: [] });
+    getImageRating.mockResolvedValue({ data: undefined });
+    getE2EHiddenGuessCard.mockResolvedValue(null);
+    buildE2EGuessCardFromPayload.mockImplementation((payload) => (
+      payload ? { listId: 1, pictureId: payload.pictureId, imageFile: payload.uri } : null
+    ));
+    buildE2EGuessCards.mockReturnValue([{ listId: 1, pictureId: 'e2e-guess-card', imageFile: 'file:///e2e.jpg' }]);
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    getLastImageId.mockResolvedValue(0);
+    getLastImageUuid.mockResolvedValue(null);
+    updateImageList.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function flushMount() {
+    for (let i = 0; i < 8; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushEffects();
+    }
+  }
+
+  async function renderSwipeImage(startGuessing = jest.fn(), { category, language, scope } = {}) {
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <AuthContext.Provider value={contextValue}>
+          <SwipeImage
+            screenWidth={320}
+            screenHeight={640}
+            startGuessing={startGuessing}
+            category={category}
+            language={language}
+            scope={scope}
+          />
+        </AuthContext.Provider>,
+      );
+
+      await flushMount();
+    });
+
+    return { renderer, startGuessing };
+  }
+
+  it('private mount sentinel write targets the group-scoped key (4-arg scope passed)', async () => {
+    const scope = { kind: 'private', groupId: 'group-7' };
+    readGroupFeedCache.mockResolvedValue({ images: [], nextCursor: null });
+    getLastImageUuid.mockResolvedValue('priv-cursor-9');
+    getImages.mockResolvedValue({ isError: false, images: [] });
+
+    await renderSwipeImage(jest.fn(), {
+      category: { id: 'cat-nature', key: 'nature' },
+      language: 'fr',
+      scope,
+    });
+
+    expect(getImages).toHaveBeenCalledTimes(2);
+    expect(saveLastImageUuid).toHaveBeenCalledTimes(1);
+    expect(saveLastImageUuid).toHaveBeenCalledWith(PRIVATE_FEED_END_CURSOR, 'nature', 'fr', scope);
+  });
+
+  it('public mount sentinel write unchanged (no scope bleed)', async () => {
+    getLocalImages.mockResolvedValue(null);
+    getLastImageUuid.mockResolvedValue('pub-cursor-9');
+    getImages.mockResolvedValue({ isError: false, images: [] });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    expect(getImages).toHaveBeenCalledTimes(2);
+    expect(saveLastImageUuid).toHaveBeenCalledTimes(1);
+    expect(saveLastImageUuid).toHaveBeenCalledWith(PUBLIC_FEED_END_CURSOR, 'nature', 'any');
+    expect(saveLastImageUuid.mock.calls[0]).toHaveLength(3);
   });
 });

--- a/__tests__/SwipeImage.test.js
+++ b/__tests__/SwipeImage.test.js
@@ -103,6 +103,7 @@ jest.mock('../services/cardDeck', () => {
   return {
     ...actual,
     removeCardFromGroupDeck: jest.fn(() => Promise.resolve()),
+    probeAllPoolForUnplayed: jest.fn(),
   };
 });
 
@@ -150,7 +151,7 @@ import {
 } from '../utils/storageDatum';
 import { addPlayedPictureId, filterPlayedCards } from '../utils/playedPictureIds';
 import { startNewServingCycle } from '../utils/servingCycle';
-import { removeCardFromGroupDeck } from '../services/cardDeck';
+import { probeAllPoolForUnplayed, removeCardFromGroupDeck } from '../services/cardDeck';
 import { prefetchIfLow, warmAllDeckIfNeeded } from '../services/cardPrefetcher';
 import { readGroupFeedCache, writeGroupFeedCache } from '../services/groups/groupFeedCache';
 import { PRIVATE_FEED_END_CURSOR } from '../services/groups/groupFeedApi';
@@ -2404,6 +2405,9 @@ describe('SwipeImage — empty-deck mount resume + cycle recovery (C2)', () => {
       cycleRestarted = true;
       return 1;
     });
+    // Step 4: the 'all'-pool probe is the sound transition proof — a drained
+    // 'all' pool ('exhausted') is what licenses the transition here.
+    probeAllPoolForUnplayed.mockResolvedValue({ status: 'exhausted' });
     filterPlayedCards.mockImplementation(async (cards) =>
       Promise.resolve(cycleRestarted
         ? cards
@@ -2507,6 +2511,7 @@ describe('SwipeImage — empty-deck mount resume + cycle recovery (C2)', () => {
       cycleRestarted = true;
       return 1;
     });
+    probeAllPoolForUnplayed.mockResolvedValue({ status: 'exhausted' });
     filterPlayedCards.mockImplementation(async (cards) =>
       Promise.resolve(cycleRestarted
         ? cards
@@ -2662,6 +2667,7 @@ describe('SwipeImage — mount recovery across all deck branches (M1/M2)', () =>
       cycleRestarted = true;
       return 1;
     });
+    probeAllPoolForUnplayed.mockResolvedValue({ status: 'exhausted' });
     filterPlayedCards.mockImplementation(async (cards) =>
       Promise.resolve(cycleRestarted
         ? cards
@@ -2697,6 +2703,7 @@ describe('SwipeImage — mount recovery across all deck branches (M1/M2)', () =>
       cycleRestarted = true;
       return 1;
     });
+    probeAllPoolForUnplayed.mockResolvedValue({ status: 'exhausted' });
     filterPlayedCards.mockImplementation(async (cards) =>
       Promise.resolve(cycleRestarted
         ? cards
@@ -2746,6 +2753,144 @@ describe('SwipeImage — mount recovery across all deck branches (M1/M2)', () =>
     }
   });
 
+  it('category mount, category deck all played, probe "unplayed" → serves the "all" deck, active category switches to "all", NO startNewServingCycle (BUG 2 pin)', async () => {
+    // Bug 2: the category-side all-played gate alone is NOT cycle exhaustion —
+    // a finished category used to wipe the SHARED played-set on every mount
+    // and re-serve the same old category images. The 'all'-pool probe finds
+    // unplayed cards → serve the 'all' deck + switch namespaces; no transition.
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'all') {
+        return Promise.resolve([
+          { listId: 1, pictureId: 'all-fresh-1', imageFile: 'file:///a1.jpg' },
+          { listId: 2, pictureId: 'all-fresh-2', imageFile: 'file:///a2.jpg' },
+        ]);
+      }
+      if (key !== 'nature') return Promise.resolve(null);
+      return Promise.resolve([
+        { listId: 1, pictureId: 'bug2-played-1', imageFile: 'file:///b1.jpg' },
+        { listId: 2, pictureId: 'bug2-played-2', imageFile: 'file:///b2.jpg' },
+        { listId: 3, pictureId: 'bug2-played-3', imageFile: 'file:///b3.jpg' },
+        { listId: 4, pictureId: 'bug2-played-4', imageFile: 'file:///b4.jpg' },
+      ]);
+    });
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cards.filter((card) => !card?.pictureId || !card.pictureId.startsWith('bug2-played-'))));
+    probeAllPoolForUnplayed.mockResolvedValue({ status: 'unplayed' });
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      expect(probeAllPoolForUnplayed).toHaveBeenCalledTimes(1);
+      expect(probeAllPoolForUnplayed).toHaveBeenCalledWith({
+        language: 'any',
+        scope: undefined,
+        authContext: contextValue,
+        excludePictureId: undefined,
+      });
+      expect(startNewServingCycle).not.toHaveBeenCalled();
+      // The serve comes from the 'all' deck, not the played category deck.
+      expect(getLocalImages).toHaveBeenCalledWith('all', 'any');
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).toContain('all-fresh-1');
+      expect(renderedPictureIds).toContain('all-fresh-2');
+      expect(renderedPictureIds).not.toContain('bug2-played-1');
+      // Namespace switch pin: a win on the served card removes it from the
+      // 'all' deck (activeCategoryKey followed the switch).
+      const servedCall = mockSwipeableCard.mock.calls.find(([props]) => props.item.pictureId === 'all-fresh-2');
+      await act(async () => {
+        await servedCall[0].removeCard(servedCall[0].item.listId);
+      });
+      expect(removeImageFromList).toHaveBeenCalledWith(2, 'all', 'any');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
+  it('probe "indeterminate" → exhausted panel, no transition (I7)', async () => {
+    // Transient probe failure must NEVER mutate cycle state — the exhausted
+    // flow stands (fail open: worst case a panel, never a premature wipe).
+    getLocalImages.mockImplementation((key) => {
+      if (key !== 'nature') return Promise.resolve(null);
+      return Promise.resolve([
+        { listId: 1, pictureId: 'indet-played-1', imageFile: 'file:///i1.jpg' },
+        { listId: 2, pictureId: 'indet-played-2', imageFile: 'file:///i2.jpg' },
+        { listId: 3, pictureId: 'indet-played-3', imageFile: 'file:///i3.jpg' },
+        { listId: 4, pictureId: 'indet-played-4', imageFile: 'file:///i4.jpg' },
+      ]);
+    });
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cards.filter((card) => !card?.pictureId || !card.pictureId.startsWith('indet-played-'))));
+    probeAllPoolForUnplayed.mockResolvedValue({ status: 'indeterminate', reason: 'network' });
+
+    try {
+      const { renderer } = await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      expect(probeAllPoolForUnplayed).toHaveBeenCalledTimes(1);
+      expect(startNewServingCycle).not.toHaveBeenCalled();
+      expect(renderedText(renderer)).toContain('No more images to guess right now!');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
+  it('private mount recovery probes/serves the group "all" namespace only (no public bleed)', async () => {
+    const scope = { kind: 'private', groupId: 'group-7' };
+    readGroupFeedCache.mockImplementation((groupId, { categoryId } = {}) => {
+      if (groupId !== 'group-7') return Promise.resolve(null);
+      if (categoryId === undefined) {
+        return Promise.resolve({
+          images: [
+            { listId: 1, pictureId: 'priv-all-fresh-1', imageFile: 'file:///pa1.jpg' },
+            { listId: 2, pictureId: 'priv-all-fresh-2', imageFile: 'file:///pa2.jpg' },
+          ],
+          nextCursor: null,
+        });
+      }
+      if (categoryId !== 'cat-nature') return Promise.resolve(null);
+      return Promise.resolve({
+        images: [
+          { listId: 1, pictureId: 'priv-cat-played-1', imageFile: 'file:///pc1.jpg' },
+          { listId: 2, pictureId: 'priv-cat-played-2', imageFile: 'file:///pc2.jpg' },
+          { listId: 3, pictureId: 'priv-cat-played-3', imageFile: 'file:///pc3.jpg' },
+          { listId: 4, pictureId: 'priv-cat-played-4', imageFile: 'file:///pc4.jpg' },
+        ],
+        nextCursor: null,
+      });
+    });
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cards.filter((card) => !card?.pictureId || !card.pictureId.startsWith('priv-cat-played-'))));
+    probeAllPoolForUnplayed.mockResolvedValue({ status: 'unplayed' });
+
+    try {
+      await renderSwipeImage(jest.fn(), {
+        category: { id: 'cat-nature', key: 'nature' },
+        language: 'fr',
+        scope,
+      });
+
+      expect(probeAllPoolForUnplayed).toHaveBeenCalledTimes(1);
+      expect(probeAllPoolForUnplayed).toHaveBeenCalledWith({
+        language: 'fr',
+        scope,
+        authContext: contextValue,
+        excludePictureId: undefined,
+      });
+      // The 'all' serve reads ONLY the group 'all' cache namespace.
+      expect(readGroupFeedCache).toHaveBeenCalledWith('group-7', { categoryId: undefined, language: 'fr' });
+      expect(getLocalImages).not.toHaveBeenCalled();
+      expect(startNewServingCycle).not.toHaveBeenCalled();
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).toContain('priv-all-fresh-1');
+      expect(renderedPictureIds).toContain('priv-all-fresh-2');
+      expect(renderedPictureIds).not.toContain('priv-cat-played-1');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
   it('new cycle serves despite stale cursor/END sentinel/exhausted marker (mount path)', async () => {
     // §5 composite: cursor parked at the old feed end AS the END sentinel +
     // an exhausted marker + a fully-played deck. The mount recovery must
@@ -2785,6 +2930,7 @@ describe('SwipeImage — mount recovery across all deck branches (M1/M2)', () =>
       cycleRestarted = true;
       return 1;
     });
+    probeAllPoolForUnplayed.mockResolvedValue({ status: 'exhausted' });
     filterPlayedCards.mockImplementation(async (cards) =>
       Promise.resolve(cycleRestarted
         ? cards

--- a/__tests__/SwipeImage.test.js
+++ b/__tests__/SwipeImage.test.js
@@ -48,27 +48,35 @@ jest.mock('../utils/ratingRequests', () => ({
   getImageTags: jest.fn(),
 }));
 
-jest.mock('../utils/storageDatum', () => ({
-  PUBLIC_FEED_END_CURSOR: '__public_feed_end__',
-  getE2EHiddenGuessCard: jest.fn(),
-  getLocalImages: jest.fn(),
-  storeImageList: jest.fn(),
-  getLastImageId: jest.fn(),
-  emptyImageList: jest.fn(),
-  removeImageFromList: jest.fn(),
-  updateImageList: jest.fn(),
-  // Real impl (pure) — SwipeImage now imports this from storageDatum instead of
-  // defining it locally, so the mock must supply the same behaviour.
-  normalizeListIds: (cards) => {
-    if (!Array.isArray(cards) || cards.length === 0) return cards;
-    const hasMissing = cards.some((c) => c?.listId == null || !Number.isFinite(c.listId));
-    if (!hasMissing) return cards;
-    let next = cards.reduce((max, c) => (Number.isFinite(c?.listId) && c.listId > max ? c.listId : max), 0);
-    return cards.map((c) => (Number.isFinite(c?.listId) ? c : { ...c, listId: (next += 1) }));
-  },
-  getLastImageUuid: jest.fn(),
-  saveLastImageUuid: jest.fn(),
-  deleteImageFromStorage: jest.fn(),
+jest.mock('../utils/storageDatum', () => {
+  const actual = jest.requireActual('../utils/storageDatum');
+  return {
+    PUBLIC_FEED_END_CURSOR: '__public_feed_end__',
+    getE2EHiddenGuessCard: jest.fn(),
+    getLocalImages: jest.fn(),
+    storeImageList: jest.fn(),
+    getLastImageId: jest.fn(),
+    emptyImageList: jest.fn(),
+    removeImageFromList: jest.fn(),
+    updateImageList: jest.fn(),
+    // Task A (Fix 1): cardDeck persist/append call this on every non-empty
+    // non-'all' batch — the component-level mock only needs it to resolve.
+    clearExhaustedCategory: jest.fn(() => Promise.resolve()),
+    // Task C (Fix 2b): played-set writer + shared filter — resolving mocks;
+    // default passthrough keeps the filter a no-op until a test overrides it.
+    addPlayedPictureId: jest.fn(() => Promise.resolve()),
+    filterPlayedCards: jest.fn((cards) => Promise.resolve(cards)),
+    // Task D (Fix 3): delegate to the REAL implementation so the mock cannot
+    // diverge from the storage-boundary numbering algorithm.
+    normalizeListIds: actual.normalizeListIds,
+    getLastImageUuid: jest.fn(),
+    saveLastImageUuid: jest.fn(),
+    deleteImageFromStorage: jest.fn(),
+  };
+});
+
+jest.mock('../services/groups/groupFeedApi', () => ({
+  PRIVATE_FEED_END_CURSOR: '__private_feed_end__',
 }));
 
 jest.mock('../services/groups/groupFeedCache', () => ({
@@ -107,18 +115,22 @@ import { buildE2EGuessCardFromPayload, buildE2EGuessCards, isE2EMode } from '../
 import { getImages } from '../utils/imagesRequests';
 import { getImageRating, getImageTags } from '../utils/ratingRequests';
 import {
+  addPlayedPictureId,
   deleteImageFromStorage,
+  filterPlayedCards,
   getE2EHiddenGuessCard,
   getLastImageId,
   getLastImageUuid,
   getLocalImages,
   PUBLIC_FEED_END_CURSOR,
   removeImageFromList,
+  saveLastImageUuid,
   storeImageList,
   updateImageList,
 } from '../utils/storageDatum';
 import { prefetchIfLow, warmAllDeckIfNeeded } from '../services/cardPrefetcher';
 import { readGroupFeedCache } from '../services/groups/groupFeedCache';
+import { PRIVATE_FEED_END_CURSOR } from '../services/groups/groupFeedApi';
 
 describe('SwipeImage', () => {
   const contextValue = {
@@ -208,7 +220,6 @@ describe('SwipeImage', () => {
 
   it('loads new images, assigns incremental list ids, and stores them when the cache is empty', async () => {
     getLocalImages.mockResolvedValue(null);
-    getLastImageId.mockResolvedValue(4);
     getImages.mockResolvedValue({
       isError: false,
       images: [
@@ -220,11 +231,14 @@ describe('SwipeImage', () => {
     await renderSwipeImage();
 
     expect(getImages).toHaveBeenCalledWith(null, contextValue, { language: undefined, scope: undefined });
+    // Fix 3: numbering moved to the storage boundary — persistCardBatch
+    // normalizes the batch it writes AND returns; handleData no longer
+    // recomputes ids in memory (no second writer → no collisions).
     expect(storeImageList).toHaveBeenCalledWith([
-      expect.objectContaining({ pictureId: 'img-1', listId: 5 }),
-      expect.objectContaining({ pictureId: 'img-2', listId: 6 }),
+      expect.objectContaining({ pictureId: 'img-1', listId: 1 }),
+      expect.objectContaining({ pictureId: 'img-2', listId: 2 }),
     ], 'all', 'any');
-    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.listId)).toEqual([6, 5]);
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.listId)).toEqual([2, 1]);
   });
 
   it('ignores a stale last image uuid when the local cache is missing and fetches a fresh batch', async () => {
@@ -239,7 +253,10 @@ describe('SwipeImage', () => {
 
     await renderSwipeImage();
 
-    expect(getImages).toHaveBeenCalledWith(null, contextValue, { language: undefined, scope: undefined });
+    // Fix 2a pin update: a head fetch over a stored REAL cursor now carries the
+    // { persistCursor: false } opts arg — suppressing the cursor write IS the
+    // rewind fix. The head query still fires and fresh uploads still surface.
+    expect(getImages).toHaveBeenCalledWith(null, contextValue, { language: undefined, scope: undefined }, { persistCursor: false });
     expect(storeImageList).toHaveBeenCalledWith([
       expect.objectContaining({ pictureId: 'img-1', listId: 1 }),
     ], 'all', 'any');
@@ -260,7 +277,11 @@ describe('SwipeImage', () => {
 
     await renderSwipeImage();
 
-    expect(getImages).toHaveBeenCalledWith(null, contextValue, expect.objectContaining({}));
+    // Fix 2a pin update: head-over-sentinel is a head REPLAY (sentinel =
+    // "already exhausted once") — it fetches with { persistCursor: false } so
+    // persisting cannot rewind AND erase the exhausted signal. The head query
+    // still fires, so fresh uploads still surface on re-probe.
+    expect(getImages).toHaveBeenCalledWith(null, contextValue, expect.objectContaining({}), { persistCursor: false });
     expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).toContain('fresh-after-exhaust');
   });
 
@@ -326,8 +347,28 @@ describe('SwipeImage', () => {
     expect(Alert.alert).toHaveBeenCalledWith('Server error', 'Please retry later');
   });
 
-  it('deletes a dismissed card at deck 4→3 without firing a foreground load (background prefetch owns refill)', async () => {
+  it('(m) removeCard records the swiped card in the played-set (Fix 2b writer)', async () => {
     getLocalImages.mockResolvedValue([
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///4.jpg' },
+    ]);
+
+    await renderSwipeImage();
+
+    const removableCard = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === 1)[0];
+
+    await act(async () => {
+      await removableCard.removeCard(1);
+      await flushEffects();
+    });
+
+    expect(addPlayedPictureId).toHaveBeenCalledWith('nat-1', 'any', undefined);
+    expect(addPlayedPictureId).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes a dismissed card at deck 4→3 without firing a foreground load (background prefetch owns refill)', async () => {    getLocalImages.mockResolvedValue([
       { listId: 1, imageFile: 'file:///1.jpg' },
       { listId: 2, imageFile: 'file:///2.jpg' },
       { listId: 3, imageFile: 'file:///3.jpg' },
@@ -838,6 +879,82 @@ describe('SwipeImage — deck-empty fallback to "all"', () => {
     return { renderer, startGuessing };
   }
 
+  it('(n) refill step 3 filters played interior cards out of the "all" deck before setImageList', async () => {
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    const allDeck = [
+      { listId: 1, pictureId: 'all-played', imageFile: 'file:///a1.jpg' },
+      { listId: 2, pictureId: 'all-fresh', imageFile: 'file:///a2.jpg' },
+    ];
+
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        natureCallCount += 1;
+        return Promise.resolve(natureCallCount === 1 ? natureCards : []);
+      }
+      if (key === 'all') {
+        return Promise.resolve([...allDeck]);
+      }
+      return Promise.resolve(null);
+    });
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cards.filter((card) => !card?.pictureId || card.pictureId !== 'all-played')));
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      const cardPropsById = {};
+      for (const listId of [1, 2, 3, 4]) {
+        cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+      }
+
+      for (const listId of [1, 2, 3, 4]) {
+        // eslint-disable-next-line no-await-in-loop
+        await act(async () => {
+          await cardPropsById[listId].removeCard(listId);
+          await flushEffects();
+        });
+      }
+
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).toContain('all-fresh');
+      expect(renderedPictureIds).not.toContain('all-played');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
+  it('(o) full-deck mount serve filters played cards before setImageList', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, pictureId: 'played-mount', imageFile: 'file:///1.jpg' },
+      { listId: 2, pictureId: 'fresh-mount', imageFile: 'file:///2.jpg' },
+      { listId: 3, pictureId: 'fresh-mount-2', imageFile: 'file:///3.jpg' },
+      { listId: 4, pictureId: 'fresh-mount-3', imageFile: 'file:///4.jpg' },
+    ]);
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cards.filter((card) => !card?.pictureId || card.pictureId !== 'played-mount')));
+
+    try {
+      await renderSwipeImage();
+
+      expect(filterPlayedCards).toHaveBeenCalledWith(
+        expect.any(Array),
+        'any',
+        undefined,
+      );
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).not.toContain('played-mount');
+      expect(renderedPictureIds).toContain('fresh-mount');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
   it('falls back to the warmed "all" deck from AsyncStorage when removeCard empties a real category deck (no foreground load)', async () => {
     const natureCards = [
       { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
@@ -1151,5 +1268,477 @@ describe('SwipeImage — deck-empty fallback to "all"', () => {
     });
 
     expect(prefetchIfLow).toHaveBeenCalled();
+  });
+});
+
+describe('SwipeImage — partial-deck mount cursor exhaustion (Fix 2a)', () => {
+  const contextValue = {
+    token: 'token',
+    uid: 'waldo@example.com',
+    expiry: '123',
+    access_token: 'access-token',
+    client: 'client-id',
+    userId: '42',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isE2EMode.mockReturnValue(false);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    getImageTags.mockResolvedValue({ data: [] });
+    getImageRating.mockResolvedValue({ data: undefined });
+    getE2EHiddenGuessCard.mockResolvedValue(null);
+    buildE2EGuessCardFromPayload.mockImplementation((payload) => (
+      payload ? { listId: 1, pictureId: payload.pictureId, imageFile: payload.uri } : null
+    ));
+    buildE2EGuessCards.mockReturnValue([{ listId: 1, pictureId: 'e2e-guess-card', imageFile: 'file:///e2e.jpg' }]);
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    getLastImageId.mockResolvedValue(0);
+    getLastImageUuid.mockResolvedValue(null);
+    updateImageList.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  // The partial-deck branch chains TWO sequential fetch rounds (cursor fetch →
+  // head probe → optional sentinel write), so the mount flush needs more
+  // microtask rounds than the single-fetch helper above.
+  async function flushMount() {
+    for (let i = 0; i < 8; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushEffects();
+    }
+  }
+
+  async function renderSwipeImage(startGuessing = jest.fn(), { category, language, scope } = {}) {
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <AuthContext.Provider value={contextValue}>
+          <SwipeImage
+            screenWidth={320}
+            screenHeight={640}
+            startGuessing={startGuessing}
+            category={category}
+            language={language}
+            scope={scope}
+          />
+        </AuthContext.Provider>,
+      );
+
+      await flushMount();
+    });
+
+    return { renderer, startGuessing };
+  }
+
+  it('(m) partial-deck mount with cursor-exhausted server: head probe fires, NO sentinel pre-write, stored real cursor untouched after non-empty head', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, pictureId: 'part-1', imageFile: 'file:///p1.jpg' },
+      { listId: 2, pictureId: 'part-2', imageFile: 'file:///p2.jpg' },
+    ]);
+    getLastImageUuid.mockResolvedValue('stored-cursor-9');
+    getImages
+      .mockResolvedValueOnce({ isError: false, images: [] })
+      .mockResolvedValueOnce({
+        isError: false,
+        images: [{ pictureId: 'head-fresh', imageFile: 'file:///hf.jpg' }],
+      });
+    // Fix 3: the append branch renders appendCardBatch's RETURNED deck — feed
+    // updateImageList the merged deck the storage boundary would produce.
+    updateImageList.mockResolvedValue([
+      { listId: 1, pictureId: 'part-1', imageFile: 'file:///p1.jpg' },
+      { listId: 2, pictureId: 'part-2', imageFile: 'file:///p2.jpg' },
+      { listId: 3, pictureId: 'head-fresh', imageFile: 'file:///hf.jpg' },
+    ]);
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    // Round 1: cursor-mode fetch (no override) — 3-arg, cursor as pictureId.
+    expect(getImages.mock.calls[0]).toHaveLength(3);
+    expect(getImages.mock.calls[0][0]).toBe('stored-cursor-9');
+    // Round 2: head probe — 4-arg with persistCursor:false (the rewind fix).
+    expect(getImages.mock.calls[1][0]).toBe(null);
+    expect(getImages.mock.calls[1][3]).toEqual({ persistCursor: false });
+    // No sentinel pre-write before the probe; the stored cursor is never
+    // rewritten by the component (getImages is mocked — it never persists
+    // either, proving the mount path performs NO cursor write at all).
+    expect(saveLastImageUuid).not.toHaveBeenCalled();
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId)).toContain('head-fresh');
+  });
+
+  it('(n) partial-deck mount with head ALSO empty → scope-correct PUBLIC sentinel written once (after the probe)', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, pictureId: 'part-1', imageFile: 'file:///p1.jpg' },
+      { listId: 2, pictureId: 'part-2', imageFile: 'file:///p2.jpg' },
+    ]);
+    getLastImageUuid.mockResolvedValue('stored-cursor-9');
+    getImages.mockResolvedValue({ isError: false, images: [] });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    // Both fetches fired (cursor round + head probe) before the sentinel write.
+    expect(getImages).toHaveBeenCalledTimes(2);
+    expect(saveLastImageUuid).toHaveBeenCalledTimes(1);
+    expect(saveLastImageUuid).toHaveBeenCalledWith(PUBLIC_FEED_END_CURSOR, 'nature', 'any');
+  });
+
+  it('(o) partial-deck mount serve filters played cards before setImageList', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, pictureId: 'part-played', imageFile: 'file:///p1.jpg' },
+      { listId: 2, pictureId: 'part-fresh', imageFile: 'file:///p2.jpg' },
+    ]);
+    getLastImageUuid.mockResolvedValue(null);
+    // Error round keeps handleData away so the SERVE result stays rendered.
+    getImages.mockResolvedValue({ isError: true, title: 'T', message: 'M' });
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cards.filter((card) => !card?.pictureId || card.pictureId !== 'part-played')));
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      expect(filterPlayedCards).toHaveBeenCalledWith(
+        expect.any(Array),
+        'any',
+        undefined,
+      );
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).not.toContain('part-played');
+      expect(renderedPictureIds).toContain('part-fresh');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
+  it('full-deck mount with all cards played → falls through to fetch (handleImagesLoading path), not blank stack', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, pictureId: 'played-1', imageFile: 'file:///1.jpg' },
+      { listId: 2, pictureId: 'played-2', imageFile: 'file:///2.jpg' },
+      { listId: 3, pictureId: 'played-3', imageFile: 'file:///3.jpg' },
+      { listId: 4, pictureId: 'played-4', imageFile: 'file:///4.jpg' },
+    ]);
+    // Played-set contains every stored pictureId → filter empties the deck.
+    filterPlayedCards.mockImplementation(async () => Promise.resolve([]));
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [{ pictureId: 'fresh-1', imageFile: 'file:///f1.jpg' }],
+    });
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      expect(getImages).toHaveBeenCalledTimes(1);
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).toContain('fresh-1');
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
+  it('full-deck mount with a partially-played deck still serves the unplayed remainder without fetching', async () => {
+    getLocalImages.mockResolvedValue([
+      { listId: 1, pictureId: 'played-1', imageFile: 'file:///1.jpg' },
+      { listId: 2, pictureId: 'played-2', imageFile: 'file:///2.jpg' },
+      { listId: 3, pictureId: 'fresh-3', imageFile: 'file:///3.jpg' },
+      { listId: 4, pictureId: 'fresh-4', imageFile: 'file:///4.jpg' },
+    ]);
+    filterPlayedCards.mockImplementation(async (cards) =>
+      Promise.resolve(cards.filter((card) => !card?.pictureId || !card.pictureId.startsWith('played-'))));
+
+    try {
+      await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+      expect(getImages).not.toHaveBeenCalled();
+      const renderedPictureIds = mockSwipeableCard.mock.calls.map(([props]) => props.item.pictureId);
+      expect(renderedPictureIds).toEqual(['fresh-4', 'fresh-3']);
+    } finally {
+      filterPlayedCards.mockImplementation((cards) => Promise.resolve(cards));
+    }
+  });
+
+  it('(o) private partial-deck mount with both fetches empty writes PRIVATE_FEED_END_CURSOR (scope-correct sentinel)', async () => {
+    const scope = { kind: 'private', groupId: 'group-7' };
+    readGroupFeedCache.mockResolvedValue({
+      images: [
+        { listId: 1, pictureId: 'part-1', imageFile: 'file:///p1.jpg' },
+        { listId: 2, pictureId: 'part-2', imageFile: 'file:///p2.jpg' },
+      ],
+      nextCursor: null,
+    });
+    getLastImageUuid.mockResolvedValue('stored-cursor-9');
+    getImages.mockResolvedValue({ isError: false, images: [] });
+
+    await renderSwipeImage(jest.fn(), {
+      category: { id: 'cat-nature', key: 'nature' },
+      language: 'fr',
+      scope,
+    });
+
+    expect(getImages).toHaveBeenCalledTimes(2);
+    expect(saveLastImageUuid).toHaveBeenCalledTimes(1);
+    expect(saveLastImageUuid).toHaveBeenCalledWith(PRIVATE_FEED_END_CURSOR, 'nature', 'fr');
+  });
+});
+
+describe('SwipeImage — handleData single-writer + resurrection race (Fix 3)', () => {
+  const contextValue = {
+    token: 'token',
+    uid: 'waldo@example.com',
+    expiry: '123',
+    access_token: 'access-token',
+    client: 'client-id',
+    userId: '42',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isE2EMode.mockReturnValue(false);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+    getImageTags.mockResolvedValue({ data: [] });
+    getImageRating.mockResolvedValue({ data: undefined });
+    getE2EHiddenGuessCard.mockResolvedValue(null);
+    buildE2EGuessCardFromPayload.mockImplementation((payload) => (
+      payload ? { listId: 1, pictureId: payload.pictureId, imageFile: payload.uri } : null
+    ));
+    buildE2EGuessCards.mockReturnValue([{ listId: 1, pictureId: 'e2e-guess-card', imageFile: 'file:///e2e.jpg' }]);
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    getLastImageId.mockResolvedValue(0);
+    getLastImageUuid.mockResolvedValue(null);
+    updateImageList.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function flushEffects() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function flushMount() {
+    for (let i = 0; i < 8; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushEffects();
+    }
+  }
+
+  function createDeferred() {
+    let resolve;
+    const promise = new Promise((nextResolve) => {
+      resolve = nextResolve;
+    });
+    return { promise, resolve };
+  }
+
+  async function renderSwipeImage(startGuessing = jest.fn(), { category, language, scope } = {}) {
+    let renderer;
+
+    await act(async () => {
+      renderer = create(
+        <AuthContext.Provider value={contextValue}>
+          <SwipeImage
+            screenWidth={320}
+            screenHeight={640}
+            startGuessing={startGuessing}
+            category={category}
+            language={language}
+            scope={scope}
+          />
+        </AuthContext.Provider>,
+      );
+
+      await flushMount();
+    });
+
+    return { renderer, startGuessing };
+  }
+
+  it('(g) append uses the returned deck — storage-side numbering wins (no duplicate keys when background prefetch numbered concurrently)', async () => {
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        natureCallCount += 1;
+        return Promise.resolve(natureCallCount === 1 ? natureCards : []);
+      }
+      return Promise.resolve(null);
+    });
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [{ pictureId: 'bg-numbered', imageFile: 'file:///bg.jpg' }],
+    });
+    // Storage-side merged deck: a background prefetch numbered cards 5–8
+    // meanwhile, so the incoming card landed at listId 9 — the component must
+    // adopt STORAGE numbering, never recompute ids from memory.
+    updateImageList.mockResolvedValue([
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+      { listId: 9, pictureId: 'bg-numbered', imageFile: 'file:///bg.jpg' },
+    ]);
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const cardPropsById = {};
+    for (const listId of [1, 2, 3, 4]) {
+      cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+    }
+    for (const listId of [1, 2, 3, 4]) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        await cardPropsById[listId].removeCard(listId);
+        await flushEffects();
+      });
+    }
+
+    const finalRender = mockSwipeableCard.mock.calls.slice(-2).map(([props]) => [props.item.pictureId, props.item.listId]);
+    expect(finalRender).toEqual([['bg-numbered', 9], ['nat-4', 4]]);
+    expect(new Set(finalRender.map(([, listId]) => listId)).size).toBe(finalRender.length);
+  });
+
+  it('(h) incoming batch whose pictureId is already in the deck does not duplicate imageList', async () => {
+    const natureCards = [
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+    ];
+    let natureCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        natureCallCount += 1;
+        return Promise.resolve(natureCallCount === 1 ? natureCards : []);
+      }
+      return Promise.resolve(null);
+    });
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [
+        { pictureId: 'nat-4', imageFile: 'file:///dup.jpg' },
+        { pictureId: 'fresh-1', imageFile: 'file:///f1.jpg' },
+      ],
+    });
+    // The storage boundary dedups by pictureId — its returned deck holds
+    // nat-4 exactly once; the component must serve that deck as-is.
+    updateImageList.mockResolvedValue([
+      { listId: 1, pictureId: 'nat-1', imageFile: 'file:///n1.jpg' },
+      { listId: 2, pictureId: 'nat-2', imageFile: 'file:///n2.jpg' },
+      { listId: 3, pictureId: 'nat-3', imageFile: 'file:///n3.jpg' },
+      { listId: 4, pictureId: 'nat-4', imageFile: 'file:///n4.jpg' },
+      { listId: 9, pictureId: 'fresh-1', imageFile: 'file:///f1.jpg' },
+    ]);
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const cardPropsById = {};
+    for (const listId of [1, 2, 3, 4]) {
+      cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+    }
+    for (const listId of [1, 2, 3, 4]) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        await cardPropsById[listId].removeCard(listId);
+        await flushEffects();
+      });
+    }
+
+    const finalRender = mockSwipeableCard.mock.calls.slice(-2).map(([props]) => [props.item.pictureId, props.item.listId]);
+    expect(finalRender).toEqual([['fresh-1', 9], ['nat-4', 4]]);
+    expect(finalRender.filter(([pid]) => pid === 'nat-4')).toHaveLength(1);
+  });
+
+  it('(i) RESURRECTION RACE: a card swiped before a slow appendCardBatch RMW resolves stays removed; pictureId-less legacy card survives', async () => {
+    const deck = [
+      { listId: 1, pictureId: 'race-a', imageFile: 'file:///1.jpg' },
+      { listId: 2, pictureId: 'race-b', imageFile: 'file:///2.jpg' },
+      { listId: 3, pictureId: 'fill-1', imageFile: 'file:///3.jpg' },
+      { listId: 4, pictureId: 'fill-2', imageFile: 'file:///4.jpg' },
+    ];
+    let deckCallCount = 0;
+    getLocalImages.mockImplementation((key) => {
+      if (key === 'nature') {
+        deckCallCount += 1;
+        return Promise.resolve(deckCallCount === 1 ? deck : []);
+      }
+      return Promise.resolve(null);
+    });
+    getImages.mockResolvedValue({
+      isError: false,
+      images: [{ pictureId: 'race-new', imageFile: 'file:///new.jpg' }],
+    });
+
+    await renderSwipeImage(jest.fn(), { category: { id: 'cat-nature', key: 'nature' } });
+
+    const cardPropsById = {};
+    for (const listId of [1, 2, 3, 4]) {
+      cardPropsById[listId] = mockSwipeableCard.mock.calls.find(([props]) => props.item.listId === listId)[0];
+    }
+
+    // Swipe fill-2, fill-1, then race-a — each removal flushes before the
+    // next, so memory (and the played-set writer) no longer contain race-a.
+    for (const listId of [4, 3, 1]) {
+      // eslint-disable-next-line no-await-in-loop
+      await act(async () => {
+        await cardPropsById[listId].removeCard(listId);
+        await flushEffects();
+      });
+    }
+    expect(addPlayedPictureId).toHaveBeenCalledWith('race-a', 'any', undefined);
+
+    // Last removal empties the deck → refill foreground load → append. The
+    // append RMW is SLOW and read storage PRE-REMOVAL: its merged deck still
+    // contains race-a and race-b plus a pictureId-less legacy card.
+    const appendGate = createDeferred();
+    updateImageList.mockReturnValueOnce(appendGate.promise);
+    mockSwipeableCard.mockClear();
+
+    let removalPromise;
+    await act(async () => {
+      removalPromise = cardPropsById[2].removeCard(2);
+      await flushEffects();
+    });
+    await act(async () => {
+      await flushMount();
+    });
+
+    await act(async () => {
+      appendGate.resolve([
+        { listId: 1, pictureId: 'race-a', imageFile: 'file:///1.jpg' },
+        { listId: 2, pictureId: 'race-b', imageFile: 'file:///2.jpg' },
+        { listId: 3, pictureId: 'race-new', imageFile: 'file:///new.jpg' },
+        { listId: 4, imageFile: 'file:///legacy.jpg' },
+      ]);
+      await flushMount();
+    });
+    await act(async () => {
+      await removalPromise;
+      await flushEffects();
+    });
+
+    // Removals win: race-a (swiped pre-RMW) and race-b (swiped as the refill
+    // trigger) must NOT resurrect; the legacy card is unidentifiable → passes.
+    const finalRender = mockSwipeableCard.mock.calls.slice(-2).map(([props]) => [props.item.pictureId ?? null, props.item.listId]);
+    expect(finalRender).toEqual([[null, 4], ['race-new', 3]]);
+    const finalPictureIds = finalRender.map(([pid]) => pid);
+    expect(finalPictureIds).not.toContain('race-a');
+    expect(finalPictureIds).not.toContain('race-b');
+    expect(mockSwipeableCard.mock.calls.map(([props]) => props.item.imageFile)).toContain('file:///legacy.jpg');
   });
 });

--- a/__tests__/auth-context.test.js
+++ b/__tests__/auth-context.test.js
@@ -5,7 +5,8 @@ jest.mock('expo-secure-store', () => ({
 }));
 
 jest.mock('../utils/storageDatum', () => ({
-  emptyImageList: jest.fn().mockResolvedValue(undefined),
+  ...jest.requireActual('../utils/storageDatum'),
+  wipePublicGuessStorage: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../services/billing/billingApi', () => ({
@@ -18,7 +19,7 @@ import { act, create } from 'react-test-renderer';
 import * as SecureStore from 'expo-secure-store';
 
 import AuthContextProvider, { AuthContext } from '../store/auth-context';
-import { emptyImageList } from '../utils/storageDatum';
+import { wipePublicGuessStorage } from '../utils/storageDatum';
 import { syncEntitlement } from '../services/billing/billingApi';
 
 const Purchases = require('react-native-purchases').default;
@@ -86,7 +87,7 @@ describe('AuthContextProvider', () => {
       });
     });
 
-    expect(emptyImageList).toHaveBeenCalledTimes(1);
+    expect(wipePublicGuessStorage).toHaveBeenCalledTimes(1);
     expect(SecureStore.setItemAsync).toHaveBeenCalledWith('token', 'Bearer token-123');
     expect(SecureStore.setItemAsync).toHaveBeenCalledWith('userId', 'user-1');
     expect(SecureStore.setItemAsync).toHaveBeenCalledWith('email', 'waldo@example.com');
@@ -183,7 +184,7 @@ describe('AuthContextProvider', () => {
       });
     });
 
-    emptyImageList.mockClear();
+    wipePublicGuessStorage.mockClear();
 
     await act(async () => {
       await latestContext.logout();
@@ -199,7 +200,7 @@ describe('AuthContextProvider', () => {
     expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('username');
     expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('isTutorialFinished');
     expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('scoreId');
-    expect(emptyImageList).toHaveBeenCalledTimes(1);
+    expect(wipePublicGuessStorage).toHaveBeenCalledTimes(1);
   });
 
   it('registers a RevenueCat customer info listener on authenticate', async () => {

--- a/__tests__/cardDeck.probe.test.ts
+++ b/__tests__/cardDeck.probe.test.ts
@@ -1,0 +1,255 @@
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  getAllKeys: jest.fn(),
+  multiRemove: jest.fn(),
+}));
+
+jest.mock('../utils/imagesRequests', () => ({
+  getImages: jest.fn(),
+}));
+
+jest.mock('../services/groups/groupFeedApi', () => ({
+  PRIVATE_FEED_END_CURSOR: '__private_feed_end__',
+}));
+
+jest.mock('../services/groups/groupFeedCache', () => {
+  const actual = jest.requireActual('../services/groups/groupFeedCache');
+  return {
+    ...actual,
+    readGroupFeedCache: jest.fn(),
+    writeGroupFeedCache: jest.fn(),
+  };
+});
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getImages } from '../utils/imagesRequests';
+import { readGroupFeedCache, writeGroupFeedCache } from '../services/groups/groupFeedCache';
+import { saveLastImageUuid } from '../utils/storageDatum';
+import { probeAllPoolForUnplayed } from '../services/cardDeck';
+
+const mockAsyncStorage = AsyncStorage as unknown as {
+  getItem: jest.MockedFunction<(key: string) => Promise<string | null>>;
+  setItem: jest.MockedFunction<(key: string, value: string) => Promise<void>>;
+  removeItem: jest.MockedFunction<(key: string) => Promise<void>>;
+  getAllKeys: jest.MockedFunction<() => Promise<readonly string[]>>;
+  multiRemove: jest.MockedFunction<(keys: readonly string[]) => Promise<void>>;
+};
+
+const mockGetImages = getImages as unknown as jest.Mock;
+
+type Store = Map<string, string>;
+
+function mockStore(initial: Record<string, string> = {}): Store {
+  const store: Store = new Map(Object.entries(initial));
+  mockAsyncStorage.getItem.mockImplementation(async (key: string) => store.get(key) ?? null);
+  mockAsyncStorage.setItem.mockImplementation(async (key: string, value: string) => {
+    store.set(key, value);
+  });
+  mockAsyncStorage.removeItem.mockImplementation(async (key: string) => {
+    store.delete(key);
+  });
+  mockAsyncStorage.getAllKeys.mockImplementation(async () => Array.from(store.keys()));
+  mockAsyncStorage.multiRemove.mockImplementation(async (keys: readonly string[]) => {
+    keys.forEach((key) => store.delete(key));
+  });
+  return store;
+}
+
+type Card = { pictureId: string; imageFile: string };
+
+function batch(prefix: string, count: number): Card[] {
+  return Array.from({ length: count }, (_, i) => ({
+    pictureId: `${prefix}${i + 1}`,
+    imageFile: `file:///cache/${prefix}${i + 1}.jpg`,
+  }));
+}
+
+function pictureIds(cards: Array<{ pictureId?: string }>): string[] {
+  return cards.map((c) => c.pictureId);
+}
+
+/**
+ * Cursor-mode server + transport-persistence simulation: serves the batch
+ * AFTER the cursor's tail (head batch when pictureId is null), and persists
+ * the served batch's tail through the REAL saveLastImageUuid (same contract
+ * as utils/imagesRequests.getImages — non-empty batch → cursor advance;
+ * opts.persistCursor === false → head replay, no write).
+ */
+function mockCursorServer(batches: Card[][]) {
+  mockGetImages.mockImplementation(async (pictureId: string | null, _ctx: unknown, filters: { language?: string; scope?: unknown }, ...rest: unknown[]) => {
+    const opts = rest[0] as { persistCursor?: boolean } | undefined;
+    const index = pictureId === null
+      ? 0
+      : batches.findIndex((b) => b.length > 0 && b[b.length - 1].pictureId === pictureId) + 1;
+    const served = batches[index];
+    if (!served || served.length === 0) {
+      return { isError: false, reason: 'empty', images: [] };
+    }
+    if (opts?.persistCursor !== false) {
+      await saveLastImageUuid(served[served.length - 1].pictureId, 'all', filters?.language, filters?.scope ?? null);
+    }
+    return { isError: false, images: served };
+  });
+}
+
+const PUBLIC_ARGS = { language: 'fr', scope: { kind: 'public' }, authContext: { token: 't' } };
+
+describe('probeAllPoolForUnplayed (sound exhaustion proof, Steps 1+2)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStore();
+    mockGetImages.mockReset();
+    readGroupFeedCache.mockResolvedValue(null);
+    writeGroupFeedCache.mockResolvedValue(undefined);
+  });
+
+  it('all-played batch pages forward, later unplayed batch appends to the "all" deck, cursor advances, no servingCycle writes', async () => {
+    const b2 = batch('played-', 2);
+    const b3 = batch('fresh-', 3);
+    const store = mockStore({
+      'lastImageUuid:all:fr': 'row-5-cursor',
+      'playedPictureIds:public:fr': JSON.stringify(pictureIds(b2)),
+    });
+    mockCursorServer([batch('old-', 5), b2, b3]);
+    // The stored cursor must be the tail of batch 1 for the server mock.
+    const b1 = batch('old-', 5);
+    store.set('lastImageUuid:all:fr', b1[4].pictureId);
+
+    const result = await probeAllPoolForUnplayed({ ...PUBLIC_ARGS });
+
+    expect(result).toEqual({ status: 'unplayed' });
+    expect(mockGetImages).toHaveBeenCalledTimes(2);
+    expect(mockGetImages.mock.calls[0][0]).toBe(b1[4].pictureId);
+    expect(mockGetImages.mock.calls[1][0]).toBe(b2[1].pictureId);
+    expect(store.get('lastImageUuid:all:fr')).toBe(b3[2].pictureId);
+    const deck = JSON.parse(store.get('imageList:all:fr') ?? '[]');
+    expect(pictureIds(deck)).toEqual(pictureIds(b3));
+    expect(Array.from(store.keys()).every((key) => !key.startsWith('servingCycle:'))).toBe(true);
+    expect(
+      mockAsyncStorage.setItem.mock.calls.filter(([key]) => key.startsWith('servingCycle:')),
+    ).toHaveLength(0);
+  });
+
+  it('drains to an empty batch → exhausted (server-proven pool drain)', async () => {
+    const b2 = batch('played-', 2);
+    const store = mockStore({
+      'playedPictureIds:public:fr': JSON.stringify(pictureIds(b2)),
+    });
+    const b1 = batch('old-', 5);
+    store.set('lastImageUuid:all:fr', b1[4].pictureId);
+    mockCursorServer([b1, b2]);
+
+    const result = await probeAllPoolForUnplayed({ ...PUBLIC_ARGS });
+
+    expect(result).toEqual({ status: 'exhausted' });
+    expect(store.get('lastImageUuid:all:fr')).toBe(b2[1].pictureId);
+    expect(store.has('imageList:all:fr')).toBe(false);
+  });
+
+  it('public sentinel: cleared before the first fetch, which is then a head fetch with cursor persist', async () => {
+    const store = mockStore({
+      'lastImageUuid:all:fr': '__public_feed_end__',
+    });
+    const b1 = batch('head-', 3);
+    mockCursorServer([b1]);
+
+    const result = await probeAllPoolForUnplayed({ ...PUBLIC_ARGS });
+
+    expect(result).toEqual({ status: 'unplayed' });
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('lastImageUuid:all:fr');
+    expect(mockGetImages.mock.calls[0][0]).toBeNull();
+    expect(mockGetImages.mock.calls[0]).toHaveLength(3);
+    expect(store.get('lastImageUuid:all:fr')).toBe(b1[2].pictureId);
+  });
+
+  it('private sentinel: cleared under the group-scoped key before the first fetch, which is then a head fetch', async () => {
+    const scope = { kind: 'private', groupId: 'g-1' };
+    const store = mockStore({
+      'groupFeed:g-1:game:all:fr:cursor': '__private_feed_end__',
+    });
+    const b1 = batch('priv-', 3);
+    mockCursorServer([b1]);
+
+    const result = await probeAllPoolForUnplayed({ language: 'fr', scope, authContext: { token: 't' } });
+
+    expect(result).toEqual({ status: 'unplayed' });
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('groupFeed:g-1:game:all:fr:cursor');
+    expect(mockGetImages.mock.calls[0][0]).toBeNull();
+    expect(mockGetImages.mock.calls[0]).toHaveLength(3);
+    expect(store.get('groupFeed:g-1:game:all:fr:cursor')).toBe(b1[2].pictureId);
+  });
+
+  it('fetch error → indeterminate, cursor untouched, no deck write', async () => {
+    const b1 = batch('old-', 5);
+    const store = mockStore({
+      'lastImageUuid:all:fr': b1[4].pictureId,
+    });
+    mockGetImages.mockResolvedValue({ isError: true, reason: 'network' });
+
+    const result = await probeAllPoolForUnplayed({ ...PUBLIC_ARGS });
+
+    expect(result).toEqual({ status: 'indeterminate', reason: 'network' });
+    expect(mockGetImages).toHaveBeenCalledTimes(1);
+    expect(store.get('lastImageUuid:all:fr')).toBe(b1[4].pictureId);
+    expect(store.has('imageList:all:fr')).toBe(false);
+  });
+
+  it('PROBE_MAX_BATCHES all-played batches → indeterminate probe-cap (fail open)', async () => {
+    const played = batch('p', 1);
+    const batches = Array.from({ length: 20 }, (_, i) => [{ ...played[0], pictureId: `cap-${i}` }]);
+    const store = mockStore({
+      'playedPictureIds:public:fr': JSON.stringify(pictureIds(batches.flat())),
+    });
+    mockCursorServer(batches);
+
+    const result = await probeAllPoolForUnplayed({ ...PUBLIC_ARGS });
+
+    expect(result).toEqual({ status: 'indeterminate', reason: 'probe-cap' });
+    expect(mockGetImages).toHaveBeenCalledTimes(20);
+    expect(store.has('imageList:all:fr')).toBe(false);
+  });
+
+  it('excludePictureId is excluded from the unplayed check (probe keeps draining past it)', async () => {
+    const justPlayed = { pictureId: 'just-played', imageFile: 'file:///cache/just.jpg' };
+    const store = mockStore({
+      'playedPictureIds:public:fr': JSON.stringify(['other-played']),
+    });
+    const b1 = batch('old-', 5);
+    store.set('lastImageUuid:all:fr', b1[4].pictureId);
+    mockCursorServer([b1, [justPlayed, { pictureId: 'other-played', imageFile: 'file:///cache/other.jpg' }]]);
+
+    const result = await probeAllPoolForUnplayed({ ...PUBLIC_ARGS, excludePictureId: 'just-played' });
+
+    expect(result).toEqual({ status: 'exhausted' });
+    expect(store.has('imageList:all:fr')).toBe(false);
+  });
+
+  it('private scope: group "all" namespace deck write + group-scoped cursor, no public bleed', async () => {
+    const scope = { kind: 'private', groupId: 'g-1' };
+    const b2 = batch('gplayed-', 2);
+    const b3 = batch('gfresh-', 3);
+    const store = mockStore({
+      'playedPictureIds:group:g-1:fr': JSON.stringify(pictureIds(b2)),
+    });
+    const b1 = batch('gold-', 5);
+    store.set('groupFeed:g-1:game:all:fr:cursor', b1[4].pictureId);
+    mockCursorServer([b1, b2, b3]);
+
+    const result = await probeAllPoolForUnplayed({ language: 'fr', scope, authContext: { token: 't' } });
+
+    expect(result).toEqual({ status: 'unplayed' });
+    expect(writeGroupFeedCache).toHaveBeenCalledWith(
+      'g-1',
+      { categoryId: undefined, language: 'fr' },
+      {
+        images: b3.map((card, i) => ({ ...card, listId: i + 1 })),
+        nextCursor: null,
+      },
+    );
+    expect(store.get('groupFeed:g-1:game:all:fr:cursor')).toBe(b3[2].pictureId);
+    expect(store.has('lastImageUuid:all:fr')).toBe(false);
+    expect(store.has('imageList:all:fr')).toBe(false);
+  });
+});

--- a/__tests__/cardDeck.test.js
+++ b/__tests__/cardDeck.test.js
@@ -25,7 +25,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { clearExhaustedCategory, getLastImageUuid, storeImageList, updateImageList } from '../utils/storageDatum';
 import { getImages } from '../utils/imagesRequests';
 import { clearGroupCategoryExhausted, readGroupFeedCache, writeGroupFeedCache } from '../services/groups/groupFeedCache';
-import { appendCardBatch, fetchCardBatch, persistCardBatch } from '../services/cardDeck';
+import { appendCardBatch, fetchCardBatch, persistCardBatch, removeCardFromGroupDeck } from '../services/cardDeck';
 
 const realUpdateImageList = jest.requireActual('../utils/storageDatum').updateImageList;
 
@@ -387,6 +387,108 @@ describe('appendCardBatch pictureId dedup (RC10/T4.3)', () => {
   });
 });
 
+describe('removeCardFromGroupDeck (Fix 1 D1 private path)', () => {
+  const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AsyncStorage.getItem.mockResolvedValue(null);
+    updateImageList.mockResolvedValue([]);
+    writeGroupFeedCache.mockResolvedValue(undefined);
+    readGroupFeedCache.mockResolvedValue(null);
+  });
+
+  it('removes only the target listId from the persisted private deck and preserves nextCursor', async () => {
+    readGroupFeedCache.mockResolvedValueOnce({
+      images: [{ listId: 1 }, { listId: 2 }, { listId: 3 }],
+      nextCursor: { page: 2 },
+    });
+
+    await removeCardFromGroupDeck({
+      groupId: 'g-3',
+      categoryId: 7,
+      language: 'fr',
+      listId: 2,
+    });
+
+    expect(readGroupFeedCache).toHaveBeenCalledWith('g-3', { categoryId: 7, language: 'fr' });
+    expect(writeGroupFeedCache).toHaveBeenCalledWith(
+      'g-3',
+      { categoryId: 7, language: 'fr' },
+      { images: [{ listId: 1 }, { listId: 3 }], nextCursor: { page: 2 } },
+    );
+  });
+
+  it('serializes with appendCardBatch on the same private deck key', async () => {
+    let store = {
+      images: [{ listId: 1 }, { listId: 2 }],
+      nextCursor: 'cursor-1',
+    };
+    let releaseFirstWrite;
+    const firstWriteGate = new Promise((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    let firstWriteGated = false;
+
+    readGroupFeedCache.mockImplementation(async () => ({
+      images: [...store.images],
+      nextCursor: store.nextCursor,
+    }));
+
+    writeGroupFeedCache.mockImplementation(async (_groupId, _meta, payload) => {
+      if (!firstWriteGated) {
+        firstWriteGated = true;
+        await firstWriteGate;
+      }
+      store = { images: payload.images, nextCursor: payload.nextCursor };
+    });
+
+    const sharedArgs = {
+      categoryKey: 'all',
+      categoryId: 'all',
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-lock' },
+    };
+
+    const append = appendCardBatch({ ...sharedArgs, cards: [{ listId: 3 }] });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const removal = removeCardFromGroupDeck({
+      groupId: 'g-lock',
+      categoryId: 'all',
+      language: 'fr',
+      listId: 1,
+    });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(readGroupFeedCache).toHaveBeenCalledTimes(1);
+
+    releaseFirstWrite();
+    await append;
+    await removal;
+
+    expect(store).toEqual({
+      images: [{ listId: 2 }, { listId: 3 }],
+      nextCursor: 'cursor-1',
+    });
+  });
+
+  it('is a no-op when the private cache is missing', async () => {
+    readGroupFeedCache.mockResolvedValueOnce(null);
+
+    await expect(removeCardFromGroupDeck({
+      groupId: 'g-3',
+      categoryId: 7,
+      language: 'fr',
+      listId: 2,
+    })).resolves.toBeUndefined();
+
+    expect(writeGroupFeedCache).not.toHaveBeenCalled();
+  });
+});
+
 describe('exhausted-marker invalidation (Fix 1)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -656,12 +758,13 @@ describe('fetchCardBatch', () => {
     expect(privateFilters).not.toHaveProperty('category_key');
   });
 
-  it('private cursor round-trip: reads the persisted cursor under the private category id namespace', async () => {
-    // Regression: buildFeedFilters omits category_key for private scopes, so
-    // the write path (getImages → fetchPrivateFeedPageForGame) must derive the
-    // cursor namespace from category_id. The READ side here must query the
-    // SAME namespace (the private category id, not 'all') or the private
-    // cursor never round-trips and pagination stalls at page 1.
+  it('private cursor round-trip: reads the persisted cursor under the group-scoped namespace', async () => {
+    // Regression (F1/F2 review fix): buildFeedFilters omits category_key for
+    // private scopes, so the write path (getImages → fetchPrivateFeedPageForGame)
+    // derives the cursor category from category_id and persists under the
+    // group-scoped key. The READ side must query the SAME (categoryKey,
+    // language, scope) tuple or the private cursor never round-trips and
+    // pagination stalls at page 1.
     await fetchCardBatch({
       categoryKey: 'cat-private-uuid',
       categoryId: 'cat-private-uuid',
@@ -670,8 +773,28 @@ describe('fetchCardBatch', () => {
       authContext: { token: 't' },
     });
 
-    expect(getLastImageUuid).toHaveBeenCalledWith('cat-private-uuid', 'fr');
+    expect(getLastImageUuid).toHaveBeenCalledWith('cat-private-uuid', 'fr', { kind: 'private', groupId: 'g-1' });
     expect(getImages.mock.calls[0][2]).toMatchObject({ category_id: 'cat-private-uuid' });
+  });
+
+  it('private sentinel passes through uncoerced (asymmetry: only the PUBLIC sentinel is coerced to a head fetch)', async () => {
+    // The PRIVATE_FEED_END_CURSOR is consumed by fetchPrivateFeedPageForGame's
+    // exhausted short-circuit — cardDeck must NOT coerce it to null the way it
+    // coerces the PUBLIC sentinel (legacy public self-heal). Reading it
+    // uncoerced keeps the sentinel semantics scope-correct.
+    getLastImageUuid.mockResolvedValue('__private_feed_end__');
+
+    await fetchCardBatch({
+      categoryKey: 'cat-private-uuid',
+      categoryId: 'cat-private-uuid',
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-1' },
+      authContext: { token: 't' },
+      // pictureIdOverride intentionally omitted (cursor-mode)
+    });
+
+    expect(getImages.mock.calls[0][0]).toBe('__private_feed_end__');
+    expect(getImages.mock.calls[0]).toHaveLength(3);
   });
 
   it('B2: PUBLIC "all" pseudo-category sends neither category_key nor category_id', async () => {

--- a/__tests__/cardDeck.test.js
+++ b/__tests__/cardDeck.test.js
@@ -6,6 +6,8 @@ jest.mock('../utils/storageDatum', () => {
     getLastImageUuid: jest.fn(),
     storeImageList: jest.fn(),
     updateImageList: jest.fn(),
+    clearExhaustedCategory: jest.fn((categoryKey, language, scope) =>
+      actual.clearExhaustedCategory(categoryKey, language, scope)),
   };
 });
 
@@ -16,13 +18,14 @@ jest.mock('../utils/imagesRequests', () => ({
 jest.mock('../services/groups/groupFeedCache', () => ({
   readGroupFeedCache: jest.fn(),
   writeGroupFeedCache: jest.fn(),
+  clearGroupCategoryExhausted: jest.fn(),
 }));
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { getLastImageUuid, updateImageList } from '../utils/storageDatum';
+import { clearExhaustedCategory, getLastImageUuid, storeImageList, updateImageList } from '../utils/storageDatum';
 import { getImages } from '../utils/imagesRequests';
-import { readGroupFeedCache, writeGroupFeedCache } from '../services/groups/groupFeedCache';
-import { appendCardBatch, fetchCardBatch } from '../services/cardDeck';
+import { clearGroupCategoryExhausted, readGroupFeedCache, writeGroupFeedCache } from '../services/groups/groupFeedCache';
+import { appendCardBatch, fetchCardBatch, persistCardBatch } from '../services/cardDeck';
 
 const realUpdateImageList = jest.requireActual('../utils/storageDatum').updateImageList;
 
@@ -108,15 +111,24 @@ describe('appendCardBatch', () => {
     );
   });
 
-  it('returns null to match persistCardBatch', async () => {
-    await expect(
-      appendCardBatch({ cards: [], categoryKey: 'all', language: 'fr', scope: { kind: 'public' } }),
-    ).resolves.toBe(null);
+  it('(e) returns the merged deck for both scopes — callers use it as the numbering source of truth (Fix 3)', async () => {
+    updateImageList.mockResolvedValueOnce([{ listId: 1 }, { listId: 2 }]);
 
-    readGroupFeedCache.mockResolvedValueOnce({ images: [], nextCursor: null });
     await expect(
-      appendCardBatch({ cards: [], categoryKey: 'all', language: 'fr', scope: { kind: 'private', groupId: 'g-3' } }),
-    ).resolves.toBe(null);
+      appendCardBatch({ cards: [{ listId: 2 }], categoryKey: 'all', language: 'fr', scope: { kind: 'public' } }),
+    ).resolves.toEqual([{ listId: 1 }, { listId: 2 }]);
+
+    readGroupFeedCache.mockResolvedValueOnce({ images: [{ listId: 1 }], nextCursor: null });
+
+    await expect(
+      appendCardBatch({
+        cards: [{ pictureId: 'x' }],
+        categoryKey: 'all',
+        categoryId: 'all',
+        language: 'fr',
+        scope: { kind: 'private', groupId: 'g-3' },
+      }),
+    ).resolves.toEqual([{ listId: 1 }, { pictureId: 'x', listId: 2 }]);
   });
 
   it('normalizes an undefined language to "any" before forwarding to delegates', async () => {
@@ -350,6 +362,9 @@ describe('appendCardBatch pictureId dedup (RC10/T4.3)', () => {
     // the REAL updateImageList against AsyncStorage mocks to verify the
     // post-append deck has no pictureId duplicate.
     updateImageList.mockImplementation(realUpdateImageList);
+    // Fix 2b: appendCardBatch now reads the played-set (filterPlayedCards)
+    // BEFORE updateImageList reads the deck — feed the played read first.
+    AsyncStorage.getItem.mockResolvedValueOnce(null);
     AsyncStorage.getItem.mockResolvedValueOnce(
       JSON.stringify([{ listId: 1, pictureId: 'card-A' }]),
     );
@@ -369,6 +384,212 @@ describe('appendCardBatch pictureId dedup (RC10/T4.3)', () => {
     const pictureIds = writtenImages.map((c) => c.pictureId);
     expect(pictureIds).toEqual(['card-A', 'card-B']);
     expect(new Set(pictureIds).size).toBe(pictureIds.length);
+  });
+});
+
+describe('exhausted-marker invalidation (Fix 1)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    updateImageList.mockResolvedValue([]);
+    writeGroupFeedCache.mockResolvedValue(undefined);
+    readGroupFeedCache.mockResolvedValue(null);
+    clearGroupCategoryExhausted.mockResolvedValue(undefined);
+  });
+
+  it('appendCardBatch with non-empty non-"all" batch clears exhausted marker (public)', async () => {
+    await appendCardBatch({
+      cards: [{ listId: 1 }],
+      categoryKey: 'city',
+      language: 'fr',
+      scope: { kind: 'public' },
+    });
+
+    expect(clearExhaustedCategory).toHaveBeenCalledWith('city', 'fr', { kind: 'public' });
+  });
+
+  it('persistCardBatch non-empty non-"all" clears marker', async () => {
+    await persistCardBatch({
+      cards: [{ listId: 1 }],
+      categoryKey: 'city',
+      language: 'fr',
+      scope: { kind: 'public' },
+    });
+
+    expect(clearExhaustedCategory).toHaveBeenCalledWith('city', 'fr', { kind: 'public' });
+  });
+
+  it('categoryKey "all" never clears', async () => {
+    await appendCardBatch({
+      cards: [{ listId: 1 }],
+      categoryKey: 'all',
+      language: 'fr',
+      scope: { kind: 'public' },
+    });
+    await persistCardBatch({
+      cards: [{ listId: 1 }],
+      categoryKey: 'all',
+      language: 'fr',
+      scope: { kind: 'public' },
+    });
+
+    expect(clearExhaustedCategory).not.toHaveBeenCalled();
+  });
+
+  it('empty batch does not clear', async () => {
+    await appendCardBatch({
+      cards: [],
+      categoryKey: 'city',
+      language: 'fr',
+      scope: { kind: 'public' },
+    });
+    await persistCardBatch({
+      cards: [],
+      categoryKey: 'city',
+      language: 'fr',
+      scope: { kind: 'public' },
+    });
+
+    expect(clearExhaustedCategory).not.toHaveBeenCalled();
+  });
+
+  it('private scope routes to group clear (clearGroupCategoryExhausted via mocked storageDatum)', async () => {
+    await appendCardBatch({
+      cards: [{ listId: 1 }],
+      categoryKey: 'city',
+      categoryId: 7,
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-3' },
+    });
+
+    expect(clearExhaustedCategory).toHaveBeenCalledWith('city', 'fr', { kind: 'private', groupId: 'g-3' });
+    expect(clearGroupCategoryExhausted).toHaveBeenCalledWith('g-3', 'city', 'fr');
+  });
+
+  it('clear failure does not reject the append (Fix 3: resolves the updateImageList deck)', async () => {
+    clearExhaustedCategory.mockRejectedValueOnce(new Error('storage clear failed'));
+
+    await expect(
+      appendCardBatch({
+        cards: [{ listId: 1 }],
+        categoryKey: 'city',
+        language: 'fr',
+        scope: { kind: 'public' },
+      }),
+    ).resolves.toEqual([]);
+
+    expect(updateImageList).toHaveBeenCalledWith([{ listId: 1 }], 'city', 'fr');
+  });
+});
+
+describe('appendCardBatch played-set filter (Fix 2b)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    updateImageList.mockResolvedValue([]);
+    writeGroupFeedCache.mockResolvedValue(undefined);
+    readGroupFeedCache.mockResolvedValue(null);
+    AsyncStorage.setItem.mockResolvedValue(undefined);
+  });
+
+  it('(j) drops incoming cards whose pictureId is in the played-set (public + private branches)', async () => {
+    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['played-1']));
+
+    await appendCardBatch({
+      cards: [{ pictureId: 'played-1' }, { pictureId: 'fresh-1' }],
+      categoryKey: 'city',
+      language: 'fr',
+      scope: { kind: 'public' },
+    });
+
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('playedPictureIds:public:fr');
+    expect(updateImageList).toHaveBeenCalledWith([{ pictureId: 'fresh-1' }], 'city', 'fr');
+
+    jest.clearAllMocks();
+    updateImageList.mockResolvedValue([]);
+    readGroupFeedCache.mockResolvedValueOnce({ images: [], nextCursor: null });
+    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['played-1']));
+
+    await appendCardBatch({
+      cards: [{ pictureId: 'played-1' }, { pictureId: 'fresh-2' }],
+      categoryKey: 'city',
+      categoryId: 7,
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-3' },
+    });
+
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('playedPictureIds:group:g-3:fr');
+    expect(writeGroupFeedCache).toHaveBeenCalledWith(
+      'g-3',
+      { categoryId: 7, language: 'fr' },
+      { images: [{ pictureId: 'fresh-2', listId: 1 }], nextCursor: null },
+    );
+  });
+
+  it('(k) incoming cards without a pictureId pass the played-set filter', async () => {
+    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['played-1']));
+
+    await appendCardBatch({
+      cards: [{ listId: 9 }, { pictureId: 'fresh-1' }],
+      categoryKey: 'city',
+      language: 'fr',
+      scope: { kind: 'public' },
+    });
+
+    expect(updateImageList).toHaveBeenCalledWith([{ listId: 9 }, { pictureId: 'fresh-1' }], 'city', 'fr');
+  });
+
+  it('played-set read failure does not reject the append (cards pass through)', async () => {
+    AsyncStorage.getItem.mockRejectedValueOnce(new Error('played read failed'));
+
+    await expect(
+      appendCardBatch({
+        cards: [{ pictureId: 'fresh-1' }],
+        categoryKey: 'city',
+        language: 'fr',
+        scope: { kind: 'public' },
+      }),
+    ).resolves.toEqual([]);
+
+    expect(updateImageList).toHaveBeenCalledWith([{ pictureId: 'fresh-1' }], 'city', 'fr');
+  });
+});
+
+describe('batch return contracts (Fix 3)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    updateImageList.mockResolvedValue([]);
+    writeGroupFeedCache.mockResolvedValue(undefined);
+    readGroupFeedCache.mockResolvedValue(null);
+  });
+
+  it('(f) persistCardBatch writes and returns normalized cards (ids 1..n on a fresh deck, both scopes)', async () => {
+    await expect(persistCardBatch({
+      cards: [{ pictureId: 'a' }, { pictureId: 'b' }, { pictureId: 'c' }],
+      categoryKey: 'all',
+      language: 'fr',
+      scope: { kind: 'public' },
+    })).resolves.toEqual([
+      { pictureId: 'a', listId: 1 },
+      { pictureId: 'b', listId: 2 },
+      { pictureId: 'c', listId: 3 },
+    ]);
+    expect(storeImageList).toHaveBeenCalledWith([
+      { pictureId: 'a', listId: 1 },
+      { pictureId: 'b', listId: 2 },
+      { pictureId: 'c', listId: 3 },
+    ], 'all', 'fr');
+
+    await expect(persistCardBatch({
+      cards: [{ pictureId: 'p' }],
+      categoryKey: 'all',
+      categoryId: 'all',
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-3' },
+    })).resolves.toEqual([{ pictureId: 'p', listId: 1 }]);
+    expect(writeGroupFeedCache).toHaveBeenCalledWith(
+      'g-3',
+      { categoryId: undefined, language: 'fr' },
+      { images: [{ pictureId: 'p', listId: 1 }], nextCursor: null },
+    );
   });
 });
 
@@ -521,6 +742,134 @@ describe('fetchCardBatch', () => {
 
     expect(getImages).toHaveBeenCalledWith(
       null,
+      { token: 't' },
+      expect.objectContaining({ category_key: 'nature' }),
+    );
+  });
+});
+
+describe('fetchCardBatch head-replay detection (Fix 2a)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getLastImageUuid.mockResolvedValue(null);
+    getImages.mockResolvedValue({ isError: false, images: [] });
+  });
+
+  it('(a) real stored cursor + null override → getImages opts { persistCursor: false } (head replay must not rewind)', async () => {
+    getLastImageUuid.mockResolvedValue('real-cursor-uuid');
+
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+      pictureIdOverride: null,
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ category_key: 'nature' }),
+      { persistCursor: false },
+    );
+  });
+
+  it('(b) PUBLIC_FEED_END_CURSOR sentinel + null override → same head-replay opt-out', async () => {
+    getLastImageUuid.mockResolvedValue('__public_feed_end__');
+
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+      pictureIdOverride: null,
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ category_key: 'nature' }),
+      { persistCursor: false },
+    );
+  });
+
+  it('(c) PRIVATE_FEED_END_CURSOR sentinel + null override → same head-replay opt-out', async () => {
+    getLastImageUuid.mockResolvedValue('__private_feed_end__');
+
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+      pictureIdOverride: null,
+    });
+
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ category_key: 'nature' }),
+      { persistCursor: false },
+    );
+  });
+
+  it('(d) no stored cursor + null override → 3-arg call (initial fill persists the head tail as cursor)', async () => {
+    getLastImageUuid.mockResolvedValue(null);
+
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+      pictureIdOverride: null,
+    });
+
+    expect(getImages.mock.calls[0]).toHaveLength(3);
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ category_key: 'nature' }),
+    );
+  });
+
+  it('(e) sentinel + omitted override → 3-arg call (sentinel un-stick keeps persisting)', async () => {
+    getLastImageUuid.mockResolvedValue('__public_feed_end__');
+
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+      // pictureIdOverride intentionally omitted (cursor-mode sentinel coercion)
+    });
+
+    expect(getImages.mock.calls[0]).toHaveLength(3);
+    expect(getImages).toHaveBeenCalledWith(
+      null,
+      { token: 't' },
+      expect.objectContaining({ category_key: 'nature' }),
+    );
+  });
+
+  it('(f) explicit uuid override → 3-arg call even with a stored cursor (explicit-uuid fetch unchanged)', async () => {
+    getLastImageUuid.mockResolvedValue('real-cursor-uuid');
+
+    await fetchCardBatch({
+      categoryKey: 'nature',
+      categoryId: 'cat-nature',
+      language: 'fr',
+      scope: { kind: 'public' },
+      authContext: { token: 't' },
+      pictureIdOverride: 'explicit-uuid',
+    });
+
+    expect(getImages.mock.calls[0]).toHaveLength(3);
+    expect(getImages).toHaveBeenCalledWith(
+      'explicit-uuid',
       { token: 't' },
       expect.objectContaining({ category_key: 'nature' }),
     );

--- a/__tests__/cardPrefetcher.test.ts
+++ b/__tests__/cardPrefetcher.test.ts
@@ -218,7 +218,7 @@ describe('cardPrefetcher', () => {
     expect(appendMock).toHaveBeenCalledTimes(1);
   });
 
-  it('cold-starts the all-deck warm from the head when the persisted all deck is empty', async () => {
+  it('cold-starts the all-deck warm in cursor mode (no head override) when the persisted all deck is empty', async () => {
     remainingMock.mockResolvedValueOnce(0);
     fetchMock.mockImplementation(() => okResponse());
 
@@ -229,8 +229,19 @@ describe('cardPrefetcher', () => {
       language: 'fr',
       scope: { kind: 'public' },
       authContext: {},
-      pictureIdOverride: null,
     });
+  });
+
+  it("warm with an existing 'all' cursor fetches cursor-mode (pages forward, no head override)", async () => {
+    remainingMock.mockResolvedValueOnce(2);
+    fetchMock.mockImplementation(() => okResponse([{ listId: 100 }]));
+
+    await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+    const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+    expect(allCalls).toHaveLength(1);
+    expect(allCalls[0]![0]).not.toHaveProperty('pictureIdOverride');
+    expect(appendMock).toHaveBeenCalledWith(expect.objectContaining({ categoryKey: 'all' }));
   });
 
   it('does not warm when categoryKey === "all"', async () => {
@@ -602,7 +613,7 @@ describe('cardPrefetcher', () => {
       const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
       expect(categoryCalls).toHaveLength(1);
       expect(allCalls).toHaveLength(1);
-      expect(allCalls[0]![0]).toMatchObject({ categoryKey: 'all', language: 'fr', pictureIdOverride: null });
+      expect(allCalls[0]![0]).toMatchObject({ categoryKey: 'all', language: 'fr' });
 
       const allAppend = appendMock.mock.calls.find((c) => c[0]?.categoryKey === 'all');
       expect(allAppend).toBeDefined();

--- a/__tests__/cardPrefetcher.test.ts
+++ b/__tests__/cardPrefetcher.test.ts
@@ -7,11 +7,16 @@ jest.mock('../utils/storageDatum', () => ({
   normalizeListIds: jest.fn((cards) => cards),
   isCategoryExhausted: jest.fn().mockResolvedValue(false),
   markCategoryExhausted: jest.fn().mockResolvedValue(undefined),
+  updateImageList: jest.fn().mockResolvedValue([]),
+  clearExhaustedCategory: jest.fn().mockResolvedValue(undefined),
+  // Fix 2b: the real appendCardBatch (Fix 1 pin) filters played cards through
+  // this helper before dedup — passthrough keeps the pin's semantics.
+  filterPlayedCards: jest.fn((cards) => Promise.resolve(cards)),
 }));
 jest.mock('../utils/e2eMode', () => ({ isE2EMode: jest.fn(() => false) }));
 
 import { fetchCardBatch, appendCardBatch } from '../services/cardDeck';
-import { getRemainingDeckCount, normalizeListIds, isCategoryExhausted, markCategoryExhausted } from '../utils/storageDatum';
+import { getRemainingDeckCount, normalizeListIds, isCategoryExhausted, markCategoryExhausted, clearExhaustedCategory } from '../utils/storageDatum';
 import { isE2EMode } from '../utils/e2eMode';
 import {
   LOW_CARD_THRESHOLD,
@@ -29,6 +34,7 @@ const e2eMock = isE2EMode as jest.MockedFunction<typeof isE2EMode>;
 const normalizeMock = normalizeListIds as jest.MockedFunction<typeof normalizeListIds>;
 const isExhaustedMock = isCategoryExhausted as jest.MockedFunction<typeof isCategoryExhausted>;
 const markExhaustedMock = markCategoryExhausted as jest.MockedFunction<typeof markCategoryExhausted>;
+const clearExhaustedMock = clearExhaustedCategory as jest.MockedFunction<typeof clearExhaustedCategory>;
 
 const IMAGES = [{ listId: 1 }, { listId: 2 }, { listId: 3 }];
 
@@ -470,6 +476,19 @@ describe('cardPrefetcher', () => {
     await Promise.resolve();
 
     expect(markExhaustedMock).toHaveBeenCalledWith('city', 'fr', { kind: 'public' });
+  });
+
+  it('Fix 1 pin: prefetch that lands ≥1 card calls clearExhaustedCategory (via appendCardBatch)', async () => {
+    // Wire the REAL appendCardBatch behind the mocked cardDeck export so the
+    // prefetch → append chain exercises the marker clear end-to-end.
+    appendMock.mockImplementation(jest.requireActual('../services/cardDeck').appendCardBatch as never);
+    remainingMock.mockResolvedValue(2);
+
+    await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+    await Promise.resolve();
+
+    expect(appendMock).toHaveBeenCalledTimes(1);
+    expect(clearExhaustedMock).toHaveBeenCalledWith('city', 'fr', { kind: 'public' });
   });
 
   it('B1(e-CC4): isError (5xx) → markCategoryExhausted NOT called (transient blip must not poison cache)', async () => {

--- a/__tests__/cardPrefetcher.test.ts
+++ b/__tests__/cardPrefetcher.test.ts
@@ -12,12 +12,18 @@ jest.mock('../utils/storageDatum', () => ({
   // Fix 2b: the real appendCardBatch (Fix 1 pin) filters played cards through
   // this helper before dedup — passthrough keeps the pin's semantics.
   filterPlayedCards: jest.fn((cards) => Promise.resolve(cards)),
+  // Real key builder: the REAL appendCardBatch (Fix 1 pin) derives its
+  // withScopeLock key through this export — delegating keeps the exact
+  // `cardDeck:append:...` format instead of a divergent copy.
+  deckWriteLockKey: jest.requireActual('../utils/storageDatum').deckWriteLockKey,
 }));
 jest.mock('../utils/e2eMode', () => ({ isE2EMode: jest.fn(() => false) }));
 
 import { fetchCardBatch, appendCardBatch } from '../services/cardDeck';
 import { getRemainingDeckCount, normalizeListIds, isCategoryExhausted, markCategoryExhausted, clearExhaustedCategory } from '../utils/storageDatum';
 import { isE2EMode } from '../utils/e2eMode';
+
+const actualCardDeck = jest.requireActual('../services/cardDeck');
 import {
   LOW_CARD_THRESHOLD,
   TARGET_BATCH_SIZE,
@@ -35,6 +41,7 @@ const normalizeMock = normalizeListIds as jest.MockedFunction<typeof normalizeLi
 const isExhaustedMock = isCategoryExhausted as jest.MockedFunction<typeof isCategoryExhausted>;
 const markExhaustedMock = markCategoryExhausted as jest.MockedFunction<typeof markCategoryExhausted>;
 const clearExhaustedMock = clearExhaustedCategory as jest.MockedFunction<typeof clearExhaustedCategory>;
+let warnSpy: jest.SpyInstance;
 
 const IMAGES = [{ listId: 1 }, { listId: 2 }, { listId: 3 }];
 
@@ -46,12 +53,17 @@ describe('cardPrefetcher', () => {
   beforeEach(() => {
     __resetForTests();
     jest.clearAllMocks();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     e2eMock.mockReturnValue(false);
     remainingMock.mockResolvedValue(0);
     fetchMock.mockResolvedValue({ isError: false, images: IMAGES } as never);
-    appendMock.mockResolvedValue(null as never);
+    appendMock.mockResolvedValue([] as never);
     isExhaustedMock.mockResolvedValue(false);
     markExhaustedMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
   });
 
   it('exports LOW_CARD_THRESHOLD equal to 4 (refill at ≤3 remaining)', () => {
@@ -126,6 +138,21 @@ describe('cardPrefetcher', () => {
     ).resolves.toBeUndefined();
 
     expect(appendMock).not.toHaveBeenCalled();
+  });
+
+  it('warns on prefetch failure even when __DEV__ is false', async () => {
+    const priorDev = global.__DEV__;
+    global.__DEV__ = false;
+    remainingMock.mockResolvedValue(2);
+    fetchMock.mockRejectedValue(new Error('network down') as never);
+
+    try {
+      await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+      expect(console.warn).toHaveBeenCalledWith('[cardPrefetcher] prefetch failed', expect.any(String), expect.any(Error));
+    } finally {
+      global.__DEV__ = priorDev;
+    }
   });
 
   it('dedups concurrent calls for the same deck key (one fetchCardBatch total)', async () => {
@@ -286,6 +313,20 @@ describe('cardPrefetcher', () => {
     const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
     expect(allCalls).toHaveLength(2);
     expect(appendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns on warm-all failure even when __DEV__ is false', async () => {
+    const priorDev = global.__DEV__;
+    global.__DEV__ = false;
+    fetchMock.mockImplementation(() => Promise.reject(new Error('net down') as never));
+
+    try {
+      await warmAllDeckIfNeeded({ language: 'fr', scope: { kind: 'public' }, authContext: {} });
+
+      expect(console.warn).toHaveBeenCalledWith('[cardPrefetcher] warm-all failed', expect.any(String), expect.any(Error));
+    } finally {
+      global.__DEV__ = priorDev;
+    }
   });
 
   it('warm-all is awaitable and shares in-flight promise across concurrent callers', async () => {
@@ -478,16 +519,24 @@ describe('cardPrefetcher', () => {
     expect(markExhaustedMock).toHaveBeenCalledWith('city', 'fr', { kind: 'public' });
   });
 
-  it('Fix 1 pin: prefetch that lands ≥1 card calls clearExhaustedCategory (via appendCardBatch)', async () => {
-    // Wire the REAL appendCardBatch behind the mocked cardDeck export so the
-    // prefetch → append chain exercises the marker clear end-to-end.
-    appendMock.mockImplementation(jest.requireActual('../services/cardDeck').appendCardBatch as never);
+  it('Fix 1 pin: prefetch that lands ≥1 card calls clearExhaustedCategory (via real appendCardBatch)', async () => {
+    // Bridge through the REAL appendCardBatch (storageDatum stays mocked at
+    // the AsyncStorage boundary: updateImageList/filterPlayedCards/
+    // clearExhaustedCategory), so the pin proves the prefetch success path
+    // triggers the marker clear through the production append contract.
+    appendMock.mockImplementation((args?: { cards?: unknown[]; categoryKey?: string; categoryId?: unknown; language?: string | null; scope?: unknown }) =>
+      actualCardDeck.appendCardBatch(args));
     remainingMock.mockResolvedValue(2);
 
     await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
     await Promise.resolve();
 
-    expect(appendMock).toHaveBeenCalledTimes(1);
+    expect(appendMock).toHaveBeenCalledWith(expect.objectContaining({
+      categoryKey: 'city',
+      categoryId: 7,
+      language: 'fr',
+      scope: { kind: 'public' },
+    }));
     expect(clearExhaustedMock).toHaveBeenCalledWith('city', 'fr', { kind: 'public' });
   });
 
@@ -535,5 +584,51 @@ describe('cardPrefetcher', () => {
 
     const allCallsBranch2 = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
     expect(allCallsBranch2).toHaveLength(0);
+  });
+
+  // characterization: pins I3, existing behavior cardPrefetcher.ts:202-205
+  describe('proactive handoff (I3)', () => {
+    it("prefetchIfLow with category remaining 3 (below LOW_CARD_THRESHOLD=4) warms the 'all' deck in the same cycle (proactive handoff I3)", async () => {
+      remainingMock.mockResolvedValueOnce(3).mockResolvedValueOnce(0);
+      fetchMock.mockImplementation((params) =>
+        okResponse((params as { categoryKey: string }).categoryKey === 'all' ? [{ listId: 100 }] : [{ listId: 1 }]),
+      );
+
+      await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const categoryCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'city');
+      const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+      expect(categoryCalls).toHaveLength(1);
+      expect(allCalls).toHaveLength(1);
+      expect(allCalls[0]![0]).toMatchObject({ categoryKey: 'all', language: 'fr', pictureIdOverride: null });
+
+      const allAppend = appendMock.mock.calls.find((c) => c[0]?.categoryKey === 'all');
+      expect(allAppend).toBeDefined();
+      expect(allAppend![0]).toMatchObject({ cards: [{ listId: 100 }], categoryKey: 'all' });
+    });
+
+    it("exhausted-marker skip path still tops the deck up from 'all' (no empty handoff)", async () => {
+      isExhaustedMock.mockResolvedValue(true);
+      remainingMock.mockResolvedValueOnce(3).mockResolvedValueOnce(0);
+      fetchMock.mockImplementation((params) =>
+        okResponse((params as { categoryKey: string }).categoryKey === 'all' ? [{ listId: 100 }, { listId: 101 }] : []),
+      );
+
+      await prefetchIfLow({ categoryKey: 'city', categoryId: 7, language: 'fr', scope: { kind: 'public' }, authContext: {} });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(isExhaustedMock).toHaveBeenCalledWith('city', 'fr', { kind: 'public' });
+      const categoryCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'city');
+      const allCalls = fetchMock.mock.calls.filter((c) => c[0]?.categoryKey === 'all');
+      expect(categoryCalls).toHaveLength(0);
+      expect(allCalls).toHaveLength(1);
+
+      const allAppend = appendMock.mock.calls.find((c) => c[0]?.categoryKey === 'all');
+      expect(allAppend).toBeDefined();
+      expect(allAppend![0]).toMatchObject({ cards: [{ listId: 100 }, { listId: 101 }], categoryKey: 'all' });
+    });
   });
 });

--- a/__tests__/flushLifecycle.test.js
+++ b/__tests__/flushLifecycle.test.js
@@ -109,6 +109,7 @@ jest.mock('../utils/storageDatum', () => ({
   saveSessionLanguageFilter: jest.fn(),
   emptyImageList: jest.fn().mockResolvedValue(undefined),
   getNextImagesForScope: jest.fn().mockResolvedValue([]),
+  wipePublicGuessStorage: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../utils/guessNavigation', () => ({

--- a/__tests__/handleGuessOutcome.test.js
+++ b/__tests__/handleGuessOutcome.test.js
@@ -1,15 +1,18 @@
 import { applySuccessSideEffects } from '../utils/handleGuessOutcome';
 import { bufferScore, mintGuessId } from '../utils/sessionScoreStore';
-import { addPlayedPictureId, removeImageFromList, deleteImageFromStorage } from '../utils/storageDatum';
+import { removeImageFromList, deleteImageFromStorage } from '../utils/storageDatum';
+import { addPlayedPictureId } from '../utils/playedPictureIds';
 
 jest.mock('../utils/sessionScoreStore', () => ({
   bufferScore: jest.fn(),
   mintGuessId: jest.fn(() => 'id-1'),
 }));
 jest.mock('../utils/storageDatum', () => ({
-  addPlayedPictureId: jest.fn(() => Promise.resolve()),
   removeImageFromList: jest.fn().mockResolvedValue(),
   deleteImageFromStorage: jest.fn().mockResolvedValue(),
+}));
+jest.mock('../utils/playedPictureIds', () => ({
+  addPlayedPictureId: jest.fn(() => Promise.resolve()),
 }));
 jest.mock('../utils/nextCardResolver', () => ({ resolveNextCard: jest.fn() }));
 

--- a/__tests__/handleGuessOutcome.test.js
+++ b/__tests__/handleGuessOutcome.test.js
@@ -1,12 +1,13 @@
 import { applySuccessSideEffects } from '../utils/handleGuessOutcome';
 import { bufferScore, mintGuessId } from '../utils/sessionScoreStore';
-import { removeImageFromList, deleteImageFromStorage } from '../utils/storageDatum';
+import { addPlayedPictureId, removeImageFromList, deleteImageFromStorage } from '../utils/storageDatum';
 
 jest.mock('../utils/sessionScoreStore', () => ({
   bufferScore: jest.fn(),
   mintGuessId: jest.fn(() => 'id-1'),
 }));
 jest.mock('../utils/storageDatum', () => ({
+  addPlayedPictureId: jest.fn(() => Promise.resolve()),
   removeImageFromList: jest.fn().mockResolvedValue(),
   deleteImageFromStorage: jest.fn().mockResolvedValue(),
 }));
@@ -82,5 +83,15 @@ describe('applySuccessSideEffects', () => {
     const arg = bufferScore.mock.calls[0][0];
     expect(arg).toEqual(expect.objectContaining({ streak: 5 }));
     expect('streakMultiplier' in arg).toBe(false);
+  });
+
+  it('(l) win records the played pictureId in the played-set (fire-and-forget, failure kept silent)', async () => {
+    addPlayedPictureId.mockRejectedValueOnce(new Error('played write failed'));
+
+    await expect(applySuccessSideEffects(baseArgs)).resolves.toBeUndefined();
+
+    expect(addPlayedPictureId).toHaveBeenCalledWith('pic-1', 'en', { kind: 'public' });
+    expect(removeImageFromList).toHaveBeenCalledWith('list-1', 'animals', 'en');
+    expect(deleteImageFromStorage).toHaveBeenCalledWith('file:///img.png');
   });
 });

--- a/__tests__/imagesRequests.test.js
+++ b/__tests__/imagesRequests.test.js
@@ -645,7 +645,7 @@ describe('imagesRequests utilities', () => {
     );
     expect(response.isError).toBe(false);
     expect(saveLastImageUuid).toHaveBeenCalledTimes(1);
-    expect(saveLastImageUuid).toHaveBeenCalledWith('cursor-9', 'cat-private-uuid', 'fr');
+    expect(saveLastImageUuid).toHaveBeenCalledWith('cursor-9', 'cat-private-uuid', 'fr', { kind: 'private', groupId: 'g-3' });
   });
 
   it('leaves the request unchanged when no filters are provided (legacy full feed)', async () => {

--- a/__tests__/imagesRequests.test.js
+++ b/__tests__/imagesRequests.test.js
@@ -456,6 +456,57 @@ describe('imagesRequests utilities', () => {
     expect(saveLastImageUuid).toHaveBeenNthCalledWith(2, 'playable-img', undefined, undefined);
   });
 
+  it('Fix 2a (g): persistCursor:false skips saveLastImageUuid on a successful batch', async () => {
+    axios.get
+      .mockResolvedValueOnce(batchResponse(['img-1']))
+      .mockResolvedValueOnce({ data: 'data:image/png;base64,abc123' });
+
+    const response = await getImages(null, { token: 'Bearer token' }, {}, { persistCursor: false });
+
+    expect(response.isError).toBe(false);
+    expect(response.images.map((image) => image.pictureId)).toEqual(['img-1']);
+    expect(saveLastImageUuid).not.toHaveBeenCalled();
+  });
+
+  it('Fix 2a (h): persistCursor:false skips the broken-batch cursor advance (loop semantics unchanged)', async () => {
+    axios.get
+      .mockResolvedValueOnce(batchResponse(['not-base64-img']))
+      .mockResolvedValueOnce({ data: 'not-base64' })
+      .mockResolvedValueOnce({ data: 'data:image/png;base64,next123' });
+    axios.post.mockResolvedValueOnce(batchResponse(['playable-img']));
+
+    const response = await getImages(null, { token: 'Bearer token' }, {}, { persistCursor: false });
+
+    expect(response.isError).toBe(false);
+    expect(response.images.map((image) => image.pictureId)).toEqual(['playable-img']);
+    // Broken batch still skipped (POST fired, loop continued) — but no cursor
+    // write at EITHER site (broken-batch advance and success).
+    expect(axios.post).toHaveBeenCalledTimes(1);
+    expect(saveLastImageUuid).not.toHaveBeenCalled();
+  });
+
+  it('Fix 2a: private scope forwards persistCursor:false so the private path also skips the cursor save', async () => {
+    axios.get
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { images: [{ id: 'img-1', name: 'img-1' }], next_cursor: 'cursor-9' },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { data: { url: 'https://backend.example/storage/img-1' } },
+      })
+      .mockResolvedValueOnce({ data: 'data:image/png;base64,Z29vZGJ5ZQ==' });
+
+    const response = await getImages(null, { token: 'Bearer token' }, {
+      category_id: 'cat-private-uuid',
+      language: 'fr',
+      scope: { kind: 'private', groupId: 'g-3' },
+    }, { persistCursor: false });
+
+    expect(response.isError).toBe(false);
+    expect(saveLastImageUuid).not.toHaveBeenCalled();
+  });
+
   it('threads category and language filters into the initial image batch query params', async () => {
     axios.get.mockResolvedValueOnce({ data: { data: [] } });
 

--- a/__tests__/languageDefaults.test.js
+++ b/__tests__/languageDefaults.test.js
@@ -51,3 +51,29 @@ describe('resolveDefaultLanguage', () => {
     expect(source).not.toMatch(/react-native-localize/);
   });
 });
+
+describe('guess screens language namespace', () => {
+  function readStringConstant(relativePath, name) {
+    const sourcePath = resolve(__dirname, '..', ...relativePath.split('/'));
+    const source = readFileSync(sourcePath, 'utf8');
+    const match = source.match(new RegExp(`const\\s+${name}\\s*=\\s*'([^']+)'`));
+
+    expect(match).toBeDefined();
+    return match[1];
+  }
+
+  it("feed-screen default language === path-screen navigation fallback ('any')", () => {
+    const feedDefault = readStringConstant(
+      'screens/GuessScreens/GuessFeedScreen.js',
+      'DEFAULT_LANGUAGE'
+    );
+    const pathFallback = readStringConstant(
+      'screens/GuessScreens/GuessPathScreen.js',
+      'NAVIGATION_ANY_LANGUAGE'
+    );
+
+    expect(feedDefault).toBe('any');
+    expect(pathFallback).toBe('any');
+    expect(feedDefault).toBe(pathFallback);
+  });
+});

--- a/__tests__/nextCardAdvancer.test.ts
+++ b/__tests__/nextCardAdvancer.test.ts
@@ -36,6 +36,15 @@ jest.mock('../utils/storageDatum', () => {
       actual.clearExhaustedCategory(categoryKey, language, scope)),
   };
 });
+// B1 (card-serving-cycle Task B): Tier-4 cycle transition needs a controlled
+// startNewServingCycle. The requireActual spread is MANDATORY — the real
+// module must stay available (isCycleExhausted and other exports are imported
+// here or by later suites).
+jest.mock('../utils/servingCycle', () => ({
+  ...jest.requireActual('../utils/servingCycle'),
+  startNewServingCycle: jest.fn(() => Promise.resolve(1)),
+}));
+
 jest.mock('../utils/e2eMode', () => ({ isE2EMode: jest.fn(() => false) }));
 // PB4 (T2.7): use the REAL prefetchIfLow (with its inFlight Map) so the
 // prefetch/foreground dedup is exercisable. warmAllDeckIfNeeded stays mocked
@@ -54,6 +63,7 @@ import { getDeckCountForScope, getRemainingDeckCount, normalizeListIds, isCatego
 import { isE2EMode } from '../utils/e2eMode';
 import { warmAllDeckIfNeeded, prefetchIfLow, __resetForTests } from '../services/cardPrefetcher';
 import { resolveNextCardWithServerFallback } from '../utils/nextCardAdvancer';
+import { startNewServingCycle } from '../utils/servingCycle';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const resolveMock = resolveNextGuessParams as jest.MockedFunction<typeof resolveNextGuessParams>;
@@ -67,6 +77,7 @@ const normalizeMock = normalizeListIds as jest.MockedFunction<typeof normalizeLi
 const isExhaustedMock = isCategoryExhausted as jest.MockedFunction<typeof isCategoryExhausted>;
 const markExhaustedMock = markCategoryExhausted as jest.MockedFunction<typeof markCategoryExhausted>;
 const clearExhaustedMock = clearExhaustedCategory as jest.MockedFunction<typeof clearExhaustedCategory>;
+const startCycleMock = startNewServingCycle as jest.MockedFunction<typeof startNewServingCycle>;
 
 // jest.setup.js globally mocks AsyncStorage; cast to a typed mock view so
 // .mockResolvedValue / .mockImplementation are visible to TypeScript.
@@ -96,7 +107,7 @@ describe('resolveNextCardWithServerFallback', () => {
     __resetForTests();
     e2eMock.mockReturnValue(false);
     warmMock.mockResolvedValue(undefined as never);
-    appendMock.mockResolvedValue(null as never);
+    appendMock.mockResolvedValue([] as never);
     // Default: deck appears "full" to the prefetcher so prefetchIfLow no-ops
     // (returns before touching inFlight) for the existing Tier-2/3/4 tests.
     remainingMock.mockResolvedValue(100);
@@ -729,6 +740,222 @@ describe('resolveNextCardWithServerFallback', () => {
         const keys = await AsyncStorage.getAllKeys();
         expect(keys).not.toContain('groupFeedExhausted:groupA:city:fr');
       });
+    });
+  });
+
+  // ─── B1 (card-serving-cycle Task B) — Tier-4 epoch-gated cycle transition ─
+  //
+  // tier4.ok && post-Tier-4 resolve null is the ALL_EXHAUSTED proof
+  // (≡ isCycleExhausted(tier4.appended, 0)): the server served ≥1 card but
+  // everything servable sits in the played-set. The advancer then
+  // startNewServingCycle(language, scope) — epoch bump + played-set/cursor/
+  // marker clear ONCE — re-resolves at the deck head (currentListId:
+  // undefined), and bounds itself to at most ONE extra head fetch per
+  // exhaustion. tier4.ok === false NEVER transitions (TRANSIENT_EMPTY /
+  // genuine empty unchanged).
+  describe('resolveNextCardWithServerFallback — B1: Tier-4 epoch-gated cycle transition', () => {
+    it('(a) Tier-4 cycle exhaustion calls startNewServingCycle exactly once with (language, scope)', async () => {
+      // category 'all': T1 local null, T2 recheck null, T2 cursor fetch empty,
+      // T4 head fetch ok, post-T4 resolve null → replay-exhaustion PROVED.
+      // Transition fires, the head-cursor LOCAL re-resolve is still null, ONE
+      // bounded head retry lands a card, the final head-cursor resolve serves it.
+      resolveMock
+        .mockResolvedValueOnce(null as never)            // Tier 1
+        .mockResolvedValueOnce(null as never)            // Tier 2 recheck
+        .mockResolvedValueOnce(null as never)            // after Tier 4 fetch+append
+        .mockResolvedValueOnce(null as never)            // head-cursor local re-resolve
+        .mockResolvedValueOnce(A_CARD_RESULT as never);  // after the bounded retry fetch
+      fetchMock
+        .mockResolvedValueOnce({ isError: false, images: [] } as never)                // Tier 2 (cursor)
+        .mockResolvedValueOnce({ isError: false, images: [{ listId: 1 }] } as never)   // Tier 4 (head)
+        .mockResolvedValueOnce({ isError: false, images: [{ listId: 1 }] } as never);  // bounded retry (head)
+
+      const result = await resolveNextCardWithServerFallback({ ...BASE_ARGS, category: { key: 'all' } });
+
+      expect(result.next).toEqual(A_CARD_RESULT);
+      expect(result.reason).toBe('ok');
+      expect(startCycleMock).toHaveBeenCalledTimes(1);
+      expect(startCycleMock).toHaveBeenCalledWith('fr', BASE_ARGS.scope);
+      // Tier-2 cursor fetch + Tier-4 head fetch + exactly ONE bounded retry.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(fetchMock).toHaveBeenNthCalledWith(3, expect.objectContaining({
+        categoryKey: 'all',
+        pictureIdOverride: null,
+      }));
+    });
+
+    it('(b) local head-cursor re-resolve success → startNewServingCycle called once, no extra fetch', async () => {
+      // The 'all' deck retains cards played in category namespaces (removal is
+      // per-namespace); once the new cycle clears the played-set they are
+      // servable again — the free local re-resolve wins with zero extra roundtrips.
+      resolveMock
+        .mockResolvedValueOnce(null as never)            // Tier 1
+        .mockResolvedValueOnce(null as never)            // Tier 2 recheck
+        .mockResolvedValueOnce(null as never)            // after Tier 4 fetch+append
+        .mockResolvedValueOnce(A_CARD_RESULT as never);  // FREE head-cursor local re-resolve
+      fetchMock
+        .mockResolvedValueOnce({ isError: false, images: [] } as never)                // Tier 2
+        .mockResolvedValueOnce({ isError: false, images: [{ listId: 1 }] } as never);  // Tier 4 head
+
+      const result = await resolveNextCardWithServerFallback({ ...BASE_ARGS, category: { key: 'all' } });
+
+      expect(result.next).toEqual(A_CARD_RESULT);
+      expect(result.reason).toBe('ok');
+      expect(startCycleMock).toHaveBeenCalledTimes(1);
+      // 'all' head fetch count stays 1 — the retained-card case costs zero extra fetches.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('(c) head-cursor pin: currentListId ≥ fresh deck max still serves the deck head after the transition', async () => {
+      // Cursor semantics: the resolver only serves listId > currentListId. The
+      // fresh replay deck renumbers 1..N, so with currentListId=999 EVERY cursor
+      // resolve is null — only a head-cursor (currentListId: undefined) resolve
+      // can surface the deck head. Stale cursor args would re-dead-end here.
+      try {
+        resolveMock.mockImplementation((args?: { currentListId?: number }) =>
+          args?.currentListId === undefined
+            ? Promise.resolve(A_CARD_RESULT as never)
+            : Promise.resolve(null as never));
+        fetchMock
+          .mockResolvedValueOnce({ isError: false, images: [] } as never)                // Tier 2
+          .mockResolvedValueOnce({ isError: false, images: [{ listId: 1 }] } as never);  // Tier 4 head
+
+        const result = await resolveNextCardWithServerFallback({
+          ...BASE_ARGS,
+          category: { key: 'all' },
+          currentListId: 999,
+        });
+
+        expect(result.next).toEqual(A_CARD_RESULT);
+        expect(result.reason).toBe('ok');
+        expect(startCycleMock).toHaveBeenCalledTimes(1);
+        // The post-transition resolve dropped the stale cursor (head-cursor args).
+        const lastResolveArgs = resolveMock.mock.calls[resolveMock.mock.calls.length - 1][0] as { currentListId?: number };
+        expect(lastResolveArgs.currentListId).toBeUndefined();
+      } finally {
+        // The args-sensitive implementation must not leak into other tests.
+        resolveMock.mockReset();
+      }
+    });
+
+    it('(d) Tier-4 fetch empty → NO startNewServingCycle, { next: null, reason: "empty" }', async () => {
+      resolveMock.mockResolvedValue(null as never);
+      fetchMock.mockResolvedValue({ isError: false, images: [] } as never);
+
+      const result = await resolveNextCardWithServerFallback({ ...BASE_ARGS, category: { key: 'all' } });
+
+      expect(result.next).toBeNull();
+      expect(result.reason).toBe('empty');
+      expect(startCycleMock).not.toHaveBeenCalled();
+      // Tier-2 cursor fetch + Tier-4 head fetch, both empty — no retry (nothing proved).
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('(e) Tier-4 network/server failure → NO startNewServingCycle (failure flow unchanged)', async () => {
+      // TRANSIENT_EMPTY (network) and server-class failure NEVER mutate cycle
+      // state (I7) — surface the typed reason only.
+      resolveMock.mockResolvedValue(null as never);
+      fetchMock.mockResolvedValue({ isError: true, reason: 'network' } as never);
+
+      const networkResult = await resolveNextCardWithServerFallback({ ...BASE_ARGS, category: { key: 'all' } });
+
+      expect(networkResult.next).toBeNull();
+      expect(networkResult.reason).toBe('network');
+
+      resolveMock.mockReset();
+      resolveMock.mockResolvedValue(null as never);
+      fetchMock.mockReset();
+      fetchMock.mockResolvedValue({ isError: true } as never);
+
+      const serverResult = await resolveNextCardWithServerFallback({ ...BASE_ARGS, category: { key: 'all' } });
+
+      expect(serverResult.next).toBeNull();
+      expect(serverResult.reason).toBe('server');
+      expect(startCycleMock).not.toHaveBeenCalled();
+    });
+
+    it('(f) retry fetch empty → exactly one transition, no second retry', async () => {
+      resolveMock.mockResolvedValue(null as never);
+      fetchMock
+        .mockResolvedValueOnce({ isError: false, images: [] } as never)                // Tier 2
+        .mockResolvedValueOnce({ isError: false, images: [{ listId: 1 }] } as never)   // Tier 4 head
+        .mockResolvedValueOnce({ isError: false, images: [] } as never);               // bounded retry: empty
+
+      const result = await resolveNextCardWithServerFallback({ ...BASE_ARGS, category: { key: 'all' } });
+
+      expect(result.next).toBeNull();
+      expect(result.reason).toBe('empty');
+      expect(startCycleMock).toHaveBeenCalledTimes(1);
+      // Bound: Tier-2 + Tier-4 + exactly ONE retry — never a second.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('(g) private scope → startNewServingCycle receives the group scope', async () => {
+      resolveMock
+        .mockResolvedValueOnce(null as never)            // Tier 1
+        .mockResolvedValueOnce(null as never)            // Tier 2 recheck
+        .mockResolvedValueOnce(null as never)            // after Tier 4 fetch+append
+        .mockResolvedValueOnce(A_CARD_RESULT as never);  // head-cursor local re-resolve
+      fetchMock
+        .mockResolvedValueOnce({ isError: false, images: [] } as never)                // Tier 2
+        .mockResolvedValueOnce({ isError: false, images: [{ listId: 1 }] } as never);  // Tier 4 head
+
+      const privateScope = { kind: 'private', groupId: 'g-1' };
+      const result = await resolveNextCardWithServerFallback({
+        ...BASE_ARGS,
+        category: { key: 'all' },
+        scope: privateScope,
+      });
+
+      expect(result.reason).toBe('ok');
+      expect(startCycleMock).toHaveBeenCalledTimes(1);
+      expect(startCycleMock).toHaveBeenCalledWith('fr', privateScope);
+    });
+
+    it('(h) Tier-1/2/3 SUCCESS → startNewServingCycle NOT called (transition confined to Tier-4 exhaustion)', async () => {
+      // Tier 1 success: local deck serves immediately.
+      resolveMock.mockReset();
+      resolveMock.mockResolvedValueOnce(A_CARD_RESULT as never);
+      fetchMock.mockResolvedValue({ isError: false, images: [{ listId: 9 }] } as never);
+      await resolveNextCardWithServerFallback(BASE_ARGS);
+
+      // Tier 2 success: foreground fetch + append, retried resolve serves.
+      resolveMock.mockReset();
+      resolveMock
+        .mockResolvedValueOnce(null as never)            // Tier 1
+        .mockResolvedValueOnce(null as never)            // Tier 2 recheck
+        .mockResolvedValueOnce(A_CARD_RESULT as never);  // after Tier 2 fetch+append
+      await resolveNextCardWithServerFallback(BASE_ARGS);
+
+      // Tier 3 success: warmed 'all' cross-fallback serves.
+      resolveMock.mockReset();
+      resolveMock
+        .mockResolvedValueOnce(null as never)            // Tier 1
+        .mockResolvedValueOnce(null as never)            // Tier 2 recheck
+        .mockResolvedValueOnce(A_CARD_RESULT as never);  // Tier 3 warmed 'all'
+      fetchMock.mockReset();
+      fetchMock.mockResolvedValue({ isError: false, images: [] } as never);
+      await resolveNextCardWithServerFallback(BASE_ARGS);
+
+      expect(startCycleMock).not.toHaveBeenCalled();
+    });
+
+    it('(i) startNewServingCycle rejection swallowed (mock rejects) → typed result, no unhandled rejection', async () => {
+      startCycleMock.mockRejectedValueOnce(new Error('storage boom') as never);
+      resolveMock
+        .mockResolvedValueOnce(null as never)            // Tier 1
+        .mockResolvedValueOnce(null as never)            // Tier 2 recheck
+        .mockResolvedValueOnce(null as never)            // after Tier 4 fetch+append
+        .mockResolvedValueOnce(A_CARD_RESULT as never);  // head-cursor re-resolve still runs post-swallow
+      fetchMock
+        .mockResolvedValueOnce({ isError: false, images: [] } as never)                // Tier 2
+        .mockResolvedValueOnce({ isError: false, images: [{ listId: 1 }] } as never);  // Tier 4 head
+
+      const result = await resolveNextCardWithServerFallback({ ...BASE_ARGS, category: { key: 'all' } });
+
+      expect(result.next).toEqual(A_CARD_RESULT);
+      expect(result.reason).toBe('ok');
+      expect(startCycleMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/__tests__/nextCardAdvancer.test.ts
+++ b/__tests__/nextCardAdvancer.test.ts
@@ -32,6 +32,8 @@ jest.mock('../utils/storageDatum', () => {
     normalizeListIds: jest.fn((cards) => cards),
     isCategoryExhausted: jest.fn(),
     markCategoryExhausted: jest.fn(),
+    clearExhaustedCategory: jest.fn((categoryKey: string, language: string | null | undefined, scope: unknown) =>
+      actual.clearExhaustedCategory(categoryKey, language, scope)),
   };
 });
 jest.mock('../utils/e2eMode', () => ({ isE2EMode: jest.fn(() => false) }));
@@ -48,7 +50,7 @@ jest.mock('../services/cardPrefetcher', () => {
 
 import { resolveNextGuessParams } from '../utils/handleGuessOutcome';
 import { fetchCardBatch, appendCardBatch } from '../services/cardDeck';
-import { getDeckCountForScope, getRemainingDeckCount, normalizeListIds, isCategoryExhausted, markCategoryExhausted } from '../utils/storageDatum';
+import { getDeckCountForScope, getRemainingDeckCount, normalizeListIds, isCategoryExhausted, markCategoryExhausted, clearExhaustedCategory } from '../utils/storageDatum';
 import { isE2EMode } from '../utils/e2eMode';
 import { warmAllDeckIfNeeded, prefetchIfLow, __resetForTests } from '../services/cardPrefetcher';
 import { resolveNextCardWithServerFallback } from '../utils/nextCardAdvancer';
@@ -64,6 +66,7 @@ const e2eMock = isE2EMode as jest.MockedFunction<typeof isE2EMode>;
 const normalizeMock = normalizeListIds as jest.MockedFunction<typeof normalizeListIds>;
 const isExhaustedMock = isCategoryExhausted as jest.MockedFunction<typeof isCategoryExhausted>;
 const markExhaustedMock = markCategoryExhausted as jest.MockedFunction<typeof markCategoryExhausted>;
+const clearExhaustedMock = clearExhaustedCategory as jest.MockedFunction<typeof clearExhaustedCategory>;
 
 // jest.setup.js globally mocks AsyncStorage; cast to a typed mock view so
 // .mockResolvedValue / .mockImplementation are visible to TypeScript.
@@ -492,6 +495,31 @@ describe('resolveNextCardWithServerFallback', () => {
       expect(result.next).not.toBeNull();
       expect((result.next as { params: { pictureId?: string } }).params.pictureId).toBe('new-card');
     });
+  });
+
+  // ─── Fix 1 — exhausted-marker invalidation pin ───────────────────────────
+  //
+  // The marker write sites (cardPrefetcher markCategoryExhausted on empty
+  // prefetch, foregroundTopUp on empty Tier-2 fetch) are paired with a CLEAR
+  // in appendCardBatch/persistCardBatch whenever a non-empty batch lands.
+  // Wire the REAL appendCardBatch behind the mocked cardDeck export so the
+  // Tier-2 → append chain exercises the clear end-to-end.
+
+  it('Fix 1 pin: Tier-2 successful fetch (non-empty) clears the exhausted marker', async () => {
+    appendMock.mockImplementation(jest.requireActual('../services/cardDeck').appendCardBatch as never);
+    mockAsyncStorage.setItem.mockResolvedValue(undefined);
+    mockAsyncStorage.getItem.mockResolvedValue(null);
+    resolveMock
+      .mockResolvedValueOnce(null as never)            // Tier 1 local empty
+      .mockResolvedValueOnce(null as never)            // Tier 2 recheck (prefetch no-op)
+      .mockResolvedValueOnce(A_CARD_RESULT as never);  // after Tier 2 fetch + append
+    fetchMock.mockResolvedValue({ isError: false, images: [{ listId: 9, pictureId: 'fresh-1' }] } as never);
+
+    const result = await resolveNextCardWithServerFallback(BASE_ARGS);
+
+    expect(result.reason).toBe('ok');
+    expect(appendMock).toHaveBeenCalledTimes(1);
+    expect(clearExhaustedMock).toHaveBeenCalledWith('city', 'fr', BASE_ARGS.scope);
   });
 
   // ─── F3a — exhausted-category cache (Tier 2 short-circuit) ──────────────

--- a/__tests__/nextCardAdvancer.test.ts
+++ b/__tests__/nextCardAdvancer.test.ts
@@ -1,9 +1,14 @@
 jest.mock('../utils/handleGuessOutcome', () => ({
   resolveNextGuessParams: jest.fn(),
 }));
+// Step 3 (Bug 1): probeAllPoolForUnplayed is mocked per-test (default
+// 'exhausted' in beforeEach); requireActual-spread keeps the real module's
+// constants and helpers available to transitively loaded code.
 jest.mock('../services/cardDeck', () => ({
+  ...jest.requireActual('../services/cardDeck'),
   fetchCardBatch: jest.fn(),
   appendCardBatch: jest.fn(),
+  probeAllPoolForUnplayed: jest.fn(),
 }));
 
 let mockFileExists = true;
@@ -58,7 +63,7 @@ jest.mock('../services/cardPrefetcher', () => {
 });
 
 import { resolveNextGuessParams } from '../utils/handleGuessOutcome';
-import { fetchCardBatch, appendCardBatch } from '../services/cardDeck';
+import { fetchCardBatch, appendCardBatch, probeAllPoolForUnplayed } from '../services/cardDeck';
 import { getDeckCountForScope, getRemainingDeckCount, normalizeListIds, isCategoryExhausted, markCategoryExhausted, clearExhaustedCategory } from '../utils/storageDatum';
 import { isE2EMode } from '../utils/e2eMode';
 import { warmAllDeckIfNeeded, prefetchIfLow, __resetForTests } from '../services/cardPrefetcher';
@@ -69,6 +74,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 const resolveMock = resolveNextGuessParams as jest.MockedFunction<typeof resolveNextGuessParams>;
 const fetchMock = fetchCardBatch as jest.MockedFunction<typeof fetchCardBatch>;
 const appendMock = appendCardBatch as jest.MockedFunction<typeof appendCardBatch>;
+const probeMock = probeAllPoolForUnplayed as jest.MockedFunction<typeof probeAllPoolForUnplayed>;
 const warmMock = warmAllDeckIfNeeded as jest.MockedFunction<typeof warmAllDeckIfNeeded>;
 const countMock = getDeckCountForScope as jest.MockedFunction<typeof getDeckCountForScope>;
 const remainingMock = getRemainingDeckCount as jest.MockedFunction<typeof getRemainingDeckCount>;
@@ -115,6 +121,10 @@ describe('resolveNextCardWithServerFallback', () => {
     // F3a defaults: cache miss (don't short-circuit) + write resolves silently.
     isExhaustedMock.mockResolvedValue(false);
     markExhaustedMock.mockResolvedValue(undefined);
+    // Step 3 default: the probe drains the pool — the transition path stays
+    // the default for the pre-existing Tier-4 pins. Per-test overrides pin
+    // 'unplayed' / 'indeterminate'.
+    probeMock.mockResolvedValue({ status: 'exhausted' } as never);
   });
 
   it('returns the locally-resolved card without any server fetch when the deck has a next card', async () => {
@@ -745,14 +755,17 @@ describe('resolveNextCardWithServerFallback', () => {
 
   // ─── B1 (card-serving-cycle Task B) — Tier-4 epoch-gated cycle transition ─
   //
-  // tier4.ok && post-Tier-4 resolve null is the ALL_EXHAUSTED proof
-  // (≡ isCycleExhausted(tier4.appended, 0)): the server served ≥1 card but
-  // everything servable sits in the played-set. The advancer then
+  // Step 3 (Bug 1): tier4.ok && post-Tier-4 resolve null is NO LONGER the
+  // exhaustion proof — it only proves ONE played-filtered HEAD batch. The
+  // advancer probes the 'all' pool (probeAllPoolForUnplayed) first:
+  // 'exhausted' (probe drained the 'all' cursor chain to server-empty) gates
   // startNewServingCycle(language, scope) — epoch bump + played-set/cursor/
-  // marker clear ONCE — re-resolves at the deck head (currentListId:
-  // undefined), and bounds itself to at most ONE extra head fetch per
-  // exhaustion. tier4.ok === false NEVER transitions (TRANSIENT_EMPTY /
-  // genuine empty unchanged).
+  // marker clear ONCE — then re-resolves at the deck head (currentListId:
+  // undefined), bounded to at most ONE extra head fetch per exhaustion.
+  // 'unplayed' → free local re-resolve, NO transition (Bug 1 kill: rows 6+
+  // serve at the handoff). 'indeterminate' → NO transition, typed null (I7).
+  // tier4.ok === false NEVER probes (TRANSIENT_EMPTY / genuine empty
+  // unchanged).
   describe('resolveNextCardWithServerFallback — B1: Tier-4 epoch-gated cycle transition', () => {
     it('(a) Tier-4 cycle exhaustion calls startNewServingCycle exactly once with (language, scope)', async () => {
       // category 'all': T1 local null, T2 recheck null, T2 cursor fetch empty,
@@ -956,6 +969,84 @@ describe('resolveNextCardWithServerFallback', () => {
       expect(result.next).toEqual(A_CARD_RESULT);
       expect(result.reason).toBe('ok');
       expect(startCycleMock).toHaveBeenCalledTimes(1);
+    });
+
+    // ─── Step 3 (Bug 1) — probe-gated transition ───────────────────────────
+
+    it('(j) Tier-4 ok but probe "unplayed" → NO startNewServingCycle; the free local re-resolve serves the appended card (BUG 1 pin: rows 6+ serve at the handoff)', async () => {
+      // The Tier-4 HEAD batch (oldest 5 rows, all played) resolves to null —
+      // the OLD code treated that as pool exhaustion and wiped the played-set
+      // (validated category images re-served). The probe pages the cursor
+      // forward, lands an unplayed row 6+, and appends it: the free local
+      // re-resolve serves it with ZERO cycle mutation.
+      resolveMock
+        .mockResolvedValueOnce(null as never)            // Tier 1
+        .mockResolvedValueOnce(null as never)            // Tier 2 recheck
+        .mockResolvedValueOnce(null as never)            // after Tier 4 head fetch+append (head batch all played)
+        .mockResolvedValueOnce(A_CARD_RESULT as never);  // free local re-resolve after the probe appended row 6+
+      fetchMock
+        .mockResolvedValueOnce({ isError: false, images: [] } as never)                // Tier 2 (cursor)
+        .mockResolvedValueOnce({ isError: false, images: [{ listId: 1 }] } as never);  // Tier 4 (head)
+      probeMock.mockResolvedValue({ status: 'unplayed' } as never);
+
+      const result = await resolveNextCardWithServerFallback({
+        ...BASE_ARGS,
+        category: { key: 'all' },
+        currentPictureId: 'img-5',
+      });
+
+      expect(result.next).toEqual(A_CARD_RESULT);
+      expect(result.reason).toBe('ok');
+      expect(probeMock).toHaveBeenCalledTimes(1);
+      expect(startCycleMock).not.toHaveBeenCalled();
+      // Tier-2 cursor fetch + Tier-4 head fetch only — no transition, no
+      // bounded head retry (the probe's append made it unnecessary).
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('(k) probe "indeterminate" → NO transition, typed null result (I7)', async () => {
+      // Transient failure or probe cap must NEVER mutate cycle state — the
+      // advancer surfaces a typed null and the reason accumulator keeps the
+      // informative tier failures.
+      resolveMock.mockResolvedValue(null as never);
+      fetchMock
+        .mockResolvedValueOnce({ isError: false, images: [] } as never)                // Tier 2
+        .mockResolvedValueOnce({ isError: false, images: [{ listId: 1 }] } as never);  // Tier 4 head
+      probeMock.mockResolvedValue({ status: 'indeterminate', reason: 'probe-cap' } as never);
+
+      const result = await resolveNextCardWithServerFallback({ ...BASE_ARGS, category: { key: 'all' } });
+
+      expect(result.next).toBeNull();
+      expect(result.reason).toBe('empty');
+      expect(startCycleMock).not.toHaveBeenCalled();
+      // No bounded head retry — the indeterminate verdict stops Tier 4.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('(l) probe receives (language, scope, excludePictureId=currentPictureId)', async () => {
+      // The just-won card is not yet in the played-set at advance time, so the
+      // advancer must forward currentPictureId as the probe's exclusion.
+      resolveMock.mockResolvedValue(null as never);
+      fetchMock
+        .mockResolvedValueOnce({ isError: false, images: [] } as never)                // Tier 2
+        .mockResolvedValueOnce({ isError: false, images: [{ listId: 1 }] } as never);  // Tier 4 head
+      probeMock.mockResolvedValue({ status: 'exhausted' } as never);
+
+      const privateScope = { kind: 'private', groupId: 'g-1' };
+      await resolveNextCardWithServerFallback({
+        ...BASE_ARGS,
+        category: { key: 'all' },
+        scope: privateScope,
+        currentPictureId: 'just-won',
+      });
+
+      expect(probeMock).toHaveBeenCalledTimes(1);
+      expect(probeMock).toHaveBeenCalledWith({
+        language: 'fr',
+        scope: privateScope,
+        authContext: BASE_ARGS.authContext,
+        excludePictureId: 'just-won',
+      });
     });
   });
 });

--- a/__tests__/playedPictureIds.test.js
+++ b/__tests__/playedPictureIds.test.js
@@ -1,0 +1,283 @@
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  getAllKeys: jest.fn(),
+  multiRemove: jest.fn(),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  addPlayedPictureId,
+  filterPlayedCards,
+  getPlayedPictureIds,
+  playedPictureIdsKey,
+  resetPlayedPictureIdsForScope,
+} from '../utils/playedPictureIds';
+import { _debugLocksSize } from '../utils/scopeMutex';
+
+describe('playedPictureIds (Fix 2 module extraction)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AsyncStorage.setItem.mockResolvedValue(undefined);
+    AsyncStorage.removeItem.mockResolvedValue(undefined);
+    AsyncStorage.getAllKeys.mockResolvedValue([]);
+    AsyncStorage.multiRemove.mockResolvedValue(undefined);
+  });
+
+  it('(a) add/get roundtrip under scope-segmented keys with group isolation', async () => {
+    expect(playedPictureIdsKey('fr', { kind: 'public' })).toBe('playedPictureIds:public:fr');
+    expect(playedPictureIdsKey(undefined, null)).toBe('playedPictureIds:public:any');
+    expect(playedPictureIdsKey('fr', { kind: 'private', groupId: 'gA' })).toBe('playedPictureIds:group:gA:fr');
+
+    await addPlayedPictureId('pic-1', 'fr', { kind: 'public' });
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('playedPictureIds:public:fr', JSON.stringify(['pic-1']));
+
+    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['pic-1']));
+    expect(await getPlayedPictureIds('fr', { kind: 'public' })).toEqual(['pic-1']);
+
+    AsyncStorage.getItem.mockResolvedValueOnce(null);
+    expect(await getPlayedPictureIds('fr', { kind: 'private', groupId: 'gB' })).toEqual([]);
+    expect(AsyncStorage.getItem).toHaveBeenLastCalledWith('playedPictureIds:group:gB:fr');
+  });
+
+  it('(b) caps the set at 200 and evicts the oldest id on overflow', async () => {
+    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(
+      Array.from({ length: 200 }, (_, i) => `p-${i}`),
+    ));
+
+    await addPlayedPictureId('new-one', 'fr', null);
+
+    const written = JSON.parse(AsyncStorage.setItem.mock.calls[0][1]);
+    expect(written).toHaveLength(200);
+    expect(written[0]).toBe('p-1');
+    expect(written[written.length - 1]).toBe('new-one');
+  });
+
+  it('(b2) idempotent add does not rewrite the set (no cap churn)', async () => {
+    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['pic-1']));
+
+    await addPlayedPictureId('pic-1', 'fr', null);
+
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('(e) falsy pictureId is a no-op (no write)', async () => {
+    await addPlayedPictureId(undefined, 'fr', null);
+    await addPlayedPictureId(null, 'fr', null);
+    await addPlayedPictureId('', 'fr', null);
+
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('(e2) concurrent adds for the same scope serialize so both ids persist', async () => {
+    const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+    let store = JSON.stringify([]);
+    let releaseFirstWrite;
+    const firstWriteGate = new Promise((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    let firstWriteGated = false;
+
+    AsyncStorage.getItem.mockImplementation(async (key) => (key === 'playedPictureIds:public:fr' ? store : null));
+    AsyncStorage.setItem.mockImplementation(async (key, value) => {
+      if (key !== 'playedPictureIds:public:fr') {
+        return;
+      }
+      if (!firstWriteGated) {
+        firstWriteGated = true;
+        await firstWriteGate;
+      }
+      store = value;
+    });
+
+    const first = addPlayedPictureId('pic-1', 'fr', null);
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const second = addPlayedPictureId('pic-2', 'fr', null);
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(AsyncStorage.getItem.mock.calls.filter(([key]) => key === 'playedPictureIds:public:fr')).toHaveLength(1);
+
+    releaseFirstWrite();
+    await first;
+    await second;
+
+    expect(JSON.parse(store)).toEqual(['pic-1', 'pic-2']);
+  });
+
+  it('(c2) cross-key lock isolation: concurrent adds in different scopes do not serialize; no locks linger', async () => {
+    const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+    const stores = new Map([
+      ['playedPictureIds:public:fr', JSON.stringify([])],
+      ['playedPictureIds:group:gA:fr', JSON.stringify([])],
+    ]);
+    let releasePublicWrite;
+    const publicWriteGate = new Promise((resolve) => { releasePublicWrite = resolve; });
+
+    AsyncStorage.getItem.mockImplementation(async (key) => stores.get(key) ?? null);
+    AsyncStorage.setItem.mockImplementation(async (key, value) => {
+      if (key === 'playedPictureIds:public:fr') {
+        await publicWriteGate;
+      }
+      stores.set(key, value);
+    });
+
+    const publicAdd = addPlayedPictureId('pub-1', 'fr', null);
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const groupAdd = addPlayedPictureId('grp-1', 'fr', { kind: 'private', groupId: 'gA' });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    // Distinct played-set lock keys → the group RMW must NOT queue behind
+    // the gated public write: its read-modify-write already completed.
+    const groupWrites = AsyncStorage.setItem.mock.calls.filter(([key]) => key === 'playedPictureIds:group:gA:fr');
+    expect(groupWrites).toHaveLength(1);
+
+    releasePublicWrite();
+    await publicAdd;
+    await groupAdd;
+    await flushMicrotasks();
+
+    expect(JSON.parse(stores.get('playedPictureIds:public:fr'))).toEqual(['pub-1']);
+    expect(JSON.parse(stores.get('playedPictureIds:group:gA:fr'))).toEqual(['grp-1']);
+    expect(_debugLocksSize()).toBe(0);
+  });
+
+  it('(i) filterPlayedCards passes pictureId-less cards through', async () => {
+    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['a']));
+
+    const filtered = await filterPlayedCards([
+      { pictureId: 'a' },
+      { listId: 5 },
+      { pictureId: 'b' },
+    ], 'fr', null);
+
+    expect(filtered).toEqual([{ listId: 5 }, { pictureId: 'b' }]);
+  });
+
+  describe('resetPlayedPictureIdsForScope (Fix 1 replay-cycle restart)', () => {
+    it('reset clears the exact public key for the language', async () => {
+      const store = new Map([['playedPictureIds:public:fr', JSON.stringify(['pic-1'])]]);
+      AsyncStorage.getItem.mockImplementation(async (key) => store.get(key) ?? null);
+      AsyncStorage.removeItem.mockImplementation(async (key) => { store.delete(key); });
+
+      await resetPlayedPictureIdsForScope('fr', null);
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledTimes(1);
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('playedPictureIds:public:fr');
+      expect(store.has('playedPictureIds:public:fr')).toBe(false);
+    });
+
+    it('reset clears the exact group key and leaves the public key untouched (no bleed)', async () => {
+      const store = new Map([
+        ['playedPictureIds:group:gA:fr', JSON.stringify(['grp-1'])],
+        ['playedPictureIds:public:fr', JSON.stringify(['pub-1'])],
+      ]);
+      AsyncStorage.getItem.mockImplementation(async (key) => store.get(key) ?? null);
+      AsyncStorage.removeItem.mockImplementation(async (key) => { store.delete(key); });
+
+      await resetPlayedPictureIdsForScope('fr', { kind: 'private', groupId: 'gA' });
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledTimes(1);
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('playedPictureIds:group:gA:fr');
+      expect(store.has('playedPictureIds:group:gA:fr')).toBe(false);
+      expect(JSON.parse(store.get('playedPictureIds:public:fr'))).toEqual(['pub-1']);
+    });
+
+    it('reset is a no-op (no throw) when the key is missing', async () => {
+      AsyncStorage.getItem.mockImplementation(async () => null);
+
+      await expect(resetPlayedPictureIdsForScope('fr', null)).resolves.toBeUndefined();
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('playedPictureIds:public:fr');
+    });
+
+    it('RACE (add write gated): concurrent reset queues on the same lock key, then wipes the settled id', async () => {
+      const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+      let store = null;
+      let releaseAddWrite;
+      const addWriteGate = new Promise((resolve) => { releaseAddWrite = resolve; });
+      let addWriteGated = false;
+
+      AsyncStorage.getItem.mockImplementation(async () => store);
+      AsyncStorage.setItem.mockImplementation(async (key, value) => {
+        if (!addWriteGated) {
+          addWriteGated = true;
+          await addWriteGate;
+        }
+        store = value;
+      });
+      AsyncStorage.removeItem.mockImplementation(async () => { store = null; });
+
+      const add = addPlayedPictureId('pic-1', 'fr', null);
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      const reset = resetPlayedPictureIdsForScope('fr', null);
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      // The reset shares the add's lock key → its removeItem must wait for
+      // the in-flight write (without the shared lock it would fire now and
+      // the gated add write would resurrect the id afterwards).
+      expect(AsyncStorage.removeItem).not.toHaveBeenCalled();
+
+      releaseAddWrite();
+      await add;
+      await reset;
+      await flushMicrotasks();
+
+      // Deterministic lock-serialized outcome for this interleaving: the add
+      // settles first, then the reset removes the exact key → key absent.
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('playedPictureIds:public:fr');
+      expect(store).toBeNull();
+      expect(_debugLocksSize()).toBe(0);
+    });
+
+    it('RACE (reset gated): concurrent add queues on the same lock key, then re-lands only its own id', async () => {
+      const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+      let store = JSON.stringify(['stale-1']);
+      let releaseResetWrite;
+      const resetWriteGate = new Promise((resolve) => { releaseResetWrite = resolve; });
+      let resetWriteGated = false;
+
+      AsyncStorage.getItem.mockImplementation(async () => store);
+      AsyncStorage.removeItem.mockImplementation(async () => {
+        if (!resetWriteGated) {
+          resetWriteGated = true;
+          await resetWriteGate;
+        }
+        store = null;
+      });
+      AsyncStorage.setItem.mockImplementation(async (key, value) => { store = value; });
+
+      const reset = resetPlayedPictureIdsForScope('fr', null);
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      const add = addPlayedPictureId('pic-1', 'fr', null);
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      // The add shares the reset's lock key → its read-modify-write must
+      // wait (no stale read racing the pending removal).
+      expect(AsyncStorage.getItem.mock.calls.filter(([key]) => key === 'playedPictureIds:public:fr')).toHaveLength(0);
+
+      releaseResetWrite();
+      await reset;
+      await add;
+      await flushMicrotasks();
+
+      // Deterministic lock-serialized outcome for this interleaving: the
+      // reset settles first, then the serialized add re-reads post-reset and
+      // re-lands exactly its own id (the stale id is gone).
+      expect(JSON.parse(store)).toEqual(['pic-1']);
+      expect(_debugLocksSize()).toBe(0);
+    });
+  });
+});

--- a/__tests__/services/groupFeedApi.test.js
+++ b/__tests__/services/groupFeedApi.test.js
@@ -204,7 +204,23 @@ describe('services/groups/groupFeedApi', () => {
     });
 
     expect(saveLastImageUuid).toHaveBeenCalledTimes(1);
-    expect(saveLastImageUuid).toHaveBeenCalledWith('cursor-2', 'all', 'fr');
+    expect(saveLastImageUuid).toHaveBeenCalledWith('cursor-2', 'all', 'fr', { kind: 'private', groupId: 'g-3' });
+  });
+
+  it('empty private page persists the PRIVATE_FEED_END_CURSOR under the group scope (public cursor never poisoned)', async () => {
+    axios.get.mockResolvedValueOnce({
+      status: 200,
+      data: { images: [], next_cursor: null },
+    });
+
+    await fetchPrivateFeedPageForGame(null, CONTEXT, {
+      groupId: 'g-3',
+      categoryKey: 'all',
+      language: 'fr',
+    });
+
+    expect(saveLastImageUuid).toHaveBeenCalledTimes(1);
+    expect(saveLastImageUuid).toHaveBeenCalledWith('__private_feed_end__', 'all', 'fr', { kind: 'private', groupId: 'g-3' });
   });
 
   it('Fix 2a: exported PRIVATE_FEED_END_CURSOR sentinel value is stable', () => {

--- a/__tests__/services/groupFeedApi.test.js
+++ b/__tests__/services/groupFeedApi.test.js
@@ -48,7 +48,9 @@ jest.mock('../../utils/auth', () => ({
 
 import axios from 'axios';
 import { getBackendHeaders, setHeaders } from '../../utils/auth';
+import { saveLastImageUuid } from '../../utils/storageDatum';
 import {
+  PRIVATE_FEED_END_CURSOR,
   fetchPrivateFeedPage,
   fetchPrivateFeedPageForGame,
   downloadPrivateImage,
@@ -158,6 +160,55 @@ describe('services/groups/groupFeedApi', () => {
     expect(response.isError).toBe(false);
     expect(response.images).toHaveLength(1);
     expect(response.images[0].imageFile).toEqual(expect.stringContaining('img-1'));
+  });
+
+  it('Fix 2a (j): private success with persistCursor:false → no cursor save (head replay must not rewind)', async () => {
+    axios.get
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { images: [{ id: 'img-1', name: 'Waldo' }], next_cursor: 'cursor-2' },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { data: { url: 'https://backend.example/storage/img-1' } },
+      })
+      .mockResolvedValueOnce({ data: 'data:image/png;base64,Z29vG5ZQ==' });
+
+    const response = await fetchPrivateFeedPageForGame(null, CONTEXT, {
+      groupId: 'g-3',
+      categoryKey: 'all',
+      language: 'fr',
+      persistCursor: false,
+    });
+
+    expect(response.isError).toBe(false);
+    expect(saveLastImageUuid).not.toHaveBeenCalled();
+  });
+
+  it('Fix 2a (k): default (persistCursor true) saves the nextCursor on private success', async () => {
+    axios.get
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { images: [{ id: 'img-1', name: 'Waldo' }], next_cursor: 'cursor-2' },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { data: { url: 'https://backend.example/storage/img-1' } },
+      })
+      .mockResolvedValueOnce({ data: 'data:image/png;base64,Z29vG5ZQ==' });
+
+    await fetchPrivateFeedPageForGame(null, CONTEXT, {
+      groupId: 'g-3',
+      categoryKey: 'all',
+      language: 'fr',
+    });
+
+    expect(saveLastImageUuid).toHaveBeenCalledTimes(1);
+    expect(saveLastImageUuid).toHaveBeenCalledWith('cursor-2', 'all', 'fr');
+  });
+
+  it('Fix 2a: exported PRIVATE_FEED_END_CURSOR sentinel value is stable', () => {
+    expect(PRIVATE_FEED_END_CURSOR).toBe('__private_feed_end__');
   });
 
   it('downloadPrivateImage requests an S3 presigned URL as arraybuffer and returns a base64 data URL', async () => {

--- a/__tests__/servingCycle.test.ts
+++ b/__tests__/servingCycle.test.ts
@@ -1,0 +1,272 @@
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  getAllKeys: jest.fn(),
+  multiRemove: jest.fn(),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  SERVING_CYCLE_PREFIX,
+  getServingCycleEpoch,
+  isCycleExhausted,
+  resetServingCycles,
+  servingCycleKey,
+  startNewServingCycle,
+} from '../utils/servingCycle';
+import { addPlayedPictureId } from '../utils/playedPictureIds';
+import { _debugLocksSize } from '../utils/scopeMutex';
+
+// jest.mock factory above is untyped; cast to a typed mock view so
+// .mockImplementation / .mockResolvedValue are visible to TypeScript
+// (same pattern as __tests__/nextCardAdvancer.test.ts).
+const mockAsyncStorage = AsyncStorage as unknown as {
+  getItem: jest.MockedFunction<(key: string) => Promise<string | null>>;
+  setItem: jest.MockedFunction<(key: string, value: string) => Promise<void>>;
+  removeItem: jest.MockedFunction<(key: string) => Promise<void>>;
+  getAllKeys: jest.MockedFunction<() => Promise<readonly string[]>>;
+  multiRemove: jest.MockedFunction<(keys: readonly string[]) => Promise<void>>;
+};
+
+type Store = Map<string, string>;
+
+function mockStore(initial: Record<string, string> = {}): Store {
+  const store: Store = new Map(Object.entries(initial));
+  mockAsyncStorage.getItem.mockImplementation(async (key: string) => store.get(key) ?? null);
+  mockAsyncStorage.setItem.mockImplementation(async (key: string, value: string) => {
+    store.set(key, value);
+  });
+  mockAsyncStorage.removeItem.mockImplementation(async (key: string) => {
+    store.delete(key);
+  });
+  mockAsyncStorage.getAllKeys.mockImplementation(async () => Array.from(store.keys()));
+  mockAsyncStorage.multiRemove.mockImplementation(async (keys: readonly string[]) => {
+    keys.forEach((key) => store.delete(key));
+  });
+  return store;
+}
+
+const flushMicrotasks = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe('servingCycle (card-serving-cycle Task A1)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAsyncStorage.setItem.mockResolvedValue(undefined);
+    mockAsyncStorage.removeItem.mockResolvedValue(undefined);
+    mockAsyncStorage.getAllKeys.mockResolvedValue([]);
+    mockAsyncStorage.multiRemove.mockResolvedValue(undefined);
+  });
+
+  it('epoch defaults to 0 for a fresh scope', async () => {
+    mockStore();
+
+    expect(await getServingCycleEpoch('fr', null)).toBe(0);
+    expect(mockAsyncStorage.getItem).toHaveBeenCalledWith('servingCycle:public:fr');
+  });
+
+  it('startNewServingCycle increments and persists the epoch', async () => {
+    const store = mockStore();
+
+    expect(await startNewServingCycle('fr', null)).toBe(1);
+    expect(store.get('servingCycle:public:fr')).toBe('1');
+    expect(await getServingCycleEpoch('fr', null)).toBe(1);
+
+    expect(await startNewServingCycle('fr', null)).toBe(2);
+    expect(await getServingCycleEpoch('fr', null)).toBe(2);
+  });
+
+  it('epoch keys are isolated public vs group and per language', async () => {
+    expect(servingCycleKey('fr', null)).toBe('servingCycle:public:fr');
+    expect(servingCycleKey(undefined, undefined)).toBe('servingCycle:public:any');
+    expect(servingCycleKey('fr', { kind: 'private', groupId: 'gA' })).toBe('servingCycle:group:gA:fr');
+    expect(servingCycleKey('en', null)).not.toBe(servingCycleKey('fr', null));
+
+    const store = mockStore({ 'servingCycle:public:fr': '3' });
+
+    expect(await getServingCycleEpoch('fr', null)).toBe(3);
+    expect(await getServingCycleEpoch('en', null)).toBe(0);
+    expect(await getServingCycleEpoch('fr', { kind: 'private', groupId: 'gA' })).toBe(0);
+    expect(store.get('servingCycle:public:fr')).toBe('3');
+  });
+
+  it('startNewServingCycle clears the scope+language played-set', async () => {
+    const store = mockStore({ 'playedPictureIds:public:fr': JSON.stringify(['pic-1', 'pic-2']) });
+
+    await startNewServingCycle('fr', null);
+
+    expect(store.has('servingCycle:public:fr')).toBe(true);
+    expect(store.has('playedPictureIds:public:fr')).toBe(false);
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('playedPictureIds:public:fr');
+  });
+
+  it('startNewServingCycle clears only the target scope\'s played-set (no cross-group/public bleed)', async () => {
+    const store = mockStore({
+      'playedPictureIds:group:gA:fr': JSON.stringify(['grp-a']),
+      'playedPictureIds:group:gB:fr': JSON.stringify(['grp-b']),
+      'playedPictureIds:public:fr': JSON.stringify(['pub']),
+    });
+
+    await startNewServingCycle('fr', { kind: 'private', groupId: 'gA' });
+
+    expect(store.has('playedPictureIds:group:gA:fr')).toBe(false);
+    expect(JSON.parse(store.get('playedPictureIds:group:gB:fr') ?? '[]')).toEqual(['grp-b']);
+    expect(JSON.parse(store.get('playedPictureIds:public:fr') ?? '[]')).toEqual(['pub']);
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledTimes(1);
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('playedPictureIds:group:gA:fr');
+  });
+
+  it('concurrent startNewServingCycle serialize — epoch increments exactly twice, played-set absent', async () => {
+    const store = mockStore({ 'playedPictureIds:public:fr': JSON.stringify(['pic-1']) });
+
+    const first = startNewServingCycle('fr', null);
+    const second = startNewServingCycle('fr', null);
+    const epochs = [await first, await second];
+
+    expect(epochs.sort()).toEqual([1, 2]);
+    expect(await getServingCycleEpoch('fr', null)).toBe(2);
+    expect(store.get('servingCycle:public:fr')).toBe('2');
+    expect(store.has('playedPictureIds:public:fr')).toBe(false);
+    await flushMicrotasks();
+    expect(_debugLocksSize()).toBe(0);
+  });
+
+  it('resetServingCycles removes all servingCycle keys incl. group keys', async () => {
+    const store = mockStore({
+      'servingCycle:public:fr': '1',
+      'servingCycle:public:en': '4',
+      'servingCycle:group:gA:fr': '2',
+      'playedPictureIds:public:fr': JSON.stringify(['pic-1']),
+    });
+
+    await resetServingCycles();
+
+    expect(mockAsyncStorage.multiRemove).toHaveBeenCalledWith([
+      'servingCycle:public:fr',
+      'servingCycle:public:en',
+      'servingCycle:group:gA:fr',
+    ]);
+    expect(Array.from(store.keys()).every((key) => !key.startsWith(`${SERVING_CYCLE_PREFIX}:`))).toBe(true);
+    expect(store.has('playedPictureIds:public:fr')).toBe(true);
+  });
+
+  it('isCycleExhausted true only when server served >0 and servable === 0 (pure, table-driven)', () => {
+    expect(mockAsyncStorage.getItem).not.toHaveBeenCalled();
+
+    const cases: Array<[serverBatchCount: number, servableCount: number, expected: boolean]> = [
+      [5, 0, true],
+      [1, 0, true],
+      [0, 0, false],
+      [0, 3, false],
+      [5, 3, false],
+      [5, 1, false],
+    ];
+
+    cases.forEach(([serverBatchCount, servableCount, expected]) => {
+      expect(isCycleExhausted(serverBatchCount, servableCount)).toBe(expected);
+    });
+  });
+
+  it('startNewServingCycle removes lastImageUuid cursors (every category key + \'all\') for the scope+language', async () => {
+    const store = mockStore({
+      'lastImageUuid:interiors:fr': 'uuid-1',
+      'lastImageUuid:nature:fr': 'uuid-2',
+      'lastImageUuid:all:fr': '__public_feed_end__',
+      'lastImageUuid:interiors:en': 'uuid-en',
+    });
+
+    await startNewServingCycle('fr', null);
+
+    expect(store.has('lastImageUuid:interiors:fr')).toBe(false);
+    expect(store.has('lastImageUuid:nature:fr')).toBe(false);
+    expect(store.has('lastImageUuid:all:fr')).toBe(false);
+    expect(store.get('lastImageUuid:interiors:en')).toBe('uuid-en');
+  });
+
+  it('startNewServingCycle removes exhaustedCategory markers including \'all\'', async () => {
+    const store = mockStore({
+      'exhaustedCategory:interiors:fr': '1',
+      'exhaustedCategory:all:fr': '1',
+      'exhaustedCategory:interiors:en': '1',
+    });
+
+    await startNewServingCycle('fr', null);
+
+    expect(store.has('exhaustedCategory:interiors:fr')).toBe(false);
+    expect(store.has('exhaustedCategory:all:fr')).toBe(false);
+    expect(store.get('exhaustedCategory:interiors:en')).toBe('1');
+  });
+
+  it('group scope clears group :cursor + groupFeedExhausted, leaves public cursors alone', async () => {
+    const store = mockStore({
+      'groupFeed:gA:cat-uuid-1:fr:cursor': JSON.stringify({ nextCursor: 'cursor-1' }),
+      'groupFeed:gA:all:fr:cursor': JSON.stringify({ nextCursor: null }),
+      'groupFeed:gA:cat-uuid-1:fr': JSON.stringify([{ listId: 1 }]),
+      'groupFeed:gA:game:cat-uuid-1:fr:cursor': 'cursor-game-1',
+      'groupFeed:gA:game:all:fr:cursor': '__private_feed_end__',
+      'groupFeedExhausted:gA:cat-uuid-1:fr': '1',
+      'groupFeed:gB:cat-uuid-1:fr:cursor': JSON.stringify({ nextCursor: 'cursor-b' }),
+      'groupFeedExhausted:gB:cat-uuid-1:fr': '1',
+      'lastImageUuid:interiors:fr': 'public-cursor',
+      'exhaustedCategory:interiors:fr': '1',
+      'groupFeed:gA:cat-uuid-1:en:cursor': JSON.stringify({ nextCursor: 'cursor-en' }),
+    });
+
+    await startNewServingCycle('fr', { kind: 'private', groupId: 'gA' });
+
+    expect(store.has('groupFeed:gA:cat-uuid-1:fr:cursor')).toBe(false);
+    expect(store.has('groupFeed:gA:all:fr:cursor')).toBe(false);
+    // F1/F2 junction pin: the group-scoped GAME transport cursor keys match
+    // the clear pattern (groupFeed:<gid>:*:<lang>:cursor) so the transition
+    // wipes the live private cursor — no post-transition cursor-mode misses.
+    expect(store.has('groupFeed:gA:game:cat-uuid-1:fr:cursor')).toBe(false);
+    expect(store.has('groupFeed:gA:game:all:fr:cursor')).toBe(false);
+    expect(store.has('groupFeedExhausted:gA:cat-uuid-1:fr')).toBe(false);
+    expect(JSON.parse(store.get('groupFeed:gA:cat-uuid-1:fr') ?? '[]')).toEqual([{ listId: 1 }]);
+    expect(store.get('lastImageUuid:interiors:fr')).toBe('public-cursor');
+    expect(store.get('exhaustedCategory:interiors:fr')).toBe('1');
+    expect(store.get('groupFeed:gB:cat-uuid-1:fr:cursor')).toBe(JSON.stringify({ nextCursor: 'cursor-b' }));
+    expect(store.get('groupFeedExhausted:gB:cat-uuid-1:fr')).toBe('1');
+    expect(store.get('groupFeed:gA:cat-uuid-1:en:cursor')).toBe(JSON.stringify({ nextCursor: 'cursor-en' }));
+  });
+
+  it('public scope leaves group keys untouched (no bleed)', async () => {
+    const store = mockStore({
+      'lastImageUuid:interiors:fr': 'public-cursor',
+      'lastImageUuid:all:fr': '__public_feed_end__',
+      'groupFeed:gA:cat-uuid-1:fr:cursor': JSON.stringify({ nextCursor: 'cursor-1' }),
+      'groupFeed:gA:cat-uuid-1:fr': JSON.stringify([{ listId: 1 }]),
+      'groupFeed:gA:game:cat-uuid-1:fr:cursor': 'cursor-game-1',
+      'groupFeedExhausted:gA:cat-uuid-1:fr': '1',
+    });
+
+    await startNewServingCycle('fr', null);
+
+    expect(store.has('lastImageUuid:interiors:fr')).toBe(false);
+    expect(store.has('lastImageUuid:all:fr')).toBe(false);
+    // F1/F2: a public transition must never wipe the group-scoped private
+    // game cursor (pre-fix the private cursor lived at lastImageUuid:<uuid>
+    // and was over-broadly cleared by the public branch).
+    expect(store.get('groupFeed:gA:cat-uuid-1:fr:cursor')).toBe(JSON.stringify({ nextCursor: 'cursor-1' }));
+    expect(store.get('groupFeed:gA:game:cat-uuid-1:fr:cursor')).toBe('cursor-game-1');
+    expect(JSON.parse(store.get('groupFeed:gA:cat-uuid-1:fr') ?? '[]')).toEqual([{ listId: 1 }]);
+    expect(store.get('groupFeedExhausted:gA:cat-uuid-1:fr')).toBe('1');
+  });
+
+  it('locks released after each call (_debugLocksSize() === 0)', async () => {
+    mockStore();
+
+    await getServingCycleEpoch('fr', null);
+    expect(_debugLocksSize()).toBe(0);
+
+    await startNewServingCycle('fr', null);
+    expect(_debugLocksSize()).toBe(0);
+
+    await startNewServingCycle('fr', { kind: 'private', groupId: 'gA' });
+    expect(_debugLocksSize()).toBe(0);
+
+    await addPlayedPictureId('pic-1', 'fr', null);
+    await startNewServingCycle('fr', null);
+    expect(_debugLocksSize()).toBe(0);
+  });
+});

--- a/__tests__/storageDatum.test.js
+++ b/__tests__/storageDatum.test.js
@@ -6,22 +6,32 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   multiRemove: jest.fn(),
 }));
 
-jest.mock('../services/groups/groupFeedCache', () => ({
-  readGroupFeedCache: jest.fn(),
-  markGroupCategoryExhausted: jest.fn(),
-  isGroupCategoryExhausted: jest.fn(),
-  clearGroupCategoryExhausted: jest.fn(),
+jest.mock('../services/groups/groupFeedCache', () => {
+  const actual = jest.requireActual('../services/groups/groupFeedCache');
+  return {
+    ...actual,
+    readGroupFeedCache: jest.fn(),
+    writeGroupFeedCache: jest.fn(),
+    markGroupCategoryExhausted: jest.fn(),
+    isGroupCategoryExhausted: jest.fn(),
+    clearGroupCategoryExhausted: jest.fn(),
+  };
+});
+
+jest.mock('../utils/imagesRequests', () => ({
+  getImages: jest.fn(),
 }));
 
 const mockDelete = jest.fn();
 let mockFileExists = true;
+let mockFileExistsByUri = null;
 
 jest.mock('expo-file-system', () => {
   const File = jest.fn().mockImplementation(function MockFile(firstArg, secondArg) {
     const baseUri = typeof firstArg === 'string' ? firstArg : firstArg?.uri;
 
     this.uri = secondArg ? `${baseUri}${secondArg}` : baseUri;
-    this.exists = mockFileExists;
+    this.exists = mockFileExistsByUri ? !!mockFileExistsByUri[this.uri] : mockFileExists;
     this.delete = mockDelete;
   });
 
@@ -40,13 +50,12 @@ import { File } from 'expo-file-system';
 import { readGroupFeedCache, markGroupCategoryExhausted, isGroupCategoryExhausted, clearGroupCategoryExhausted } from '../services/groups/groupFeedCache';
 
 import {
-  addPlayedPictureId,
   clearE2EHiddenGuessCard,
   clearExhaustedCategory,
   deleteImageFromStorage,
   emptyImageList,
+  deckWriteLockKey,
   exhaustedCategoryKey,
-  filterPlayedCards,
   getDeckCountForScope,
   getE2EHiddenGuessCard,
   getLastImageId,
@@ -56,7 +65,6 @@ import {
   getNextImageForScope,
   getNextImagesForScope,
   getOnboardingCompleted,
-  getPlayedPictureIds,
   getPreferredLanguage,
   getRemainingDeckCount,
   getSessionLanguageFilter,
@@ -64,7 +72,6 @@ import {
   isCategoryExhausted,
   markCategoryExhausted,
   normalizeListIds,
-  playedPictureIdsKey,
   removeImageFromList,
   saveE2EHiddenGuessCard,
   saveLastImageUuid,
@@ -74,13 +81,16 @@ import {
   setOnboardingCompleted,
   storeImageList,
   updateImageList,
+  wipePublicGuessStorage,
 } from '../utils/storageDatum';
+import { appendCardBatch } from '../services/cardDeck';
 
 describe('storageDatum utilities', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDelete.mockReset();
     mockFileExists = true;
+    mockFileExistsByUri = null;
     AsyncStorage.setItem.mockResolvedValue(undefined);
     AsyncStorage.removeItem.mockResolvedValue(undefined);
     AsyncStorage.getAllKeys.mockResolvedValue([]);
@@ -104,10 +114,11 @@ describe('storageDatum utilities', () => {
 
   it('prunes entries whose cached image file no longer exists and re-stores the trimmed list', async () => {
     mockFileExists = false;
-    AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([
+    const stored = JSON.stringify([
       { listId: 1, imageFile: 'file:///cache/gone.jpg' },
       { listId: 2, imageFile: 'file:///cache/also-gone.jpg' },
-    ]));
+    ]);
+    AsyncStorage.getItem.mockImplementation(async (key) => (key === 'imageList:all:any' ? stored : null));
 
     const result = await getLocalImages('all', 'any');
 
@@ -134,6 +145,38 @@ describe('storageDatum utilities', () => {
 
     AsyncStorage.getItem.mockResolvedValueOnce('uuid-1');
     expect(await getLastImageUuid()).toBe('uuid-1');
+  });
+
+  it('private game-path cursor round-trip persists under the groupFeed-scoped key, not lastImageUuid', async () => {
+    const scope = { kind: 'private', groupId: 'g-9' };
+
+    await saveLastImageUuid('cursor-42', 'cat-uuid-7', 'fr', scope);
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('groupFeed:g-9:game:cat-uuid-7:fr:cursor', 'cursor-42');
+
+    await saveLastImageUuid('cursor-a', undefined, undefined, { kind: 'private', groupId: 'gA' });
+    expect(AsyncStorage.setItem).toHaveBeenLastCalledWith('groupFeed:gA:game:all:any:cursor', 'cursor-a');
+
+    AsyncStorage.getItem.mockResolvedValueOnce('cursor-42');
+    expect(await getLastImageUuid('cat-uuid-7', 'fr', scope)).toBe('cursor-42');
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('groupFeed:g-9:game:cat-uuid-7:fr:cursor');
+  });
+
+  it('private END sentinel lands in the group-scoped key; the public all cursor stays untouched (no poisoning)', async () => {
+    const scope = { kind: 'private', groupId: 'g-9' };
+
+    await saveLastImageUuid('__private_feed_end__', 'all', 'fr', scope);
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('groupFeed:g-9:game:all:fr:cursor', '__private_feed_end__');
+
+    // Asymmetry preserved: the PUBLIC 'all' cursor read must not see the
+    // private sentinel (pre-fix the sentinel was written to
+    // lastImageUuid:all:<lang> and poisoned the public feed cursor).
+    AsyncStorage.getItem.mockImplementation(async (key) => (
+      key === 'groupFeed:g-9:game:all:fr:cursor' ? '__private_feed_end__' : null
+    ));
+    expect(await getLastImageUuid('all', 'fr')).toBeNull();
+    expect(await getLastImageUuid('all', 'fr', scope)).toBe('__private_feed_end__');
   });
 
   it('round-trips the session language filter and returns null when unset', async () => {
@@ -209,19 +252,104 @@ describe('storageDatum utilities', () => {
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('e2eHiddenGuessCard');
   });
 
-  it('empties the stored image list, clears cache files, and removes tracking keys', async () => {
+  it('empties the stored image list for one tuple, clears cache files, and removes exact tracking keys', async () => {
     AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([
       { imageFile: 'file:///cache/a.jpg' },
       { imageFile: 'file:///cache/b.jpg' },
     ]));
 
-    await emptyImageList();
+    await emptyImageList('city', 'fr');
 
     expect(File).toHaveBeenCalledWith('file:///cache/a.jpg');
     expect(File).toHaveBeenCalledWith('file:///cache/b.jpg');
     expect(mockDelete).toHaveBeenCalledTimes(2);
-    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('imageList:all:any');
-    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('lastImageUuid:all:any');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('imageList:city:fr');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('lastImageUuid:city:fr');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('exhaustedCategory:city:fr');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('playedPictureIds:public:fr');
+  });
+
+  it('wipes public guess storage across namespaces and deletes cached deck files', async () => {
+    AsyncStorage.getAllKeys.mockResolvedValue([
+      'imageList:interior:en',
+      'imageList:city:fr',
+      'lastImageUuid:interior:en',
+      'lastImageUuid:private-category:en',
+      'exhaustedCategory:city:fr',
+      'playedPictureIds:public:en',
+      'playedPictureIds:public:any',
+      'groupFeed:g1:all:any',
+      'groupFeedExhausted:g1:city:fr',
+      'playedPictureIds:group:g1:en',
+    ]);
+    AsyncStorage.getItem.mockImplementation(async (key) => {
+      if (key === 'imageList:interior:en') {
+        return JSON.stringify([
+          { imageFile: 'file:///cache/interior-a.jpg' },
+          { imageFile: 'file:///cache/interior-b.jpg' },
+        ]);
+      }
+      if (key === 'imageList:city:fr') {
+        return JSON.stringify([{ imageFile: 'file:///cache/city-a.jpg' }]);
+      }
+      return null;
+    });
+
+    await wipePublicGuessStorage();
+
+    expect(File).toHaveBeenCalledWith('file:///cache/interior-a.jpg');
+    expect(File).toHaveBeenCalledWith('file:///cache/interior-b.jpg');
+    expect(File).toHaveBeenCalledWith('file:///cache/city-a.jpg');
+    expect(mockDelete).toHaveBeenCalledTimes(3);
+    expect(AsyncStorage.multiRemove).toHaveBeenCalledWith(expect.arrayContaining([
+      'imageList:interior:en',
+      'imageList:city:fr',
+      'lastImageUuid:interior:en',
+      'lastImageUuid:private-category:en',
+      'exhaustedCategory:city:fr',
+      'playedPictureIds:public:en',
+      'playedPictureIds:public:any',
+    ]));
+    const removedKeys = AsyncStorage.multiRemove.mock.calls[0][0];
+    expect(removedKeys).not.toContain('groupFeed:g1:all:any');
+    expect(removedKeys).not.toContain('groupFeedExhausted:g1:city:fr');
+    expect(removedKeys).not.toContain('playedPictureIds:group:g1:en');
+  });
+
+  it('wipePublicGuessStorage removes servingCycle: keys (public and group)', async () => {
+    AsyncStorage.getAllKeys.mockResolvedValue([
+      'servingCycle:public:fr',
+      'servingCycle:public:any',
+      'servingCycle:group:g1:fr',
+    ]);
+
+    await wipePublicGuessStorage();
+
+    expect(AsyncStorage.multiRemove).toHaveBeenCalledTimes(1);
+    const removedKeys = AsyncStorage.multiRemove.mock.calls[0][0];
+    expect(removedKeys).toEqual(
+      expect.arrayContaining([
+        'servingCycle:public:fr',
+        'servingCycle:public:any',
+        'servingCycle:group:g1:fr',
+      ]),
+    );
+  });
+
+  it('wipe leaves group deck/played keys untouched (existing pin stays)', async () => {
+    AsyncStorage.getAllKeys.mockResolvedValue([
+      'groupFeed:g1:all:any',
+      'groupFeedExhausted:g1:city:fr',
+      'playedPictureIds:group:g1:en',
+      'servingCycle:group:g1:fr',
+    ]);
+
+    await wipePublicGuessStorage();
+
+    const removedKeys = AsyncStorage.multiRemove.mock.calls[0][0];
+    expect(removedKeys).not.toContain('groupFeed:g1:all:any');
+    expect(removedKeys).not.toContain('groupFeedExhausted:g1:city:fr');
+    expect(removedKeys).not.toContain('playedPictureIds:group:g1:en');
   });
 
   it('appends new images and removes entries by list id', async () => {
@@ -881,43 +1009,6 @@ describe('storageDatum utilities', () => {
   });
 
   describe('played-picture set (Fix 2b)', () => {
-    it('(a) add/get roundtrip under scope-segmented keys with group isolation', async () => {
-      expect(playedPictureIdsKey('fr', { kind: 'public' })).toBe('playedPictureIds:public:fr');
-      expect(playedPictureIdsKey(undefined, null)).toBe('playedPictureIds:public:any');
-      expect(playedPictureIdsKey('fr', { kind: 'private', groupId: 'gA' })).toBe('playedPictureIds:group:gA:fr');
-
-      await addPlayedPictureId('pic-1', 'fr', { kind: 'public' });
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith('playedPictureIds:public:fr', JSON.stringify(['pic-1']));
-
-      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['pic-1']));
-      expect(await getPlayedPictureIds('fr', { kind: 'public' })).toEqual(['pic-1']);
-
-      AsyncStorage.getItem.mockResolvedValueOnce(null);
-      expect(await getPlayedPictureIds('fr', { kind: 'private', groupId: 'gB' })).toEqual([]);
-      expect(AsyncStorage.getItem).toHaveBeenLastCalledWith('playedPictureIds:group:gB:fr');
-    });
-
-    it('(b) caps the set at 200 and evicts the oldest id on overflow', async () => {
-      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(
-        Array.from({ length: 200 }, (_, i) => `p-${i}`),
-      ));
-
-      await addPlayedPictureId('new-one', 'fr', null);
-
-      const written = JSON.parse(AsyncStorage.setItem.mock.calls[0][1]);
-      expect(written).toHaveLength(200);
-      expect(written[0]).toBe('p-1');
-      expect(written[written.length - 1]).toBe('new-one');
-    });
-
-    it('(b2) idempotent add does not rewrite the set (no cap churn)', async () => {
-      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['pic-1']));
-
-      await addPlayedPictureId('pic-1', 'fr', null);
-
-      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
-    });
-
     it('(c) getNextImage skips a played card and serves the next one', async () => {
       AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([
         { listId: 1, pictureId: 'a', imageFile: 'file:///cache/1.jpg' },
@@ -946,14 +1037,6 @@ describe('storageDatum utilities', () => {
 
       expect(card).toEqual({ listId: 2, pictureId: 'b', imageFile: 'file:///cache/p2.jpg' });
       expect(AsyncStorage.getItem).toHaveBeenCalledWith('playedPictureIds:group:g-3:fr');
-    });
-
-    it('(e) falsy pictureId is a no-op (no write)', async () => {
-      await addPlayedPictureId(undefined, 'fr', null);
-      await addPlayedPictureId(null, 'fr', null);
-      await addPlayedPictureId('', 'fr', null);
-
-      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
     });
 
     it('(f) emptyImageList clears the public played key for the language and NO group key', async () => {
@@ -1001,17 +1084,170 @@ describe('storageDatum utilities', () => {
       expect(removed).toContain('playedPictureIds:group:gB:en');
       expect(removed).not.toContain('playedPictureIds:public:any');
     });
+  });
 
-    it('(i) filterPlayedCards passes pictureId-less cards through', async () => {
-      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['a']));
+  describe('deck write lock — removal serialization (Fix 1 D1)', () => {
+    const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
 
-      const filtered = await filterPlayedCards([
-        { pictureId: 'a' },
-        { listId: 5 },
-        { pictureId: 'b' },
-      ], 'fr', null);
+    it('(a) RACE: removal write held open + concurrent appendCardBatch on the same key → final deck keeps BOTH batches minus the removed card', async () => {
+      let store = JSON.stringify([{ listId: 1 }, { listId: 2 }]);
+      let releaseRemovalWrite;
+      const removalWriteGate = new Promise((resolve) => { releaseRemovalWrite = resolve; });
+      let removalWriteGated = false;
 
-      expect(filtered).toEqual([{ listId: 5 }, { pictureId: 'b' }]);
+      AsyncStorage.getItem.mockImplementation(async (key) => (key === 'imageList:city:fr' ? store : null));
+      AsyncStorage.setItem.mockImplementation(async (key, value) => {
+        if (key !== 'imageList:city:fr') return;
+        if (!removalWriteGated) {
+          removalWriteGated = true;
+          await removalWriteGate;
+        }
+        store = value;
+      });
+
+      const removal = removeImageFromList(1, 'city', 'fr');
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      const append = appendCardBatch({
+        cards: [{ listId: 3 }],
+        categoryKey: 'city',
+        language: 'fr',
+        scope: { kind: 'public' },
+      });
+      await flushMicrotasks();
+      await flushMicrotasks();
+      // The append RMW must queue behind the in-flight removal (same lock
+      // key): without the lock it would already have read the stale deck.
+      expect(AsyncStorage.getItem.mock.calls.filter(([key]) => key === 'imageList:city:fr')).toHaveLength(1);
+
+      releaseRemovalWrite();
+      await removal;
+      await append;
+
+      expect(JSON.parse(store)).toEqual([{ listId: 2 }, { listId: 3 }]);
+    });
+
+    it('(b) two concurrent removals both land (serialized read-modify-write)', async () => {
+      let store = JSON.stringify([{ listId: 1 }, { listId: 2 }, { listId: 3 }]);
+      let releaseFirstWrite;
+      const firstWriteGate = new Promise((resolve) => { releaseFirstWrite = resolve; });
+      let firstWriteGated = false;
+
+      AsyncStorage.getItem.mockImplementation(async (key) => (key === 'imageList:nature:fr' ? store : null));
+      AsyncStorage.setItem.mockImplementation(async (key, value) => {
+        if (key !== 'imageList:nature:fr') return;
+        if (!firstWriteGated) {
+          firstWriteGated = true;
+          await firstWriteGate;
+        }
+        store = value;
+      });
+
+      const first = removeImageFromList(1, 'nature', 'fr');
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      const second = removeImageFromList(2, 'nature', 'fr');
+      await flushMicrotasks();
+      await flushMicrotasks();
+      expect(AsyncStorage.getItem.mock.calls.filter(([key]) => key === 'imageList:nature:fr')).toHaveLength(1);
+
+      releaseFirstWrite();
+      await first;
+      await second;
+
+      expect(JSON.parse(store)).toEqual([{ listId: 3 }]);
+    });
+  });
+
+  describe('deck write lock — trim serialization (Fix 2 D2)', () => {
+    const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
+    it('(b) all-viable deck read performs NO write-back (steady-state reads stay lock-free)', async () => {
+      const stored = [
+        { listId: 1, imageFile: 'file:///cache/1.jpg' },
+        { listId: 2, imageFile: 'file:///cache/2.jpg' },
+      ];
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(stored));
+
+      const result = await getLocalImages('all', 'any');
+
+      expect(result).toEqual(stored);
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+      expect(AsyncStorage.multiRemove).not.toHaveBeenCalled();
+    });
+
+    it('re-reads and trims the latest persisted deck under the lock so concurrent appends survive', async () => {
+      mockFileExistsByUri = {
+        'file:///cache/gone.jpg': false,
+        'file:///cache/live.jpg': true,
+        'file:///cache/new.jpg': true,
+      };
+
+      let store = JSON.stringify([
+        { listId: 1, imageFile: 'file:///cache/gone.jpg' },
+        { listId: 2, imageFile: 'file:///cache/live.jpg' },
+      ]);
+      let releaseAppendWrite;
+      const appendWriteGate = new Promise((resolve) => {
+        releaseAppendWrite = resolve;
+      });
+      let appendWriteGated = false;
+
+      AsyncStorage.getItem.mockImplementation(async (key) => {
+        if (key === 'imageList:city:fr') {
+          return store;
+        }
+        if (key === 'playedPictureIds:public:fr') {
+          return null;
+        }
+        return null;
+      });
+      AsyncStorage.setItem.mockImplementation(async (key, value) => {
+        if (key !== 'imageList:city:fr') {
+          return;
+        }
+        if (!appendWriteGated) {
+          appendWriteGated = true;
+          await appendWriteGate;
+        }
+        store = value;
+      });
+
+      const append = appendCardBatch({
+        cards: [{ listId: 3, imageFile: 'file:///cache/new.jpg' }],
+        categoryKey: 'city',
+        language: 'fr',
+        scope: { kind: 'public' },
+      });
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      const read = getLocalImages('city', 'fr');
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      releaseAppendWrite();
+      const result = await read;
+      await append;
+
+      expect(result).toEqual([
+        { listId: 2, imageFile: 'file:///cache/live.jpg' },
+        { listId: 3, imageFile: 'file:///cache/new.jpg' },
+      ]);
+      expect(JSON.parse(store)).toEqual([
+        { listId: 2, imageFile: 'file:///cache/live.jpg' },
+        { listId: 3, imageFile: 'file:///cache/new.jpg' },
+      ]);
+    });
+  });
+
+  describe('deckWriteLockKey', () => {
+    it('matches the shared public and private key format used by every deck writer', () => {
+      expect(deckWriteLockKey({ categoryKey: 'city', language: 'fr', scope: null })).toBe('cardDeck:append:public:city:fr');
+      expect(deckWriteLockKey({ categoryId: 7, language: 'fr', scope: { kind: 'private', groupId: 'g-1' } })).toBe('cardDeck:append:private:g-1:7:fr');
+      expect(deckWriteLockKey({ categoryId: 'all', language: undefined, scope: { kind: 'private', groupId: 'g-1' } })).toBe('cardDeck:append:private:g-1:all:any');
     });
   });
 });

--- a/__tests__/storageDatum.test.js
+++ b/__tests__/storageDatum.test.js
@@ -2,6 +2,8 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
   setItem: jest.fn(),
   removeItem: jest.fn(),
+  getAllKeys: jest.fn(),
+  multiRemove: jest.fn(),
 }));
 
 jest.mock('../services/groups/groupFeedCache', () => ({
@@ -38,11 +40,13 @@ import { File } from 'expo-file-system';
 import { readGroupFeedCache, markGroupCategoryExhausted, isGroupCategoryExhausted, clearGroupCategoryExhausted } from '../services/groups/groupFeedCache';
 
 import {
+  addPlayedPictureId,
   clearE2EHiddenGuessCard,
   clearExhaustedCategory,
   deleteImageFromStorage,
   emptyImageList,
   exhaustedCategoryKey,
+  filterPlayedCards,
   getDeckCountForScope,
   getE2EHiddenGuessCard,
   getLastImageId,
@@ -52,12 +56,15 @@ import {
   getNextImageForScope,
   getNextImagesForScope,
   getOnboardingCompleted,
+  getPlayedPictureIds,
   getPreferredLanguage,
   getRemainingDeckCount,
   getSessionLanguageFilter,
   getUserTags,
   isCategoryExhausted,
   markCategoryExhausted,
+  normalizeListIds,
+  playedPictureIdsKey,
   removeImageFromList,
   saveE2EHiddenGuessCard,
   saveLastImageUuid,
@@ -76,6 +83,8 @@ describe('storageDatum utilities', () => {
     mockFileExists = true;
     AsyncStorage.setItem.mockResolvedValue(undefined);
     AsyncStorage.removeItem.mockResolvedValue(undefined);
+    AsyncStorage.getAllKeys.mockResolvedValue([]);
+    AsyncStorage.multiRemove.mockResolvedValue(undefined);
     readGroupFeedCache.mockReset();
     markGroupCategoryExhausted.mockReset();
     isGroupCategoryExhausted.mockReset();
@@ -825,6 +834,184 @@ describe('storageDatum utilities', () => {
       await emptyImageList('city', 'fr');
 
       expect(AsyncStorage.removeItem).toHaveBeenCalledWith('exhaustedCategory:city:fr');
+    });
+  });
+
+  describe('normalizeListIds collision repair (Fix 3)', () => {
+    it('(a) reassigns LATER duplicate finite ids beyond the deck max, order preserved', () => {
+      const result = normalizeListIds([
+        { pictureId: 'a', listId: 1 },
+        { pictureId: 'b', listId: 2 },
+        { pictureId: 'c', listId: 1 },
+        { pictureId: 'd', listId: 2 },
+      ]);
+
+      expect(result.map((c) => [c.pictureId, c.listId])).toEqual([
+        ['a', 1],
+        ['b', 2],
+        ['c', 3],
+        ['d', 4],
+      ]);
+    });
+
+    it('(b) healthy deck returns the SAME reference (identity no-op)', () => {
+      const cards = [{ listId: 1 }, { listId: 2 }, { listId: 3 }];
+      expect(normalizeListIds(cards)).toBe(cards);
+    });
+
+    it('(c) repairs a missing + duplicate mix in one pass', () => {
+      const result = normalizeListIds([
+        { pictureId: 'a', listId: 3 },
+        { pictureId: 'b' },
+        { pictureId: 'c', listId: 3 },
+        { pictureId: 'd', listId: null },
+      ]);
+
+      expect(result.map((c) => c.listId)).toEqual([3, 4, 5, 6]);
+    });
+
+    it('(d) all-finite all-duplicate deck is repaired (no missing-id early return)', () => {
+      const result = normalizeListIds([
+        { pictureId: 'a', listId: 1 },
+        { pictureId: 'b', listId: 1 },
+      ]);
+
+      expect(result.map((c) => c.listId)).toEqual([1, 2]);
+    });
+  });
+
+  describe('played-picture set (Fix 2b)', () => {
+    it('(a) add/get roundtrip under scope-segmented keys with group isolation', async () => {
+      expect(playedPictureIdsKey('fr', { kind: 'public' })).toBe('playedPictureIds:public:fr');
+      expect(playedPictureIdsKey(undefined, null)).toBe('playedPictureIds:public:any');
+      expect(playedPictureIdsKey('fr', { kind: 'private', groupId: 'gA' })).toBe('playedPictureIds:group:gA:fr');
+
+      await addPlayedPictureId('pic-1', 'fr', { kind: 'public' });
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith('playedPictureIds:public:fr', JSON.stringify(['pic-1']));
+
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['pic-1']));
+      expect(await getPlayedPictureIds('fr', { kind: 'public' })).toEqual(['pic-1']);
+
+      AsyncStorage.getItem.mockResolvedValueOnce(null);
+      expect(await getPlayedPictureIds('fr', { kind: 'private', groupId: 'gB' })).toEqual([]);
+      expect(AsyncStorage.getItem).toHaveBeenLastCalledWith('playedPictureIds:group:gB:fr');
+    });
+
+    it('(b) caps the set at 200 and evicts the oldest id on overflow', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(
+        Array.from({ length: 200 }, (_, i) => `p-${i}`),
+      ));
+
+      await addPlayedPictureId('new-one', 'fr', null);
+
+      const written = JSON.parse(AsyncStorage.setItem.mock.calls[0][1]);
+      expect(written).toHaveLength(200);
+      expect(written[0]).toBe('p-1');
+      expect(written[written.length - 1]).toBe('new-one');
+    });
+
+    it('(b2) idempotent add does not rewrite the set (no cap churn)', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['pic-1']));
+
+      await addPlayedPictureId('pic-1', 'fr', null);
+
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it('(c) getNextImage skips a played card and serves the next one', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([
+        { listId: 1, pictureId: 'a', imageFile: 'file:///cache/1.jpg' },
+        { listId: 2, pictureId: 'b', imageFile: 'file:///cache/2.jpg' },
+      ]));
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['a']));
+
+      expect(await getNextImage('all', 'any')).toEqual({ listId: 2, pictureId: 'b', imageFile: 'file:///cache/2.jpg' });
+    });
+
+    it('(d) getNextImageForScope skips a played card on the private branch', async () => {
+      readGroupFeedCache.mockResolvedValueOnce({
+        images: [
+          { listId: 1, pictureId: 'a', imageFile: 'file:///cache/p1.jpg' },
+          { listId: 2, pictureId: 'b', imageFile: 'file:///cache/p2.jpg' },
+        ],
+        nextCursor: null,
+      });
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['a']));
+
+      const card = await getNextImageForScope({
+        category: { key: 'all' },
+        language: 'fr',
+        scope: { kind: 'private', groupId: 'g-3' },
+      });
+
+      expect(card).toEqual({ listId: 2, pictureId: 'b', imageFile: 'file:///cache/p2.jpg' });
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith('playedPictureIds:group:g-3:fr');
+    });
+
+    it('(e) falsy pictureId is a no-op (no write)', async () => {
+      await addPlayedPictureId(undefined, 'fr', null);
+      await addPlayedPictureId(null, 'fr', null);
+      await addPlayedPictureId('', 'fr', null);
+
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it('(f) emptyImageList clears the public played key for the language and NO group key', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(null);
+
+      await emptyImageList('city', 'fr');
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('playedPictureIds:public:fr');
+      const removedKeys = AsyncStorage.removeItem.mock.calls.map(([key]) => key);
+      expect(removedKeys.some((key) => key.startsWith('playedPictureIds:group:'))).toBe(false);
+    });
+
+    it('(g) clearGroupFeedCache clears only that group\'s played-set (public + other groups untouched)', async () => {
+      const { clearGroupFeedCache } = jest.requireActual('../services/groups/groupFeedCache');
+      AsyncStorage.getAllKeys.mockResolvedValue([
+        'playedPictureIds:group:gA:fr',
+        'playedPictureIds:group:gB:fr',
+        'playedPictureIds:public:fr',
+        'groupFeed:gA:all:any',
+        'groupFeed:gB:all:any',
+      ]);
+
+      await clearGroupFeedCache('gA');
+
+      const removed = AsyncStorage.multiRemove.mock.calls.map(([keys]) => keys).flat();
+      expect(removed).toContain('playedPictureIds:group:gA:fr');
+      expect(removed).toContain('groupFeed:gA:all:any');
+      expect(removed).not.toContain('playedPictureIds:group:gB:fr');
+      expect(removed).not.toContain('playedPictureIds:public:fr');
+      expect(removed).not.toContain('groupFeed:gB:all:any');
+    });
+
+    it('(h) purgeAllPrivateCaches clears all group played-sets, public untouched', async () => {
+      const { purgeAllPrivateCaches } = jest.requireActual('../services/groups/groupFeedCache');
+      AsyncStorage.getAllKeys.mockResolvedValue([
+        'playedPictureIds:group:gA:fr',
+        'playedPictureIds:group:gB:en',
+        'playedPictureIds:public:any',
+      ]);
+
+      await purgeAllPrivateCaches();
+
+      const removed = AsyncStorage.multiRemove.mock.calls.map(([keys]) => keys).flat();
+      expect(removed).toContain('playedPictureIds:group:gA:fr');
+      expect(removed).toContain('playedPictureIds:group:gB:en');
+      expect(removed).not.toContain('playedPictureIds:public:any');
+    });
+
+    it('(i) filterPlayedCards passes pictureId-less cards through', async () => {
+      AsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(['a']));
+
+      const filtered = await filterPlayedCards([
+        { pictureId: 'a' },
+        { listId: 5 },
+        { pictureId: 'b' },
+      ], 'fr', null);
+
+      expect(filtered).toEqual([{ listId: 5 }, { pictureId: 'b' }]);
     });
   });
 });

--- a/__tests__/storageDatum.test.js
+++ b/__tests__/storageDatum.test.js
@@ -52,6 +52,7 @@ import { readGroupFeedCache, markGroupCategoryExhausted, isGroupCategoryExhauste
 import {
   clearE2EHiddenGuessCard,
   clearExhaustedCategory,
+  clearLastImageUuid,
   deleteImageFromStorage,
   emptyImageList,
   deckWriteLockKey,
@@ -145,6 +146,15 @@ describe('storageDatum utilities', () => {
 
     AsyncStorage.getItem.mockResolvedValueOnce('uuid-1');
     expect(await getLastImageUuid()).toBe('uuid-1');
+  });
+
+  it('clearLastImageUuid removes the scoped cursor key (public + private)', async () => {
+    await clearLastImageUuid('all', 'fr');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('lastImageUuid:all:fr');
+
+    await clearLastImageUuid('all', 'fr', { kind: 'private', groupId: 'g-9' });
+    expect(AsyncStorage.removeItem).toHaveBeenLastCalledWith('groupFeed:g-9:game:all:fr:cursor');
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
   });
 
   it('private game-path cursor round-trip persists under the groupFeed-scoped key, not lastImageUuid', async () => {

--- a/components/UI/SwipeImage.js
+++ b/components/UI/SwipeImage.js
@@ -7,11 +7,12 @@ import SwipeableCard from './SwipeableCard';
 import LoadingOverlay from './LoadingOverlay';
 import useBadgeDetail from './useBadgeDetail';
 
-import { getE2EHiddenGuessCard, getLocalImages, getLastImageId, normalizeListIds, removeImageFromList, deleteImageFromStorage, saveLastImageUuid, PUBLIC_FEED_END_CURSOR } from '../../utils/storageDatum';
+import { addPlayedPictureId, filterPlayedCards, getE2EHiddenGuessCard, getLocalImages, normalizeListIds, removeImageFromList, deleteImageFromStorage, saveLastImageUuid, PUBLIC_FEED_END_CURSOR } from '../../utils/storageDatum';
 import { AuthContext } from '../../store/auth-context';
 import { buildE2EGuessCardFromPayload, buildE2EGuessCards, isE2EMode } from '../../utils/e2eMode';
 import { GlobalStyle } from '../../constants/theme';
 import { readGroupFeedCache, writeGroupFeedCache } from '../../services/groups/groupFeedCache';
+import { PRIVATE_FEED_END_CURSOR } from '../../services/groups/groupFeedApi';
 import { fetchCardBatch, persistCardBatch, appendCardBatch } from '../../services/cardDeck';
 import { prefetchIfLow, warmAllDeckIfNeeded } from '../../services/cardPrefetcher';
 import { RECENT_ALL_CATEGORY } from '../../constants/categories';
@@ -58,49 +59,42 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
     const aKey = activeCategoryKeyRef.current;
     const aCat = activeCategoryRef.current;
     const currentImageList = imageListRef.current;
-    const lastId = currentImageList?.length
-      ? currentImageList.reduce((maxId, image) => Math.max(maxId, image?.listId ?? 0), 0)
-      : await getLastImageId(aKey, lang);
-    // This is done to add a unique identifier to each object in 'data', which will be used to keep track of the order in which images are displayed.
-    const updatedImageList = data?.map((image, index) => ({
-     ...image,
-     listId: lastId + 1 + index,
-    }));
 
     if (currentImageList === null) {
       console.log("updatedImageList handleData imageList null");
-      await persistCardBatch({
-        cards: updatedImageList,
+      const normalized = await persistCardBatch({
+        cards: data,
         categoryKey: aKey,
         categoryId: aCat?.id,
         language: lang,
         scope,
       });
-      setImageList(updatedImageList);
+      setImageList(normalized);
 
-      if (updatedImageList?.length > 0) {
-        return true
-      };
-
-      if (updatedImageList?.length === 0) {
-        return false
-      };
+      return normalized?.length > 0;
     };
 
     if (currentImageList !== null) {
       console.log("updatedImageList handleData imageList !== null");
 
-      if (updatedImageList?.length > 0) {
-        await appendCardBatch({
-          cards: updatedImageList,
+      if (data?.length > 0) {
+        const merged = await appendCardBatch({
+          cards: data,
           categoryKey: aKey,
           categoryId: aCat?.id,
           language: lang,
           scope,
         });
-        const newImageList = [...currentImageList, ...updatedImageList];
-        setImageList(newImageList);
-        return true;
+        // Resurrection-race reconciliation (Fix 3 §2.3.4): removeCard runs
+        // OUTSIDE appendCardBatch's scope lock, so an in-flight append RMW that
+        // read the deck BEFORE a removal can return a merged deck still
+        // containing the just-swiped card. Removals win: keep only cards whose
+        // pictureId is still in memory or in the incoming batch — pictureId-less
+        // legacy cards are unidentifiable and pass through.
+        const allowed = new Set([...(currentImageList ?? []), ...(data ?? [])].map((c) => c?.pictureId).filter(Boolean));
+        const reconciled = merged.filter((c) => !c?.pictureId || allowed.has(c.pictureId));
+        setImageList(reconciled);
+        return reconciled?.length > 0;
       }
 
       return false;
@@ -180,10 +174,13 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
    *   bypassing any stale cursor so newly-uploaded images can surface).
    * - full (length ≥ 4) → use the local deck directly (no fetch).
    * - partial (1–3) → cursor-based `handleImagesLoading()` (no override → reads
-   *   the persisted cursor); if it returns `false` (cursor exhausted), write the
-   *   `PUBLIC_FEED_END_CURSOR` sentinel and do ONE fresh
-   *   `handleImagesLoading(null)` so newly-available server images can be
-   *   reached. The cached deck is NOT wiped — only the cursor is replaced.
+   *   the persisted cursor); if it returns `false` (cursor exhausted), do ONE
+   *   fresh `handleImagesLoading(null)` head probe — Fix 2a keeps the stored
+   *   real cursor untouched (no rewind, no sentinel pre-write). Only if that
+   *   head probe ALSO returns `false` do we write the SCOPE-CORRECT exhausted
+   *   sentinel (public: `PUBLIC_FEED_END_CURSOR`, private:
+   *   `PRIVATE_FEED_END_CURSOR`) so the exhausted signal survives. The cached
+   *   deck is NOT wiped — only the cursor is replaced.
    *
    * @returns {Promise<void>}
    */
@@ -211,7 +208,16 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
 
     // if localImageList [] or null, get Images() / show loadingOverlay
     if (localImageList !== null && (localImageList?.length >= 4)) {
-      setImageList(normalizeListIds(localImageList));
+      // Review MINOR #1: if every stored card is already in the played-set the
+      // filtered deck is EMPTY — serving it would render a blank stack with no
+      // fetch and no noMoreCard signal. Fall through to a cursor-mode load
+      // instead; the refill/fallback machinery owns the rest from there.
+      const filtered = await filterPlayedCards(normalizeListIds(localImageList), lang, scope);
+      if (filtered.length > 0) {
+        setImageList(filtered);
+      } else {
+        await handleImagesLoading();
+      }
     } else if (localImageList === null || localImageList?.length === 0) {
       // Empty category deck on mount — cold-start the ACTIVE category with a
       // fresh server query (pictureId=null). Do NOT consult the stored cursor:
@@ -220,11 +226,20 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       // once the user is actually swiping and the deck empties.
       await handleImagesLoading(null);
     } else {
-      setImageList(normalizeListIds(localImageList));
+      setImageList(await filterPlayedCards(normalizeListIds(localImageList), lang, scope));
       const cursorResult = await handleImagesLoading();
       if (cursorResult === false) {
-        await saveLastImageUuid(PUBLIC_FEED_END_CURSOR, categoryKey, lang);
-        await handleImagesLoading(null);
+        // Fix 2a: no sentinel pre-write before the head probe — the probe runs
+        // with the stored REAL cursor intact (head-replay guard keeps it), so
+        // fresh uploads surface without rewinding pagination.
+        const headResult = await handleImagesLoading(null);
+        if (headResult === false) {
+          await saveLastImageUuid(
+            isPrivateScope ? PRIVATE_FEED_END_CURSOR : PUBLIC_FEED_END_CURSOR,
+            categoryKey,
+            lang,
+          );
+        }
       }
     };
   }, [category?.id, categoryKey, context, handleImagesLoading, isPrivateScope, lang, language, privateGroupId, scope]);
@@ -250,11 +265,11 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
     const aKey = activeCategoryKeyRef.current;
     const aCat = activeCategoryRef.current;
 
-    const readDeck = async (deckKey, deckCategory) => normalizeListIds(
+    const readDeck = async (deckKey, deckCategory) => filterPlayedCards(normalizeListIds(
       isPrivateScope
         ? (await readGroupFeedCache(privateGroupId, { categoryId: deckCategory?.id === 'all' ? undefined : deckCategory?.id, language: lang }))?.images ?? []
         : await getLocalImages(deckKey, lang) ?? [],
-    );
+    ), lang, scope);
 
     // 1. Re-read the active deck — the background prefetcher may have appended
     //    cards to AsyncStorage that local state hasn't picked up yet.
@@ -314,6 +329,10 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       const updatedImageList = currentList.filter((item) => item.listId !== id);
       const image = currentList.find((item) => item.listId === id);
       const aCat = activeCategoryRef.current;
+
+      if (image?.pictureId) {
+        addPlayedPictureId(image.pictureId, lang, scope).catch(() => {});
+      }
 
       if (image?.imageFile) {
         await deleteImage(id, image.imageFile);

--- a/components/UI/SwipeImage.js
+++ b/components/UI/SwipeImage.js
@@ -15,7 +15,7 @@ import { buildE2EGuessCardFromPayload, buildE2EGuessCards, isE2EMode } from '../
 import { GlobalStyle } from '../../constants/theme';
 import { readGroupFeedCache } from '../../services/groups/groupFeedCache';
 import { PRIVATE_FEED_END_CURSOR } from '../../services/groups/groupFeedApi';
-import { fetchCardBatch, persistCardBatch, appendCardBatch, removeCardFromGroupDeck } from '../../services/cardDeck';
+import { fetchCardBatch, persistCardBatch, appendCardBatch, probeAllPoolForUnplayed, removeCardFromGroupDeck } from '../../services/cardDeck';
 import { prefetchIfLow, warmAllDeckIfNeeded } from '../../services/cardPrefetcher';
 import { RECENT_ALL_CATEGORY } from '../../constants/categories';
 /* https://snack.expo.dev/embedded/@aboutreact/tinder-like-swipeable-card-example?preview=true&platform=ios&iframeId=0kofaqg0vl&theme=dark */
@@ -187,14 +187,24 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
    *   Probe also `false` → write the SCOPE-CORRECT exhausted sentinel
    *   (public: `PUBLIC_FEED_END_CURSOR`, private: `PRIVATE_FEED_END_CURSOR`).
    * - Probe `'error'` → same non-null empty restore, recovery gated off (I7).
-   * - Cycle recovery (I4), gated on a probe that did NOT error: exhaustion
-   *   proof = the deck head is non-empty but every card is already played
-   *   this cycle (`isCycleExhausted`) → at most ONE `startNewServingCycle`
-   *   transition per mount clears the played-set and re-serves the deck head
-   *   oldest-first. The three deck branches are mutually exclusive and each
-   *   invokes this helper at most once per mount, so no extra transition
-   *   guard is needed. A genuinely empty deck (server empty) is NOT
-   *   exhaustion — the exhausted flow stands, no transition.
+   * - Cycle recovery (I4), gated on a probe that did NOT error: the
+   *   CATEGORY-side proof is the deck head non-empty but every card already
+   *   played this cycle (`isCycleExhausted`) — that alone is NOT exhaustion
+   *   (Bug 2: re-entering a finished category used to wipe the SHARED
+   *   played-set on every mount). The sound 'all'-pool proof comes from
+   *   `probeAllPoolForUnplayed`:
+   *   - `'unplayed'` → the 'all' pool still serves unplayed cards: serve the
+   *     'all' deck and switch the active category to 'all' (same mechanism as
+   *     refillOrFallback step 3). NO transition.
+   *   - `'exhausted'` → 'all' pool server-drained — BOTH pools proven
+   *     exhausted → at most ONE `startNewServingCycle` transition per mount
+   *     clears the played-set and re-serves the deck head oldest-first.
+   *   - `'indeterminate'` → transient failure: NO transition, the exhausted
+   *     flow stands (I7).
+   *   The three deck branches are mutually exclusive and each invokes this
+   *   helper at most once per mount, so no extra transition guard is needed.
+   *   A genuinely empty deck (server empty) is NOT exhaustion — the exhausted
+   *   flow stands, no transition.
    *
    * @param {boolean|'error'|void} cursorResult - The branch's cursor-round result.
    * @param {{resetServeStateForHead: boolean}} opts - Whether the head probe
@@ -247,10 +257,33 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
     );
     const servableCount = (await filterPlayedCards(headDeck, lang, scope)).length;
     if (isCycleExhausted(headDeck.length, servableCount)) {
-      await startNewServingCycle(lang, scope).catch(() => {});
-      setImageList(await filterPlayedCards(headDeck, lang, scope));
+      const probe = await probeAllPoolForUnplayed({
+        language: lang,
+        scope,
+        authContext: context,
+        excludePictureId: imageListRef.current?.[0]?.pictureId,
+      });
+      if (probe?.status === 'unplayed') {
+        // Serve the 'all' deck (the probe appended ≥1 unplayed card to it)
+        // and switch the active category the same way refillOrFallback
+        // step 3 does, so win-removal namespaces stay consistent.
+        const allDeck = await filterPlayedCards(normalizeListIds(
+          isPrivateScope
+            ? (await readGroupFeedCache(privateGroupId, { categoryId: undefined, language: lang }))?.images ?? []
+            : await getLocalImages('all', lang) ?? [],
+        ), lang, scope);
+        if (allDeck.length > 0) {
+          setActiveCategoryKey('all');
+          setActiveCategory(RECENT_ALL_CATEGORY);
+          setImageList(allDeck);
+        }
+      } else if (probe?.status === 'exhausted') {
+        await startNewServingCycle(lang, scope).catch(() => {});
+        setImageList(await filterPlayedCards(headDeck, lang, scope));
+      }
+      // 'indeterminate' → NO transition (I7); the exhausted flow stands.
     }
-  }, [category?.id, categoryKey, handleImagesLoading, isPrivateScope, lang, privateGroupId, scope]);
+  }, [category?.id, categoryKey, context, handleImagesLoading, isPrivateScope, lang, privateGroupId, scope]);
 
   /**
    * Mount loader. Reads the local deck for the active (category, language) and

--- a/components/UI/SwipeImage.js
+++ b/components/UI/SwipeImage.js
@@ -7,13 +7,15 @@ import SwipeableCard from './SwipeableCard';
 import LoadingOverlay from './LoadingOverlay';
 import useBadgeDetail from './useBadgeDetail';
 
-import { addPlayedPictureId, filterPlayedCards, getE2EHiddenGuessCard, getLocalImages, normalizeListIds, removeImageFromList, deleteImageFromStorage, saveLastImageUuid, PUBLIC_FEED_END_CURSOR } from '../../utils/storageDatum';
+import { getE2EHiddenGuessCard, getLocalImages, isCategoryExhausted, normalizeListIds, removeImageFromList, deleteImageFromStorage, saveLastImageUuid, PUBLIC_FEED_END_CURSOR } from '../../utils/storageDatum';
+import { addPlayedPictureId, filterPlayedCards } from '../../utils/playedPictureIds';
+import { isCycleExhausted, startNewServingCycle } from '../../utils/servingCycle';
 import { AuthContext } from '../../store/auth-context';
 import { buildE2EGuessCardFromPayload, buildE2EGuessCards, isE2EMode } from '../../utils/e2eMode';
 import { GlobalStyle } from '../../constants/theme';
-import { readGroupFeedCache, writeGroupFeedCache } from '../../services/groups/groupFeedCache';
+import { readGroupFeedCache } from '../../services/groups/groupFeedCache';
 import { PRIVATE_FEED_END_CURSOR } from '../../services/groups/groupFeedApi';
-import { fetchCardBatch, persistCardBatch, appendCardBatch } from '../../services/cardDeck';
+import { fetchCardBatch, persistCardBatch, appendCardBatch, removeCardFromGroupDeck } from '../../services/cardDeck';
 import { prefetchIfLow, warmAllDeckIfNeeded } from '../../services/cardPrefetcher';
 import { RECENT_ALL_CATEGORY } from '../../constants/categories';
 /* https://snack.expo.dev/embedded/@aboutreact/tinder-like-swipeable-card-example?preview=true&platform=ios&iframeId=0kofaqg0vl&theme=dark */
@@ -69,15 +71,18 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
         language: lang,
         scope,
       });
-      setImageList(normalized);
+      // Repeals predecessor plan D3 exemption ("UI replay feature"): the
+      // persisted deck stays COMPLETE (resume truth, I5), but the mount serve
+      // honors once-per-cycle (I1) — only unplayed cards reach the stack.
+      const filtered = await filterPlayedCards(normalized, lang, scope);
+      setImageList(filtered);
 
-      return normalized?.length > 0;
+      return filtered?.length > 0;
     };
 
     if (currentImageList !== null) {
-      console.log("updatedImageList handleData imageList !== null");
-
       if (data?.length > 0) {
+        console.log("updatedImageList handleData imageList !== null");
         const merged = await appendCardBatch({
           cards: data,
           categoryKey: aKey,
@@ -168,19 +173,98 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
   }, [loadNewImages]);
 
   /**
+   * Shared mount recovery tail (I4/I7), run by ALL THREE deck branches of
+   * `handleGetImagesList` once their cursor round came back without servable
+   * cards. After the branch's cursor round:
+   * - `'error'` → restore the non-null empty serve state so the error/retry
+   *   panel renders (an errored round never ran `handleData`; a null list
+   *   would pin the loading overlay forever). No probe, no cycle mutation.
+   * - `false` → ONE fresh `handleImagesLoading(null)` head probe. When
+   *   `resetServeStateForHead` is set (empty/full-deck branches) the serve
+   *   state is reset first so the head batch takes the FULL-persist path
+   *   (resume truth, I5) — the cycle-recovery re-read below needs the landed
+   *   batch on disk; the partial-deck branch keeps Fix 2a's append path.
+   *   Probe also `false` → write the SCOPE-CORRECT exhausted sentinel
+   *   (public: `PUBLIC_FEED_END_CURSOR`, private: `PRIVATE_FEED_END_CURSOR`).
+   * - Probe `'error'` → same non-null empty restore, recovery gated off (I7).
+   * - Cycle recovery (I4), gated on a probe that did NOT error: exhaustion
+   *   proof = the deck head is non-empty but every card is already played
+   *   this cycle (`isCycleExhausted`) → at most ONE `startNewServingCycle`
+   *   transition per mount clears the played-set and re-serves the deck head
+   *   oldest-first. The three deck branches are mutually exclusive and each
+   *   invokes this helper at most once per mount, so no extra transition
+   *   guard is needed. A genuinely empty deck (server empty) is NOT
+   *   exhaustion — the exhausted flow stands, no transition.
+   *
+   * @param {boolean|'error'|void} cursorResult - The branch's cursor-round result.
+   * @param {{resetServeStateForHead: boolean}} opts - Whether the head probe
+   *   may reset the serve state (empty/full-deck) or must append (partial).
+   * @returns {Promise<void>}
+   */
+  const runMountRecoveryFlow = useCallback(async (cursorResult, { resetServeStateForHead }) => {
+    console.log("runMountRecoveryFlow");
+
+    if (cursorResult === 'error') {
+      // Restore the non-null empty serve state so the error panel can render
+      // (a null list would pin the loading overlay forever). Only the
+      // null-serve branches (empty / filtered-empty full deck) need it — the
+      // partial branch already holds a non-null serve.
+      if (resetServeStateForHead) {
+        setImageList([]);
+      }
+      return;
+    }
+    if (cursorResult !== false) {
+      return;
+    }
+
+    if (resetServeStateForHead) {
+      imageListRef.current = null;
+      setImageList(null);
+    }
+    const headResult = await handleImagesLoading(null);
+    if (headResult === 'error') {
+      // Restore the non-null empty serve state so the error panel can
+      // render (a null list would pin the loading overlay forever).
+      if (resetServeStateForHead) {
+        setImageList([]);
+      }
+      return;
+    }
+    if (headResult === false) {
+      await saveLastImageUuid(
+        isPrivateScope ? PRIVATE_FEED_END_CURSOR : PUBLIC_FEED_END_CURSOR,
+        categoryKey,
+        lang,
+        ...(isPrivateScope ? [scope] : []),
+      );
+    }
+
+    const headDeck = normalizeListIds(
+      isPrivateScope
+        ? (await readGroupFeedCache(privateGroupId, { categoryId: category?.id === 'all' ? undefined : category?.id, language: lang }))?.images ?? []
+        : await getLocalImages(categoryKey, lang) ?? [],
+    );
+    const servableCount = (await filterPlayedCards(headDeck, lang, scope)).length;
+    if (isCycleExhausted(headDeck.length, servableCount)) {
+      await startNewServingCycle(lang, scope).catch(() => {});
+      setImageList(await filterPlayedCards(headDeck, lang, scope));
+    }
+  }, [category?.id, categoryKey, handleImagesLoading, isPrivateScope, lang, privateGroupId, scope]);
+
+  /**
    * Mount loader. Reads the local deck for the active (category, language) and
-   * branches by deck size (e2e mode short-circuits to a fixture/saved card):
-   * - cold (null / length 0) → `handleImagesLoading(null)` (fresh head query,
-   *   bypassing any stale cursor so newly-uploaded images can surface).
-   * - full (length ≥ 4) → use the local deck directly (no fetch).
-   * - partial (1–3) → cursor-based `handleImagesLoading()` (no override → reads
-   *   the persisted cursor); if it returns `false` (cursor exhausted), do ONE
-   *   fresh `handleImagesLoading(null)` head probe — Fix 2a keeps the stored
-   *   real cursor untouched (no rewind, no sentinel pre-write). Only if that
-   *   head probe ALSO returns `false` do we write the SCOPE-CORRECT exhausted
-   *   sentinel (public: `PUBLIC_FEED_END_CURSOR`, private:
-   *   `PRIVATE_FEED_END_CURSOR`) so the exhausted signal survives. The cached
-   *   deck is NOT wiped — only the cursor is replaced.
+   * branches by deck size (e2e mode short-circuits to a fixture/saved card);
+   * every non-e2e branch funnels into `runMountRecoveryFlow` when its filtered
+   * serve comes back empty:
+   * - cold (null / length 0) → cursor-based `handleImagesLoading()` FIRST (I5
+   *   resume), then the shared recovery tail.
+   * - full (length ≥ 4) → serve the played-filtered local deck directly; when
+   *   the filter empties it (every stored card played — the common
+   *   'recent/all' exhaustion entry), run the SAME recovery tail instead of
+   *   dead-ending on the exhausted panel.
+   * - partial (1–3) → played-filtered serve + cursor-based top-up, then the
+   *   shared recovery tail (head probe keeps Fix 2a's append path).
    *
    * @returns {Promise<void>}
    */
@@ -210,39 +294,33 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
     if (localImageList !== null && (localImageList?.length >= 4)) {
       // Review MINOR #1: if every stored card is already in the played-set the
       // filtered deck is EMPTY — serving it would render a blank stack with no
-      // fetch and no noMoreCard signal. Fall through to a cursor-mode load
-      // instead; the refill/fallback machinery owns the rest from there.
+      // fetch and no noMoreCard signal. Run the shared mount recovery tail
+      // instead (cursor round → head probe → sentinel → at most ONE cycle
+      // transition, I4).
       const filtered = await filterPlayedCards(normalizeListIds(localImageList), lang, scope);
       if (filtered.length > 0) {
         setImageList(filtered);
       } else {
-        await handleImagesLoading();
+        await runMountRecoveryFlow(await handleImagesLoading(), { resetServeStateForHead: true });
       }
     } else if (localImageList === null || localImageList?.length === 0) {
-      // Empty category deck on mount — cold-start the ACTIVE category with a
-      // fresh server query (pictureId=null). Do NOT consult the stored cursor:
-      // it may be a stale exhausted marker, and we want new uploads to surface.
-      // Cross-fallback to 'recent/all' belongs to mid-play (refillOrFallback),
-      // once the user is actually swiping and the deck empties.
-      await handleImagesLoading(null);
+      // Empty category deck on mount (I5): cursor-mode FIRST — the persisted
+      // keyset cursor resumes the feed after the last served card. Only an
+      // exhausted cursor round falls back to a fresh head query (new uploads
+      // surface), mirroring the partial-deck branch below — including the
+      // scope-correct sentinel write when both rounds come back empty.
+      // Cross-fallback to 'recent/all' belongs to mid-play (refillOrFallback).
+      const cursorResult = await handleImagesLoading();
+      await runMountRecoveryFlow(cursorResult, { resetServeStateForHead: true });
     } else {
       setImageList(await filterPlayedCards(normalizeListIds(localImageList), lang, scope));
       const cursorResult = await handleImagesLoading();
-      if (cursorResult === false) {
-        // Fix 2a: no sentinel pre-write before the head probe — the probe runs
-        // with the stored REAL cursor intact (head-replay guard keeps it), so
-        // fresh uploads surface without rewinding pagination.
-        const headResult = await handleImagesLoading(null);
-        if (headResult === false) {
-          await saveLastImageUuid(
-            isPrivateScope ? PRIVATE_FEED_END_CURSOR : PUBLIC_FEED_END_CURSOR,
-            categoryKey,
-            lang,
-          );
-        }
-      }
+      // Fix 2a: no serve-state reset before the head probe — the partial deck
+      // keeps the append path (stored REAL cursor intact, no rewind). The
+      // shared recovery tail still applies (I4).
+      await runMountRecoveryFlow(cursorResult, { resetServeStateForHead: false });
     };
-  }, [category?.id, categoryKey, context, handleImagesLoading, isPrivateScope, lang, language, privateGroupId, scope]);
+  }, [category?.id, categoryKey, context, handleImagesLoading, isPrivateScope, lang, language, privateGroupId, runMountRecoveryFlow, scope]);
 
 
   const deleteImage = useCallback(async (id, imageFilePath) => {
@@ -314,6 +392,13 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
 
     // 4. Both empty — last-resort foreground load (will show the overlay, but
     //    only when truly out of cards). Keep on the active category/scope.
+    if (aKey !== 'all') {
+      const exhausted = await isCategoryExhausted(aKey, language, scope).catch(() => false);
+      if (exhausted) {
+        setNoMoreCard('exhausted');
+        return;
+      }
+    }
     await handleImagesLoading();
   }, [context, handleImagesLoading, isPrivateScope, lang, language, privateGroupId, scope]);
 
@@ -337,13 +422,19 @@ export default function SwipeImage({ screenWidth, screenHeight, startGuessing, c
       if (image?.imageFile) {
         await deleteImage(id, image.imageFile);
       }
+      // Synchronous ref sync (beyond the render-phase assignment at the top):
+      // closes the stale-ref window where an in-flight handleData
+      // reconciliation — building its allowed-pictureId set from this ref
+      // before the re-render commits — would resurrect the just-removed card.
+      imageListRef.current = updatedImageList;
       setImageList(updatedImageList);
       if (isPrivateScope) {
-        await writeGroupFeedCache(
-          privateGroupId,
-          { categoryId: aCat?.id === 'all' ? undefined : aCat?.id, language: lang },
-          { images: updatedImageList, nextCursor: null },
-        );
+        await removeCardFromGroupDeck({
+          groupId: privateGroupId,
+          categoryId: aCat?.id === 'all' ? undefined : aCat?.id,
+          language: lang,
+          listId: id,
+        });
       }
 
       // SwipeImage intentionally operates cursor-agnostic; pass undefined so

--- a/screens/GuessScreens/GuessFeedScreen.js
+++ b/screens/GuessScreens/GuessFeedScreen.js
@@ -16,7 +16,13 @@ import { useAuthContext } from '../../store/auth-context';
 import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../../store/privateGroupTheme-context';
 import { handleOrientation } from '../../utils/orientation';
 
-const DEFAULT_LANGUAGE = 'en';
+// Language namespace contract (I6): an unset filter means NO server filter.
+// GuessPathScreen navigates with NAVIGATION_ANY_LANGUAGE ('any') when no stored
+// pick exists, and resolveServerLanguage (cardDeck.js) strips 'any' at the
+// server boundary — mirroring getSessionLanguageFilter's "unset" sentinel
+// (storageDatum.js). A hard 'en' default here made every unset query hit
+// `WHERE language = 'en'` against fr/null rows → empty feed until manual reload.
+const DEFAULT_LANGUAGE = 'any';
 
 // SwipeImage treats `category` and `language` as optional (defaults to 'all' / 'any').
 // GuessFeedScreen is currently the only caller in the authenticated stack, but we

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -9,7 +9,8 @@ import { GlobalStyle } from '../constants/theme';
 import { updateUser, deleteAccount } from '../utils/auth';
 import { AuthContext } from '../store/auth-context';
 import { checkSecureStoreItem } from '../utils/auth';
-import { getPreferredLanguage, savePreferredLanguage } from '../utils/storageDatum';
+import { getPreferredLanguage, savePreferredLanguage, wipePublicGuessStorage } from '../utils/storageDatum';
+import { resetServingCycles } from '../utils/servingCycle';
 import { resolveDefaultLanguage } from '../utils/languageDefaults';
 import CenteredModal from '../components/UI/CenteredModal';
 import LoadingOverlay from '../components/UI/LoadingOverlay';
@@ -118,6 +119,19 @@ const SettingsScreen = ({ navigation }) => {
       'Preferred language saved!',
       `Your preferred language for new enigmas is now: ${code}`
     );
+  };
+
+  const devResetGuessServing = async () => {
+    try {
+      await wipePublicGuessStorage();
+      await resetServingCycles();
+      Alert.alert(
+        'Guess serving reset',
+        'Serving state cleared. Return to the category list and start fresh.'
+      );
+    } catch (error) {
+      Alert.alert('Reset failed', `${error?.message ?? 'Unknown error'}`);
+    }
   };
 
   const handleChangePassword = async () => {
@@ -340,6 +354,21 @@ const SettingsScreen = ({ navigation }) => {
               )}
               </SettingsSection>
             </View>
+
+            {__DEV__ && (
+              <View style={styles.section}>
+                <SettingsSection title="Developer">
+                  <Button
+                    accessibilityLabel="Reset guess serving (dev)"
+                    onPress={() => devResetGuessServing()}
+                    style={styles.button}
+                    testID="settings.button.reset-guess-serving"
+                  >
+                    Reset guess serving (dev)
+                  </Button>
+                </SettingsSection>
+              </View>
+            )}
 
             <View style={styles.dangerZoneContainer}>
               <Text style={styles.dangerZoneText}>Danger Zone</Text>

--- a/services/cardDeck.d.ts
+++ b/services/cardDeck.d.ts
@@ -41,9 +41,17 @@ export interface PersistCardBatchArgs {
   scope?: unknown;
 }
 
+export interface RemoveCardFromGroupDeckArgs {
+  groupId: string;
+  categoryId?: string | number | null;
+  language?: string | null;
+  listId: number;
+}
+
 export function fetchCardBatch(args?: FetchCardBatchArgs): Promise<FetchCardBatchResult>;
 // Fix 3: both write boundaries return their persisted result — the merged/
 // normalized deck that callers (SwipeImage.handleData) use as the numbering
 // source of truth.
 export function appendCardBatch(args?: AppendCardBatchArgs): Promise<CardImage[]>;
 export function persistCardBatch(args?: PersistCardBatchArgs): Promise<CardImage[]>;
+export function removeCardFromGroupDeck(args?: RemoveCardFromGroupDeckArgs): Promise<void>;

--- a/services/cardDeck.d.ts
+++ b/services/cardDeck.d.ts
@@ -48,6 +48,21 @@ export interface RemoveCardFromGroupDeckArgs {
   listId: number;
 }
 
+export interface ProbeAllPoolForUnplayedArgs {
+  language?: string | null;
+  scope?: unknown;
+  authContext?: unknown;
+  excludePictureId?: string;
+}
+
+export type ProbeAllPoolForUnplayedResult =
+  | { status: 'unplayed' }
+  | { status: 'exhausted' }
+  | { status: 'indeterminate'; reason?: 'network' | 'server' | 'probe-cap' };
+
+export const PROBE_MAX_BATCHES: number;
+export function probeAllPoolForUnplayed(args?: ProbeAllPoolForUnplayedArgs): Promise<ProbeAllPoolForUnplayedResult>;
+
 export function fetchCardBatch(args?: FetchCardBatchArgs): Promise<FetchCardBatchResult>;
 // Fix 3: both write boundaries return their persisted result — the merged/
 // normalized deck that callers (SwipeImage.handleData) use as the numbering

--- a/services/cardDeck.d.ts
+++ b/services/cardDeck.d.ts
@@ -42,5 +42,8 @@ export interface PersistCardBatchArgs {
 }
 
 export function fetchCardBatch(args?: FetchCardBatchArgs): Promise<FetchCardBatchResult>;
-export function appendCardBatch(args?: AppendCardBatchArgs): Promise<null>;
-export function persistCardBatch(args?: PersistCardBatchArgs): Promise<null>;
+// Fix 3: both write boundaries return their persisted result — the merged/
+// normalized deck that callers (SwipeImage.handleData) use as the numbering
+// source of truth.
+export function appendCardBatch(args?: AppendCardBatchArgs): Promise<CardImage[]>;
+export function persistCardBatch(args?: PersistCardBatchArgs): Promise<CardImage[]>;

--- a/services/cardDeck.js
+++ b/services/cardDeck.js
@@ -1,5 +1,6 @@
 import { getImages } from '../utils/imagesRequests';
-import { PUBLIC_FEED_END_CURSOR, clearExhaustedCategory, filterPlayedCards, getLastImageUuid, normalizeListIds, storeImageList, updateImageList } from '../utils/storageDatum';
+import { PUBLIC_FEED_END_CURSOR, clearExhaustedCategory, deckWriteLockKey, getLastImageUuid, normalizeListIds, storeImageList, updateImageList } from '../utils/storageDatum';
+import { filterPlayedCards } from '../utils/playedPictureIds';
 import { withScopeLock } from '../utils/scopeMutex';
 import { readGroupFeedCache, writeGroupFeedCache } from './groups/groupFeedCache';
 
@@ -106,7 +107,11 @@ export function fetchCardBatch({ categoryKey, categoryId, language, scope, authC
 
   const p = (async () => {
     const lang = normalizeLanguage(language);
-    const lastImageUuid = await getLastImageUuid(categoryKey, lang);
+    // Scope-aware cursor read (F1/F2): private scopes read the group-scoped
+    // game-cursor key (same key saveLastImageUuid writes on the private
+    // transport path); public/undefined scope keeps the shared
+    // `lastImageUuid:<cat>:<lang>` shape.
+    const lastImageUuid = await getLastImageUuid(categoryKey, lang, scope);
     // Fix 2a: a head fetch (pictureIdOverride === null) over ANY stored cursor
     // value (real uuid or either feed-end sentinel) is a head REPLAY —
     // persisting the head batch's tail would rewind the cursor and re-download
@@ -214,36 +219,51 @@ export async function persistCardBatch({ cards, categoryKey, categoryId, languag
 }
 
 /**
- * Append a card batch to the persisted deck (scope-aware). Mirrors persistCardBatch
- * scope branching but appends instead of overwriting. Used by background prefetch
- * (cardPrefetcher) to grow the deck without losing existing cards.
- * - Public scope: reuses updateImageList (already appends to AsyncStorage).
- * - Private scope: reads the group feed cache, concatenates, writes back.
- * Returns the merged deck; callers use it as the numbering source of truth.
+ * Remove one card from the persisted private-group deck under the shared deck
+ * write lock. Re-reads the PERSISTED deck inside the lock so a stale in-memory
+ * component list cannot erase concurrently prefetched cards.
  *
- * The RMW window (read → concat → write) is serialized per scope via
- * withScopeLock. Key derivation mirrors getDeckCountForScope / groupFeedListKey:
- * (categoryKey|categoryId, language, groupId) → one lock per scope. Closes R2:
- * without the lock, two concurrent appendCardBatch calls for the same scope
- * would both read the prior deck, each concat its own batch, and the later
- * write wins → the earlier batch is orphaned on disk and the deck stays empty.
+ * @param {object} args - { groupId, categoryId, language, listId }
+ * @returns {Promise<void>}
  */
-function appendCardBatchLockKey({ categoryKey, categoryId, language, scope }) {
-  const lang = normalizeLanguage(language);
-  if (isPrivateScope(scope)) {
-    const cid = resolveCategoryId(categoryId);
-    return `cardDeck:append:private:${scope.groupId}:${cid ?? 'all'}:${lang}`;
+export async function removeCardFromGroupDeck({ groupId, categoryId, language, listId } = {}) {
+  if (!groupId) {
+    return;
   }
-  return `cardDeck:append:public:${categoryKey || 'all'}:${lang}`;
+
+  const lang = normalizeLanguage(language);
+  const cid = resolveCategoryId(categoryId);
+
+  await withScopeLock(
+    deckWriteLockKey({ categoryId: cid, language: lang, scope: { kind: 'private', groupId } }),
+    async () => {
+      const existing = await readGroupFeedCache(groupId, { categoryId: cid, language: lang });
+      if (!existing) {
+        return;
+      }
+
+      const prior = Array.isArray(existing.images) ? existing.images : [];
+      const images = prior.filter((card) => card?.listId !== listId);
+      await writeGroupFeedCache(
+        groupId,
+        { categoryId: cid, language: lang },
+        { images, nextCursor: existing?.nextCursor ?? null },
+      );
+    },
+  );
 }
 
 /**
  * Append a batch to the persisted deck, scope-aware (mirrors persistCardBatch
  * but appends instead of overwriting). Dedups incoming cards against the
  * existing deck via dedupByPictureId, then serializes the read-modify-write
- * per scope under withScopeLock. The append lock key (appendCardBatchLockKey)
- * is deliberately separate from the fetch dedup key (fetchBatchDedupKey), so
- * the append lock never blocks the fetch path — no deadlock.
+ * per scope under withScopeLock(deckWriteLockKey(...)) — the SHARED deck-write
+ * lock (see utils/storageDatum.js#deckWriteLockKey). Without the lock, two
+ * concurrent appendCardBatch calls for the same scope would both read the
+ * prior deck, each concat its own batch, and the later write wins → the
+ * earlier batch is orphaned on disk and the deck stays empty. The append lock
+ * key is deliberately separate from the fetch dedup key (fetchBatchDedupKey),
+ * so the append lock never blocks the fetch path — no deadlock.
  *
  * Returns the merged deck; callers use it as the numbering source of truth
  * (Fix 3: the storage boundary is the SINGLE listId writer).
@@ -254,25 +274,28 @@ function appendCardBatchLockKey({ categoryKey, categoryId, language, scope }) {
 export async function appendCardBatch({ cards, categoryKey, categoryId, language, scope } = {}) {
   const lang = normalizeLanguage(language);
 
-  return withScopeLock(appendCardBatchLockKey({ categoryKey, categoryId, language, scope }), async () => {
-    clearExhaustedMarkerIfLanded(cards, categoryKey, lang, scope);
-    const incoming = await filterPlayedCards(cards, lang, scope);
-    if (isPrivateScope(scope)) {
-      const cid = resolveCategoryId(categoryId);
-      const existing = await readGroupFeedCache(scope.groupId, { categoryId: cid, language: lang });
-      const prior = existing?.images ?? [];
-      const deduped = dedupByPictureId(prior, incoming);
-      const merged = normalizeListIds([...prior, ...deduped]);
-      await writeGroupFeedCache(
-        scope.groupId,
-        { categoryId: cid, language: lang },
-        { images: merged, nextCursor: existing?.nextCursor ?? null },
-      );
-      return merged;
-    }
+  return withScopeLock(
+    deckWriteLockKey({ categoryKey, categoryId, language: lang, scope }),
+    async () => {
+      clearExhaustedMarkerIfLanded(cards, categoryKey, lang, scope);
+      const incoming = await filterPlayedCards(cards, lang, scope);
+      if (isPrivateScope(scope)) {
+        const cid = resolveCategoryId(categoryId);
+        const existing = await readGroupFeedCache(scope.groupId, { categoryId: cid, language: lang });
+        const prior = existing?.images ?? [];
+        const deduped = dedupByPictureId(prior, incoming);
+        const merged = normalizeListIds([...prior, ...deduped]);
+        await writeGroupFeedCache(
+          scope.groupId,
+          { categoryId: cid, language: lang },
+          { images: merged, nextCursor: existing?.nextCursor ?? null },
+        );
+        return merged;
+      }
 
-    return await updateImageList(incoming, categoryKey, lang);
-  });
+      return await updateImageList(incoming, categoryKey, lang);
+    },
+  );
 }
 
 /**

--- a/services/cardDeck.js
+++ b/services/cardDeck.js
@@ -1,5 +1,5 @@
 import { getImages } from '../utils/imagesRequests';
-import { PUBLIC_FEED_END_CURSOR, getLastImageUuid, normalizeListIds, storeImageList, updateImageList } from '../utils/storageDatum';
+import { PUBLIC_FEED_END_CURSOR, clearExhaustedCategory, filterPlayedCards, getLastImageUuid, normalizeListIds, storeImageList, updateImageList } from '../utils/storageDatum';
 import { withScopeLock } from '../utils/scopeMutex';
 import { readGroupFeedCache, writeGroupFeedCache } from './groups/groupFeedCache';
 
@@ -107,6 +107,13 @@ export function fetchCardBatch({ categoryKey, categoryId, language, scope, authC
   const p = (async () => {
     const lang = normalizeLanguage(language);
     const lastImageUuid = await getLastImageUuid(categoryKey, lang);
+    // Fix 2a: a head fetch (pictureIdOverride === null) over ANY stored cursor
+    // value (real uuid or either feed-end sentinel) is a head REPLAY —
+    // persisting the head batch's tail would rewind the cursor and re-download
+    // the whole feed on the next top-up. Pass persistCursor:false so getImages
+    // leaves the stored cursor untouched. The conditional spread keeps
+    // non-replay calls 3-arg (existing call-shape pins stay green).
+    const isHeadReplay = pictureIdOverride === null && !!lastImageUuid;
     const pictureId = pictureIdOverride !== undefined ? pictureIdOverride : lastImageUuid;
 
     // Legacy self-heal: prior app versions persisted PUBLIC_FEED_END_CURSOR to
@@ -117,9 +124,14 @@ export function fetchCardBatch({ categoryKey, categoryId, language, scope, authC
     // head; the next non-empty batch overwrites the stale key with a real uuid.
     const effectivePictureId = pictureId === PUBLIC_FEED_END_CURSOR ? null : pictureId;
 
-    return getImages(effectivePictureId, authContext, buildFeedFilters({
-      categoryKey, categoryId, language, scope,
-    }));
+    return getImages(
+      effectivePictureId,
+      authContext,
+      buildFeedFilters({
+        categoryKey, categoryId, language, scope,
+      }),
+      ...(isHeadReplay ? [{ persistCursor: false }] : []),
+    );
   })();
 
   fetchInFlight.set(key, p);
@@ -157,27 +169,48 @@ function buildFeedFilters({ categoryKey, categoryId, language, scope }) {
 }
 
 /**
+ * Clear the exhausted-category marker whenever a NON-EMPTY batch for a real
+ * category lands at a deck-write boundary. Paired writers of the marker —
+ * services/cardPrefetcher.ts:190 (empty background prefetch) and
+ * utils/nextCardAdvancer.ts:169 (empty Tier-2 foreground fetch) — must not
+ * outlive proof that the server still serves the category: a stale marker
+ * blocks every subsequent top-up, so new uploads never surface (Fix 1).
+ * appendCardBatch clears on the RAW incoming batch length (pre-dedup — the
+ * server proved the category non-empty regardless of local duplicates).
+ * Fire-and-forget: the clear is advisory and must never reject the write path.
+ */
+function clearExhaustedMarkerIfLanded(cards, categoryKey, lang, scope) {
+  if (!(Array.isArray(cards) && cards.length > 0 && categoryKey && categoryKey !== 'all')) {
+    return;
+  }
+  clearExhaustedCategory(categoryKey, lang, scope).catch(() => {});
+}
+
+/**
  * Overwrite (not append) the persisted deck for the scope with the given cards.
  * Public scope → storeImageList; private scope → writeGroupFeedCache.
- * Always returns null (callers ignore the deck contents here).
+ * Returns the merged deck's normalized cards; callers (SwipeImage.handleData)
+ * use the RETURN as the numbering source of truth (Fix 3 single-writer).
  *
  * @param {object} args - { cards, categoryKey, categoryId, language, scope }
- * @returns {Promise<null>}
+ * @returns {Promise<Array<object>>} The normalized persisted cards.
  */
 export async function persistCardBatch({ cards, categoryKey, categoryId, language, scope } = {}) {
   const lang = normalizeLanguage(language);
+  const normalized = normalizeListIds(Array.isArray(cards) ? cards : []);
+  clearExhaustedMarkerIfLanded(cards, categoryKey, lang, scope);
 
   if (isPrivateScope(scope)) {
     await writeGroupFeedCache(
       scope.groupId,
       { categoryId: resolveCategoryId(categoryId), language: lang },
-      { images: cards, nextCursor: null },
+      { images: normalized, nextCursor: null },
     );
-    return null;
+    return normalized;
   }
 
-  await storeImageList(cards, categoryKey, lang);
-  return null;
+  await storeImageList(normalized, categoryKey, lang);
+  return normalized;
 }
 
 /**
@@ -186,7 +219,7 @@ export async function persistCardBatch({ cards, categoryKey, categoryId, languag
  * (cardPrefetcher) to grow the deck without losing existing cards.
  * - Public scope: reuses updateImageList (already appends to AsyncStorage).
  * - Private scope: reads the group feed cache, concatenates, writes back.
- * Returns null (matches persistCardBatch return contract).
+ * Returns the merged deck; callers use it as the numbering source of truth.
  *
  * The RMW window (read → concat → write) is serialized per scope via
  * withScopeLock. Key derivation mirrors getDeckCountForScope / groupFeedListKey:
@@ -212,29 +245,33 @@ function appendCardBatchLockKey({ categoryKey, categoryId, language, scope }) {
  * is deliberately separate from the fetch dedup key (fetchBatchDedupKey), so
  * the append lock never blocks the fetch path — no deadlock.
  *
+ * Returns the merged deck; callers use it as the numbering source of truth
+ * (Fix 3: the storage boundary is the SINGLE listId writer).
+ *
  * @param {object} args - { cards, categoryKey, categoryId, language, scope }
- * @returns {Promise<null>} always null (matches persistCardBatch contract)
+ * @returns {Promise<Array<object>>} The new persisted deck (post-dedup/normalize).
  */
 export async function appendCardBatch({ cards, categoryKey, categoryId, language, scope } = {}) {
   const lang = normalizeLanguage(language);
 
   return withScopeLock(appendCardBatchLockKey({ categoryKey, categoryId, language, scope }), async () => {
+    clearExhaustedMarkerIfLanded(cards, categoryKey, lang, scope);
+    const incoming = await filterPlayedCards(cards, lang, scope);
     if (isPrivateScope(scope)) {
       const cid = resolveCategoryId(categoryId);
       const existing = await readGroupFeedCache(scope.groupId, { categoryId: cid, language: lang });
       const prior = existing?.images ?? [];
-      const deduped = dedupByPictureId(prior, cards);
+      const deduped = dedupByPictureId(prior, incoming);
       const merged = normalizeListIds([...prior, ...deduped]);
       await writeGroupFeedCache(
         scope.groupId,
         { categoryId: cid, language: lang },
         { images: merged, nextCursor: existing?.nextCursor ?? null },
       );
-      return null;
+      return merged;
     }
 
-    await updateImageList(cards, categoryKey, lang);
-    return null;
+    return await updateImageList(incoming, categoryKey, lang);
   });
 }
 

--- a/services/cardDeck.js
+++ b/services/cardDeck.js
@@ -1,8 +1,9 @@
 import { getImages } from '../utils/imagesRequests';
-import { PUBLIC_FEED_END_CURSOR, clearExhaustedCategory, deckWriteLockKey, getLastImageUuid, normalizeListIds, storeImageList, updateImageList } from '../utils/storageDatum';
+import { PUBLIC_FEED_END_CURSOR, clearExhaustedCategory, clearLastImageUuid, deckWriteLockKey, getLastImageUuid, normalizeListIds, storeImageList, updateImageList } from '../utils/storageDatum';
 import { filterPlayedCards } from '../utils/playedPictureIds';
 import { withScopeLock } from '../utils/scopeMutex';
 import { readGroupFeedCache, writeGroupFeedCache } from './groups/groupFeedCache';
+import { PRIVATE_FEED_END_CURSOR } from './groups/groupFeedApi';
 
 function normalizeLanguage(language) {
   return language || 'any';
@@ -317,4 +318,74 @@ function dedupByPictureId(prior, incoming) {
     Array.isArray(prior) ? prior.map((c) => c?.pictureId).filter(Boolean) : [],
   );
   return incoming.filter((c) => !c?.pictureId || !priorIds.has(c.pictureId));
+}
+
+/**
+ * Upper bound on how many all-played batches probeAllPoolForUnplayed pages
+ * through before giving up. A cap hit yields 'indeterminate' (fail OPEN: no
+ * cycle transition follows — worst case an exhausted panel, never a repeat),
+ * never a false 'exhausted'.
+ */
+export const PROBE_MAX_BATCHES = 20;
+
+/**
+ * Sound exhaustion proof for the 'all' pool: page the cursor forward
+ * (cursor-mode fetches only — pictureIdOverride stays undefined, NEVER null)
+ * until either an UNPLAYED card lands (pool not exhausted) or the server
+ * returns an empty batch (pool drained — the only valid exhaustion signal).
+ *
+ * Replaces the unsound one-head-batch proof (`tier4.ok && !next`,
+ * `isCycleExhausted(headDeck.length, filtered)`) that treated ONE
+ * played-filtered head batch as whole-pool exhaustion and triggered
+ * premature cycle transitions (validated images re-served, category-only
+ * wipe loop).
+ *
+ * Writes ONLY the feed cursor: the transport's own batch-tail persist plus
+ * one sentinel clear. No cycle-state writes, no servingCycle import
+ * (cycle policy stays storage-only in utils/servingCycle.ts). Transient
+ * fetch failures return 'indeterminate' and mutate nothing (I7).
+ *
+ * Sentinel pre-clear: a stored feed-end cursor (PUBLIC or PRIVATE sentinel)
+ * makes every cursor-mode fetch a no-advance replay (public) or an
+ * exhausted short-circuit (private) — the probe could never move. The mount
+ * path writes that sentinel unsoundly, and clearing a feed-end marker never
+ * rewinds a real cursor (I5 intact).
+ *
+ * @param {object} args - { language, scope, authContext, excludePictureId }
+ * @param {string} [args.excludePictureId] - Just-played card, not yet in the
+ *   played-set at advance time — excluded from the unplayed CHECK only (the
+ *   full batch is still appended through appendCardBatch on success).
+ * @returns {Promise<{status:'unplayed'}|{status:'exhausted'}|{status:'indeterminate', reason:string}>}
+ */
+export async function probeAllPoolForUnplayed({ language, scope, authContext, excludePictureId } = {}) {
+  const lang = normalizeLanguage(language);
+
+  const cursor = await getLastImageUuid('all', lang, scope);
+  if (cursor === PUBLIC_FEED_END_CURSOR || cursor === PRIVATE_FEED_END_CURSOR) {
+    await clearLastImageUuid('all', lang, scope);
+  }
+
+  for (let fetched = 0; fetched < PROBE_MAX_BATCHES; fetched++) {
+    const result = await fetchCardBatch({ categoryKey: 'all', language: lang, scope, authContext });
+
+    if (!result || result.isError === true) {
+      return { status: 'indeterminate', reason: result?.reason ?? 'server' };
+    }
+
+    const batch = Array.isArray(result.images) ? result.images : [];
+    if (batch.length === 0) {
+      return { status: 'exhausted' };
+    }
+
+    const unplayed = await filterPlayedCards(batch, lang, scope);
+    const candidates = excludePictureId
+      ? unplayed.filter((card) => card?.pictureId !== excludePictureId)
+      : unplayed;
+    if (candidates.length > 0) {
+      await appendCardBatch({ cards: batch, categoryKey: 'all', language: lang, scope });
+      return { status: 'unplayed' };
+    }
+  }
+
+  return { status: 'indeterminate', reason: 'probe-cap' };
 }

--- a/services/cardPrefetcher.ts
+++ b/services/cardPrefetcher.ts
@@ -265,7 +265,6 @@ export async function warmAllDeckIfNeeded({
         language,
         scope,
         authContext,
-        pictureIdOverride: null,
       });
       if (r && !r.isError && r.images?.length) {
         // T2.6 defense-in-depth: normalize before append (aligns with T1.9).

--- a/services/cardPrefetcher.ts
+++ b/services/cardPrefetcher.ts
@@ -190,9 +190,7 @@ export async function prefetchIfLow({
           await markCategoryExhausted(categoryKey, language, scope).catch(() => {});
         }
       } catch (e) {
-        if (__DEV__) {
-          console.warn('[cardPrefetcher] prefetch failed', dk, e);
-        }
+        console.warn('[cardPrefetcher] prefetch failed', dk, e);
       }
     }
 
@@ -280,9 +278,7 @@ export async function warmAllDeckIfNeeded({
         });
       }
     } catch (e) {
-      if (__DEV__) {
-        console.warn('[cardPrefetcher] warm-all failed', wk, e);
-      }
+      console.warn('[cardPrefetcher] warm-all failed', wk, e);
     } finally {
       allWarming.delete(wk);
     }

--- a/services/groups/groupFeedApi.js
+++ b/services/groups/groupFeedApi.js
@@ -188,6 +188,12 @@ export async function fetchPrivateFeedPageForGame(pictureId, context, { groupId,
     return { isError: false, images: [] };
   }
 
+  // Group-scoped cursor namespace (F1/F2 review fix): the private transport
+  // cursor + END sentinel persist under `groupFeed:<gid>:game:<cat>:<lang>:cursor`
+  // via saveLastImageUuid's scope param — never the shared public
+  // `lastImageUuid:*` namespace. Legacy unscoped private keys are dead (one
+  // head-probe degradation after update, then the scoped cursor takes over).
+  const cursorScope = { kind: 'private', groupId };
   const response = await fetchPrivateFeedPage(context, {
     groupId,
     cursor: pictureId || null,
@@ -204,13 +210,13 @@ export async function fetchPrivateFeedPageForGame(pictureId, context, { groupId,
 
   if (rows.length === 0) {
     if (persistCursor) {
-      await saveLastImageUuid(PRIVATE_FEED_END_CURSOR, categoryKey, language);
+      await saveLastImageUuid(PRIVATE_FEED_END_CURSOR, categoryKey, language, cursorScope);
     }
     return { isError: false, images: [] };
   }
 
   if (persistCursor) {
-    await saveLastImageUuid(nextCursor ?? PRIVATE_FEED_END_CURSOR, categoryKey, language);
+    await saveLastImageUuid(nextCursor ?? PRIVATE_FEED_END_CURSOR, categoryKey, language, cursorScope);
   }
 
   const downloaded = await Promise.all(

--- a/services/groups/groupFeedApi.js
+++ b/services/groups/groupFeedApi.js
@@ -5,7 +5,7 @@ import Image from '../../models/image';
 import { getBackendHeaders, setHeaders, mapRequestError } from '../../utils/auth';
 import { saveLastImageUuid } from '../../utils/storageDatum';
 
-const PRIVATE_FEED_END_CURSOR = '__private_feed_end__';
+export const PRIVATE_FEED_END_CURSOR = '__private_feed_end__';
 
 function imagesUrl(groupId) {
   return `${process.env.EXPO_PUBLIC_APP_BACKEND_URL}api/v1/private_groups/${groupId}/images`;
@@ -183,7 +183,7 @@ export async function downloadPrivateImage(context, { groupId, imageId }) {
   return extracted || null;
 }
 
-export async function fetchPrivateFeedPageForGame(pictureId, context, { groupId, categoryId, language, categoryKey } = {}) {
+export async function fetchPrivateFeedPageForGame(pictureId, context, { groupId, categoryId, language, categoryKey, persistCursor = true } = {}) {
   if (pictureId === PRIVATE_FEED_END_CURSOR) {
     return { isError: false, images: [] };
   }
@@ -203,11 +203,15 @@ export async function fetchPrivateFeedPageForGame(pictureId, context, { groupId,
   const nextCursor = response.data?.nextCursor ?? null;
 
   if (rows.length === 0) {
-    await saveLastImageUuid(PRIVATE_FEED_END_CURSOR, categoryKey, language);
+    if (persistCursor) {
+      await saveLastImageUuid(PRIVATE_FEED_END_CURSOR, categoryKey, language);
+    }
     return { isError: false, images: [] };
   }
 
-  await saveLastImageUuid(nextCursor ?? PRIVATE_FEED_END_CURSOR, categoryKey, language);
+  if (persistCursor) {
+    await saveLastImageUuid(nextCursor ?? PRIVATE_FEED_END_CURSOR, categoryKey, language);
+  }
 
   const downloaded = await Promise.all(
     rows.map(async (row) => {

--- a/services/groups/groupFeedCache.js
+++ b/services/groups/groupFeedCache.js
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { File, Paths } from 'expo-file-system';
-import { clearAllPrivatePlayedPictureIds, clearPlayedPictureIdsForGroup } from '../../utils/storageDatum';
+import { clearAllPrivatePlayedPictureIds, clearPlayedPictureIdsForGroup } from '../../utils/playedPictureIds';
 
 const PREFIX = 'groupFeed';
 const EXHAUSTED_PREFIX = 'groupFeedExhausted';
@@ -13,11 +13,22 @@ function groupFeedCursorKey(groupId, categoryKey, language) {
   return `${groupFeedListKey(groupId, categoryKey, language)}:cursor`;
 }
 
+/**
+ * Game-path TRANSPORT cursor key (private serving cursor, F1/F2 review fix).
+ * Distinct from groupFeedCursorKey (deck-cache `{nextCursor}` JSON written by
+ * writeGroupFeedCache) via the `game:` category-segment marker, and shaped to
+ * match the servingCycle group-branch clear (`groupFeed:<gid>:*:<lang>:cursor`)
+ * so a cycle transition wipes it together with the other group cursors.
+ */
+function groupGameCursorKey(groupId, categoryKey, language) {
+  return `${PREFIX}:${groupId}:game:${categoryKey || 'all'}:${language || 'any'}:cursor`;
+}
+
 function groupFeedExhaustedKey(groupId, categoryKey, language) {
   return `${EXHAUSTED_PREFIX}:${groupId}:${categoryKey || 'all'}:${language || 'any'}`;
 }
 
-export { groupFeedListKey, groupFeedCursorKey, groupFeedExhaustedKey };
+export { groupFeedListKey, groupFeedCursorKey, groupGameCursorKey, groupFeedExhaustedKey };
 
 function localFileExists(uri) {
   try {

--- a/services/groups/groupFeedCache.js
+++ b/services/groups/groupFeedCache.js
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { File, Paths } from 'expo-file-system';
+import { clearAllPrivatePlayedPictureIds, clearPlayedPictureIdsForGroup } from '../../utils/storageDatum';
 
 const PREFIX = 'groupFeed';
 const EXHAUSTED_PREFIX = 'groupFeedExhausted';
@@ -97,6 +98,8 @@ export async function clearGroupFeedCache(groupId) {
   if (target.length > 0) {
     await AsyncStorage.multiRemove(target);
   }
+
+  await clearPlayedPictureIdsForGroup(groupId);
 }
 
 export async function clearAllGroupFeedCaches() {
@@ -150,6 +153,7 @@ function isPrivateCacheUri(uri) {
 export async function purgeAllPrivateCaches() {
   await clearAllGroupFeedCaches();
   await clearAllGroupFeedExhaustedMarkers();
+  await clearAllPrivatePlayedPictureIds();
 
   try {
     Paths.cache.create({ idempotent: true, intermediates: true });

--- a/store/auth-context.js
+++ b/store/auth-context.js
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useRef, useState } from "react";
 import * as SecureStore from 'expo-secure-store';
 
 import { setUnauthorizedHandler } from "../utils/apiClient";
-import { emptyImageList } from "../utils/storageDatum";
+import { wipePublicGuessStorage } from "../utils/storageDatum";
 import { flush } from "../utils/sessionScoreStore";
 
 export const AuthContext = createContext({
@@ -221,7 +221,7 @@ export default function AuthContextProvider({ children }) {
   };
 
   async function authenticate({token, userId, email, username, isTutorialFinished, scoreId, isPaid, paidTier, paidExpiresAt, isGroupOwner, activeGroupId}) {
-    await emptyImageList();
+    await wipePublicGuessStorage();
 
     setAuthToken(token);
     await SecureStore.setItemAsync('token', token);
@@ -296,7 +296,7 @@ export default function AuthContextProvider({ children }) {
       await SecureStore.deleteItemAsync('activeGroupId');
       await SecureStore.deleteItemAsync('isPrivateMode');
 
-      await emptyImageList();
+      await wipePublicGuessStorage();
 
       await teardownCreatorBilling();
 

--- a/utils/handleGuessOutcome.js
+++ b/utils/handleGuessOutcome.js
@@ -1,5 +1,6 @@
 import { bufferScore, mintGuessId } from './sessionScoreStore';
-import { addPlayedPictureId, removeImageFromList, deleteImageFromStorage } from './storageDatum';
+import { removeImageFromList, deleteImageFromStorage } from './storageDatum';
+import { addPlayedPictureId } from './playedPictureIds';
 import { resolveNextCard } from './nextCardResolver';
 import { SPEED_MULTIPLIER_BASE } from './speedMultiplier';
 

--- a/utils/handleGuessOutcome.js
+++ b/utils/handleGuessOutcome.js
@@ -1,5 +1,5 @@
 import { bufferScore, mintGuessId } from './sessionScoreStore';
-import { removeImageFromList, deleteImageFromStorage } from './storageDatum';
+import { addPlayedPictureId, removeImageFromList, deleteImageFromStorage } from './storageDatum';
 import { resolveNextCard } from './nextCardResolver';
 import { SPEED_MULTIPLIER_BASE } from './speedMultiplier';
 
@@ -29,6 +29,7 @@ export async function applySuccessSideEffects({ listId, categoryKey, language, i
   });
 
   try {
+    addPlayedPictureId(pictureId, language, scope).catch(() => {});
     await removeImageFromList(listId, categoryKey, language);
     await deleteImageFromStorage(imageFile);
   } catch (e) {

--- a/utils/imagesRequests.js
+++ b/utils/imagesRequests.js
@@ -430,10 +430,13 @@ export async function getImages(pictureId, context, filters = {}, opts = {}) {
 
   if (isPrivateScope(filters?.scope)) {
     // Private cursor namespace: PRIVATE filters carry no category_key (server
-    // contract stays category_id), so derive the LOCAL cursor/exhausted
-    // namespace from the category id (or 'all'). cardDeck.fetchCardBatch reads
-    // the cursor with the same categoryKey value, so the private cursor
-    // round-trips instead of falling back to the shared public 'all' key.
+    // contract stays category_id), so derive the LOCAL cursor category segment
+    // from the category id (or 'all'). cardDeck.fetchCardBatch reads the
+    // cursor with the same categoryKey value, so the private cursor
+    // round-trips. Persistence itself is GROUP-SCOPED (F1/F2):
+    // fetchPrivateFeedPageForGame threads { kind: 'private', groupId } into
+    // saveLastImageUuid, landing at `groupFeed:<gid>:game:<cat>:<lang>:cursor`
+    // — never the shared public `lastImageUuid:*` namespace.
     return fetchPrivateFeedPageForGame(pictureId, context, {
       groupId: filters.scope.groupId,
       categoryId: filters?.category_id,

--- a/utils/imagesRequests.js
+++ b/utils/imagesRequests.js
@@ -415,11 +415,18 @@ async function downloadImageBatch(imagesInfosData, token) {
  *   previous page, or `null` for the first page.
  * @param {Object}      context   Auth context (forwarded to `getBackendHeaders`).
  * @param {Object}      [filters] Optional `{ category_id, language, category_key, scope }`.
+ * @param {Object}      [opts]    Optional `{ persistCursor }` — transport flag;
+ *   `false` suppresses every `saveLastImageUuid` cursor write (head-replay
+ *   guard, Fix 2a). Defaults to `true` (cursor advances as before).
  * @returns {Promise<GetImagesResult>}
  */
-export async function getImages(pictureId, context, filters = {}) {
+// SRP tradeoff (Fix 2a, plan §2.5): `persistCursor` is a transport-persistence
+// concern riding this request function. Splitting cursor persistence out of
+// getImages was reviewed and deferred — the flag stays until that refactor.
+export async function getImages(pictureId, context, filters = {}, opts = {}) {
   console.log("getImages");
   console.log("getImages pictureId", pictureId);
+  const { persistCursor = true } = opts;
 
   if (isPrivateScope(filters?.scope)) {
     // Private cursor namespace: PRIVATE filters carry no category_key (server
@@ -432,6 +439,7 @@ export async function getImages(pictureId, context, filters = {}) {
       categoryId: filters?.category_id,
       language: filters?.language,
       categoryKey: filters?.category_key ?? filters?.category_id ?? 'all',
+      persistCursor,
     });
   }
 
@@ -473,7 +481,9 @@ export async function getImages(pictureId, context, filters = {}) {
     const { images, sawNetworkFailure } = await downloadImageBatch(imagesInfosData, token);
 
     if (images.length > 0) {
-      await saveLastImageUuid(lastBatchPictureId, filters?.category_key, filters?.language);
+      if (persistCursor) {
+        await saveLastImageUuid(lastBatchPictureId, filters?.category_key, filters?.language);
+      }
       return { isError: false, images: images };
     }
 
@@ -486,7 +496,9 @@ export async function getImages(pictureId, context, filters = {}) {
       };
     }
 
-    await saveLastImageUuid(lastBatchPictureId, filters?.category_key, filters?.language);
+    if (persistCursor) {
+      await saveLastImageUuid(lastBatchPictureId, filters?.category_key, filters?.language);
+    }
     skippedBrokenBatches += 1;
     nextPictureId = lastBatchPictureId;
   }

--- a/utils/nextCardAdvancer.ts
+++ b/utils/nextCardAdvancer.ts
@@ -17,6 +17,7 @@ import { resolveNextGuessParams } from './handleGuessOutcome';
 import { fetchCardBatch, appendCardBatch } from '../services/cardDeck';
 import { warmAllDeckIfNeeded, getInFlightPrefetch, getPrefetchScopeKey } from '../services/cardPrefetcher';
 import { isCategoryExhausted, markCategoryExhausted } from './storageDatum';
+import { startNewServingCycle, ServingScope } from './servingCycle';
 
 export type NextGuessResult = { params: Record<string, unknown> } | null | undefined;
 
@@ -241,6 +242,35 @@ export async function resolveNextCardWithServerFallback({
   if (tier4.ok) {
     next = await resolveNextGuessParams(resolveArgs);
     if (next) return { next, reason: 'ok' };
+
+    // Cycle transition (B1, epoch-bookkept): tier4.ok && !next is the
+    // ALL_EXHAUSTED proof — the server served ≥1 card yet nothing resolves,
+    // i.e. isCycleExhausted(tier4.appended, 0): every servable card sits in
+    // the played-set. startNewServingCycle bumps the cycle epoch and clears
+    // the scope+language played-set + stale cursors/markers ONCE
+    // (cross-category is intended: Tier 4 only fires once the category AND
+    // 'all' are exhausted), so looping 'all' starts a NEW cycle at the deck
+    // head. tier4.ok === false NEVER transitions: TRANSIENT_EMPTY
+    // (network/server) and genuine empty keep the existing failureReasons
+    // flow — no epoch bump, no played-set clear.
+    // Head-cursor args (currentListId: undefined): the fresh deck renumbers
+    // listIds 1..N, and the just-played currentListId can be ≥ the fresh max
+    // (listId wrap at the cycle boundary) — a stale cursor would re-dead-end
+    // the resolve. resolveArgs.currentPictureId exclusion survives via the
+    // spread. The free local re-resolve runs BEFORE any retry: the 'all' deck
+    // retains cross-namespace played cards now servable in the new cycle, at
+    // zero extra roundtrips. Bound: at most ONE extra head fetch per cycle
+    // exhaustion (the single retry below) — never more.
+    await startNewServingCycle(language, scope as ServingScope).catch(() => {});
+    const headCursorArgs = { ...resolveArgs, currentListId: undefined };
+    next = await resolveNextGuessParams(headCursorArgs);
+    if (next) return { next, reason: 'ok' };
+
+    const tier4Retry = await foregroundTopUp(tier4Args, 'all', null);
+    if (tier4Retry.ok) {
+      next = await resolveNextGuessParams(headCursorArgs);
+      if (next) return { next, reason: 'ok' };
+    }
   } else {
     failureReasons.push(tier4.reason);
   }

--- a/utils/nextCardAdvancer.ts
+++ b/utils/nextCardAdvancer.ts
@@ -14,7 +14,7 @@
 // category, the 'all' cross-fallback is also empty).
 
 import { resolveNextGuessParams } from './handleGuessOutcome';
-import { fetchCardBatch, appendCardBatch } from '../services/cardDeck';
+import { fetchCardBatch, appendCardBatch, probeAllPoolForUnplayed } from '../services/cardDeck';
 import { warmAllDeckIfNeeded, getInFlightPrefetch, getPrefetchScopeKey } from '../services/cardPrefetcher';
 import { isCategoryExhausted, markCategoryExhausted } from './storageDatum';
 import { startNewServingCycle, ServingScope } from './servingCycle';
@@ -243,33 +243,60 @@ export async function resolveNextCardWithServerFallback({
     next = await resolveNextGuessParams(resolveArgs);
     if (next) return { next, reason: 'ok' };
 
-    // Cycle transition (B1, epoch-bookkept): tier4.ok && !next is the
-    // ALL_EXHAUSTED proof — the server served ≥1 card yet nothing resolves,
-    // i.e. isCycleExhausted(tier4.appended, 0): every servable card sits in
-    // the played-set. startNewServingCycle bumps the cycle epoch and clears
-    // the scope+language played-set + stale cursors/markers ONCE
-    // (cross-category is intended: Tier 4 only fires once the category AND
-    // 'all' are exhausted), so looping 'all' starts a NEW cycle at the deck
-    // head. tier4.ok === false NEVER transitions: TRANSIENT_EMPTY
-    // (network/server) and genuine empty keep the existing failureReasons
-    // flow — no epoch bump, no played-set clear.
-    // Head-cursor args (currentListId: undefined): the fresh deck renumbers
-    // listIds 1..N, and the just-played currentListId can be ≥ the fresh max
-    // (listId wrap at the cycle boundary) — a stale cursor would re-dead-end
-    // the resolve. resolveArgs.currentPictureId exclusion survives via the
-    // spread. The free local re-resolve runs BEFORE any retry: the 'all' deck
-    // retains cross-namespace played cards now servable in the new cycle, at
-    // zero extra roundtrips. Bound: at most ONE extra head fetch per cycle
-    // exhaustion (the single retry below) — never more.
-    await startNewServingCycle(language, scope as ServingScope).catch(() => {});
-    const headCursorArgs = { ...resolveArgs, currentListId: undefined };
-    next = await resolveNextGuessParams(headCursorArgs);
-    if (next) return { next, reason: 'ok' };
+    // Probe (Step 3, Bug 1): tier4.ok && !next only proves that ONE
+    // played-filtered HEAD batch of 'all' resolved to nothing — NOT
+    // whole-pool exhaustion (the head batch is the oldest N rows; rows N+1+
+    // may still be unplayed). probeAllPoolForUnplayed pages the 'all' cursor
+    // chain forward to a sound verdict:
+    // - 'unplayed': the probe appended ≥1 unplayed card to the 'all' deck —
+    //   the free LOCAL re-resolve below serves it with NO cycle transition
+    //   (rows N+1+ now serve at the category→'all' handoff; kills the Bug 1
+    //   premature played-set wipe that re-served validated cards).
+    // - 'exhausted': pool-global proof — the probe drained the 'all' cursor
+    //   chain to a server-empty batch. Only then does the CYCLE_TRANSITION
+    //   fire (startNewServingCycle: epoch bump + played-set/cursor/marker
+    //   clear ONCE, cross-category by design), so looping 'all' starts a NEW
+    //   cycle at the deck head.
+    // - 'indeterminate': transient failure or probe cap — NEVER transitions
+    //   (I7); the typed null result carries the accumulated reason.
+    // excludePictureId: the just-won card is not yet in the played-set at
+    // advance time, so it is excluded from the probe's unplayed check only.
+    const probe = await probeAllPoolForUnplayed({
+      language,
+      scope,
+      authContext,
+      excludePictureId: currentPictureId,
+    });
 
-    const tier4Retry = await foregroundTopUp(tier4Args, 'all', null);
-    if (tier4Retry.ok) {
+    if (probe?.status === 'unplayed') {
+      // NO transition — the probe just appended unplayed cards beyond the
+      // played head batch; the free local re-resolve serves them.
+      next = await resolveNextGuessParams(resolveArgs);
+      if (next) return { next, reason: 'ok' };
+    } else if (probe?.status === 'exhausted') {
+      // Cycle transition (B1, epoch-bookkept): the proof is now POOL-GLOBAL
+      // (the probe drained the 'all' cursor chain to server-empty), not
+      // head-batch-local. Head-cursor args (currentListId: undefined): the
+      // fresh deck renumbers listIds 1..N, and the just-played currentListId
+      // can be ≥ the fresh max (listId wrap at the cycle boundary) — a stale
+      // cursor would re-dead-end the resolve. resolveArgs.currentPictureId
+      // exclusion survives via the spread. The free local re-resolve runs
+      // BEFORE any retry: the 'all' deck retains cross-namespace played cards
+      // now servable in the new cycle, at zero extra roundtrips. Bound: at
+      // most ONE extra head fetch per cycle exhaustion (the single retry
+      // below) — never more.
+      await startNewServingCycle(language, scope as ServingScope).catch(() => {});
+      const headCursorArgs = { ...resolveArgs, currentListId: undefined };
       next = await resolveNextGuessParams(headCursorArgs);
       if (next) return { next, reason: 'ok' };
+
+      const tier4Retry = await foregroundTopUp(tier4Args, 'all', null);
+      if (tier4Retry.ok) {
+        next = await resolveNextGuessParams(headCursorArgs);
+        if (next) return { next, reason: 'ok' };
+      }
+    } else if (probe?.status === 'indeterminate') {
+      failureReasons.push((probe.reason ?? 'server') as FailureReason);
     }
   } else {
     failureReasons.push(tier4.reason);

--- a/utils/playedPictureIds.d.ts
+++ b/utils/playedPictureIds.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Type declarations for `utils/playedPictureIds.js`. The runtime module is
+ * plain JavaScript; these declarations pin the structured-args contract
+ * actually used at runtime.
+ */
+
+import type { CardImage } from '../services/cardDeck';
+
+// F2b played-picture set (scope-aware: public vs per-group, per-language).
+// Shared memory of recently played pictureIds so fall-through/replay paths
+// skip just-played cards. Cap-evicted (most recent 200 kept).
+export const PLAYED_PICTURE_IDS_PREFIX: string;
+export function playedPictureIdsKey(language: string | null | undefined, scope: unknown): string;
+export function getPlayedPictureIds(language: string | null | undefined, scope: unknown): Promise<string[]>;
+export function addPlayedPictureId(pictureId: string | null | undefined, language: string | null | undefined, scope: unknown): Promise<void>;
+export function filterPlayedCards(cards: CardImage[], language: string | null | undefined, scope: unknown): Promise<CardImage[]>;
+export function clearPlayedPictureIdsForGroup(groupId: string): Promise<void>;
+export function clearAllPrivatePlayedPictureIds(): Promise<void>;
+// Fix 1 replay-cycle restart: clears the WHOLE scope+language played-set under
+// the SAME lock key as addPlayedPictureId, so an in-flight add cannot write
+// stale ids after the reset.
+export function resetPlayedPictureIdsForScope(language: string | null | undefined, scope: unknown): Promise<void>;

--- a/utils/playedPictureIds.js
+++ b/utils/playedPictureIds.js
@@ -1,0 +1,83 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { withScopeLock } from './scopeMutex';
+
+const PLAYED_PICTURE_IDS_CAP = 200;
+export const PLAYED_PICTURE_IDS_PREFIX = 'playedPictureIds';
+
+function isPrivateScope(scope) {
+  return scope?.kind === 'private' && scope?.groupId;
+}
+
+export function playedPictureIdsKey(language, scope) {
+  return `${PLAYED_PICTURE_IDS_PREFIX}:${isPrivateScope(scope) ? `group:${scope.groupId}` : 'public'}:${language || 'any'}`;
+};
+
+export async function getPlayedPictureIds(language, scope) {
+  const stored = await AsyncStorage.getItem(playedPictureIdsKey(language, scope));
+  if (!stored) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+export async function addPlayedPictureId(pictureId, language, scope) {
+  if (!pictureId) {
+    return;
+  }
+  const key = playedPictureIdsKey(language, scope);
+
+  await withScopeLock(key, async () => {
+    const played = await getPlayedPictureIds(language, scope);
+    if (played.includes(pictureId)) {
+      return;
+    }
+    const next = [...played, pictureId].slice(-PLAYED_PICTURE_IDS_CAP);
+    await AsyncStorage.setItem(key, JSON.stringify(next));
+  });
+};
+
+export async function filterPlayedCards(cards, language, scope) {
+  if (!Array.isArray(cards)) {
+    return [];
+  }
+  let playedIds;
+  try {
+    playedIds = await getPlayedPictureIds(language, scope);
+  } catch {
+    return cards;
+  }
+  if (playedIds.length === 0) {
+    return cards;
+  }
+  const played = new Set(playedIds);
+  return cards.filter((card) => !card?.pictureId || !played.has(card.pictureId));
+};
+
+async function removeKeysByPrefix(prefix) {
+  const keys = await AsyncStorage.getAllKeys();
+  const target = keys.filter((key) => typeof key === 'string' && key.startsWith(prefix));
+  if (target.length > 0) {
+    await AsyncStorage.multiRemove(target);
+  }
+};
+
+export async function clearPlayedPictureIdsForGroup(groupId) {
+  await removeKeysByPrefix(`${PLAYED_PICTURE_IDS_PREFIX}:group:${groupId}:`);
+};
+
+export async function clearAllPrivatePlayedPictureIds() {
+  await removeKeysByPrefix(`${PLAYED_PICTURE_IDS_PREFIX}:group:`);
+};
+
+export async function resetPlayedPictureIdsForScope(language, scope) {
+  const key = playedPictureIdsKey(language, scope);
+
+  await withScopeLock(key, async () => {
+    await AsyncStorage.removeItem(key);
+  });
+};

--- a/utils/servingCycle.ts
+++ b/utils/servingCycle.ts
@@ -1,0 +1,114 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { withScopeLock } from './scopeMutex';
+import { resetPlayedPictureIdsForScope } from './playedPictureIds';
+
+export const SERVING_CYCLE_PREFIX = 'servingCycle';
+const LAST_IMAGE_UUID_KEY_PREFIX = 'lastImageUuid:';
+const EXHAUSTED_CATEGORY_KEY_PREFIX = 'exhaustedCategory:';
+const GROUP_FEED_KEY_PREFIX = 'groupFeed:';
+const GROUP_FEED_EXHAUSTED_KEY_PREFIX = 'groupFeedExhausted:';
+
+export type ServingScope = { kind?: string; groupId?: string } | null | undefined;
+
+function isGroupScope(scope: ServingScope): scope is { kind: string; groupId: string } {
+  return scope?.kind === 'private' && !!scope.groupId;
+}
+
+export function servingCycleKey(language: string | null | undefined, scope: ServingScope): string {
+  return `${SERVING_CYCLE_PREFIX}:${isGroupScope(scope) ? `group:${scope.groupId}` : 'public'}:${language || 'any'}`;
+}
+
+export async function getServingCycleEpoch(
+  language: string | null | undefined,
+  scope: ServingScope,
+): Promise<number> {
+  const stored = await AsyncStorage.getItem(servingCycleKey(language, scope));
+  const parsed = parseInt(stored ?? '', 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export async function startNewServingCycle(
+  language: string | null | undefined,
+  scope: ServingScope,
+): Promise<number> {
+  const key = servingCycleKey(language, scope);
+  return withScopeLock(key, async () => {
+    const current = await getServingCycleEpoch(language, scope);
+    const next = current + 1;
+    await AsyncStorage.setItem(key, String(next));
+    // Lock order: servingCycle→played only; playedPictureIds.js never imports
+    // servingCycle → no inverse order, no deadlock.
+    await resetPlayedPictureIdsForScope(language, scope);
+    await clearStaleCycleCursorsAndMarkers(language, scope);
+    return next;
+  });
+}
+
+/**
+ * A2: a stale cursor parked at the old feed-end makes every cursor-mode fetch
+ * miss forever (head replays persist nothing, cardDeck.js:117), and an
+ * `exhaustedCategory:all` marker never auto-clears (clearExhaustedMarkerIfLanded
+ * excludes 'all'). Both must go under the SAME epoch lock/transition, scoped to
+ * (scope, language): public clears `lastImageUuid:*:<lang>` cursors +
+ * `exhaustedCategory:*:<lang>` markers; group parity clears this group's
+ * `groupFeed:<gid>:*:<lang>:cursor` entries + `groupFeedExhausted:<gid>:*:<lang>`
+ * markers. Key shapes mirror utils/storageDatum.js and
+ * services/groups/groupFeedCache.js (no import — module stays
+ * AsyncStorage + scopeMutex + playedPictureIds).
+ */
+async function clearStaleCycleCursorsAndMarkers(
+  language: string | null | undefined,
+  scope: ServingScope,
+): Promise<void> {
+  const lang = language || 'any';
+  const langSuffix = `:${lang}`;
+  const keys = await AsyncStorage.getAllKeys();
+
+  const matches = (key: unknown, prefix: string, suffix: string): key is string =>
+    typeof key === 'string' && key.startsWith(prefix) && key.endsWith(suffix);
+
+  // Private game-path transport cursor is being relocated to the
+  // groupFeed:<gid>:<cat>:<lang> namespace (parallel agent), making the :cursor
+  // clear operative; legacy unscoped lastImageUuid:* private keys are dead
+  // garbage cleared only by dev wipe.
+  const groupId = isGroupScope(scope) ? scope.groupId : undefined;
+  const target = groupId
+    ? keys.filter(
+        (key) =>
+          matches(key, `${GROUP_FEED_KEY_PREFIX}${groupId}:`, `${langSuffix}:cursor`) ||
+          matches(key, `${GROUP_FEED_EXHAUSTED_KEY_PREFIX}${groupId}:`, langSuffix),
+      )
+    : keys.filter(
+        (key) =>
+          matches(key, LAST_IMAGE_UUID_KEY_PREFIX, langSuffix) ||
+          matches(key, EXHAUSTED_CATEGORY_KEY_PREFIX, langSuffix),
+      );
+
+  if (target.length > 0) {
+    await AsyncStorage.multiRemove(target);
+  }
+}
+
+async function removeKeysByPrefix(prefix: string): Promise<void> {
+  const keys = await AsyncStorage.getAllKeys();
+  const target = keys.filter((key) => typeof key === 'string' && key.startsWith(prefix));
+  if (target.length > 0) {
+    await AsyncStorage.multiRemove(target);
+  }
+}
+
+export async function resetServingCycles(): Promise<void> {
+  await removeKeysByPrefix(`${SERVING_CYCLE_PREFIX}:`);
+}
+
+/**
+ * I4 proof predicate: repeats are impossible until 'all' is PROVEN exhausted.
+ * Proof = the server served at least one card (serverBatchCount > 0) but the
+ * played-filtered resolve is empty (servableCount === 0) — every card the
+ * server offered has already been played this cycle. Any other combination
+ * (server genuinely empty, or unplayed cards still servable) is NOT cycle
+ * exhaustion and must never trigger a cycle transition.
+ */
+export function isCycleExhausted(serverBatchCount: number, servableCount: number): boolean {
+  return serverBatchCount > 0 && servableCount === 0;
+}

--- a/utils/storageDatum.d.ts
+++ b/utils/storageDatum.d.ts
@@ -12,6 +12,18 @@
 
 import type { CardImage } from '../services/cardDeck';
 
+export interface DeckWriteLockScope {
+  kind?: string;
+  groupId?: string;
+}
+
+export interface DeckWriteLockKeyArgs {
+  categoryKey?: string | null;
+  categoryId?: string | number | null;
+  language?: string | null;
+  scope?: DeckWriteLockScope | null;
+}
+
 export interface RemainingDeckCategory {
   key: string;
   id?: string | number;
@@ -32,11 +44,14 @@ export interface ScopeDeckCountArgs {
 
 export function getRemainingDeckCount(args?: RemainingDeckCountArgs): Promise<number>;
 export function getDeckCountForScope(args?: ScopeDeckCountArgs): Promise<number>;
+export function deckWriteLockKey(args?: DeckWriteLockKeyArgs): string;
 // Guarantee every card has a finite, UNIQUE listId: assigns ids for
 // missing/non-finite listIds AND reassigns later duplicates past the deck's
 // pre-pass max. Healthy decks (no missing, no duplicate finite ids) return
 // the input array by identity.
 export function normalizeListIds(cards: CardImage[]): CardImage[];
+export function removeImageFromList(listId: number, categoryKey?: string | null, language?: string | null): Promise<null>;
+export function wipePublicGuessStorage(): Promise<void>;
 
 export interface NextImagesForScopeArgs {
   category?: { key?: string; id?: string | number };
@@ -59,12 +74,3 @@ export function markCategoryExhausted(categoryKey: string | null | undefined, la
 export function isCategoryExhausted(categoryKey: string | null | undefined, language: string | null | undefined, scope: unknown): Promise<boolean>;
 export function clearExhaustedCategory(categoryKey: string | null | undefined, language: string | null | undefined, scope: unknown): Promise<void>;
 
-// F2b played-picture set (scope-aware: public vs per-group, per-language).
-// Shared memory of recently played pictureIds so fall-through/replay paths
-// skip just-played cards. Cap-evicted (most recent 200 kept).
-export function playedPictureIdsKey(language: string | null | undefined, scope: unknown): string;
-export function getPlayedPictureIds(language: string | null | undefined, scope: unknown): Promise<string[]>;
-export function addPlayedPictureId(pictureId: string | null | undefined, language: string | null | undefined, scope: unknown): Promise<void>;
-export function filterPlayedCards(cards: CardImage[], language: string | null | undefined, scope: unknown): Promise<CardImage[]>;
-export function clearPlayedPictureIdsForGroup(groupId: string): Promise<void>;
-export function clearAllPrivatePlayedPictureIds(): Promise<void>;

--- a/utils/storageDatum.d.ts
+++ b/utils/storageDatum.d.ts
@@ -32,6 +32,10 @@ export interface ScopeDeckCountArgs {
 
 export function getRemainingDeckCount(args?: RemainingDeckCountArgs): Promise<number>;
 export function getDeckCountForScope(args?: ScopeDeckCountArgs): Promise<number>;
+// Guarantee every card has a finite, UNIQUE listId: assigns ids for
+// missing/non-finite listIds AND reassigns later duplicates past the deck's
+// pre-pass max. Healthy decks (no missing, no duplicate finite ids) return
+// the input array by identity.
 export function normalizeListIds(cards: CardImage[]): CardImage[];
 
 export interface NextImagesForScopeArgs {
@@ -54,3 +58,13 @@ export function exhaustedCategoryKey(categoryKey: string | null | undefined, lan
 export function markCategoryExhausted(categoryKey: string | null | undefined, language: string | null | undefined, scope: unknown): Promise<void>;
 export function isCategoryExhausted(categoryKey: string | null | undefined, language: string | null | undefined, scope: unknown): Promise<boolean>;
 export function clearExhaustedCategory(categoryKey: string | null | undefined, language: string | null | undefined, scope: unknown): Promise<void>;
+
+// F2b played-picture set (scope-aware: public vs per-group, per-language).
+// Shared memory of recently played pictureIds so fall-through/replay paths
+// skip just-played cards. Cap-evicted (most recent 200 kept).
+export function playedPictureIdsKey(language: string | null | undefined, scope: unknown): string;
+export function getPlayedPictureIds(language: string | null | undefined, scope: unknown): Promise<string[]>;
+export function addPlayedPictureId(pictureId: string | null | undefined, language: string | null | undefined, scope: unknown): Promise<void>;
+export function filterPlayedCards(cards: CardImage[], language: string | null | undefined, scope: unknown): Promise<CardImage[]>;
+export function clearPlayedPictureIdsForGroup(groupId: string): Promise<void>;
+export function clearAllPrivatePlayedPictureIds(): Promise<void>;

--- a/utils/storageDatum.js
+++ b/utils/storageDatum.js
@@ -1,11 +1,15 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { File, Paths } from "expo-file-system";
+import { withScopeLock } from "./scopeMutex";
 import {
   readGroupFeedCache,
   markGroupCategoryExhausted,
   isGroupCategoryExhausted,
   clearGroupCategoryExhausted,
+  groupGameCursorKey,
 } from "../services/groups/groupFeedCache";
+import { filterPlayedCards, playedPictureIdsKey, PLAYED_PICTURE_IDS_PREFIX } from "./playedPictureIds";
+import { SERVING_CYCLE_PREFIX } from "./servingCycle";
 
 const E2E_HIDDEN_GUESS_CARD_KEY = 'e2eHiddenGuessCard';
 const SESSION_LANGUAGE_FILTER_KEY = 'sessionLanguageFilter';
@@ -14,23 +18,52 @@ const ONBOARDING_COMPLETED_KEY = 'onboardingCompleted';
 const USER_TAGS_KEY = 'userTags';
 const DEFAULT_LANGUAGE = 'en';
 export const PUBLIC_FEED_END_CURSOR = '__public_feed_end__';
-const PLAYED_PICTURE_IDS_CAP = 200;
-const PLAYED_PICTURE_IDS_PREFIX = 'playedPictureIds';
+const IMAGE_LIST_KEY_PREFIX = 'imageList:';
+const LAST_IMAGE_UUID_KEY_PREFIX = 'lastImageUuid:';
+const EXHAUSTED_CATEGORY_KEY_PREFIX = 'exhaustedCategory:';
 
 function imageListKey(categoryKey, language) {
-  return `imageList:${categoryKey || 'all'}:${language || 'any'}`;
+  return `${IMAGE_LIST_KEY_PREFIX}${categoryKey || 'all'}:${language || 'any'}`;
 };
 
 function lastImageUuidKey(categoryKey, language) {
-  return `lastImageUuid:${categoryKey || 'all'}:${language || 'any'}`;
+  return `${LAST_IMAGE_UUID_KEY_PREFIX}${categoryKey || 'all'}:${language || 'any'}`;
 };
 
 export function exhaustedCategoryKey(categoryKey, language) {
-  return `exhaustedCategory:${categoryKey || 'all'}:${language || 'any'}`;
+  return `${EXHAUSTED_CATEGORY_KEY_PREFIX}${categoryKey || 'all'}:${language || 'any'}`;
 };
 
 function isPrivateScope(scope) {
   return scope?.kind === 'private' && scope?.groupId;
+}
+
+/**
+ * Build the deck-write lock key for (category, language, scope).
+ *
+ * Despite the legacy `cardDeck:append:` format (kept for compatibility so
+ * in-flight appends and every other deck writer share the SAME key), this
+ * key guards ALL persisted-deck writes:
+ * - append: `appendCardBatch` (services/cardDeck.js)
+ * - removal: `removeImageFromList` (this file) and
+ *   `removeCardFromGroupDeck` (services/cardDeck.js)
+ * - trim: the `getLocalImages` dead-file write-back (this file)
+ *
+ * `withScopeLock` is NON-REENTRANT: never acquire this key inside a section
+ * that already holds it (e.g. `updateImageList` / `readGroupFeedCache` are
+ * lock-free internals called INSIDE held sections).
+ *
+ * @param {{ categoryKey?: string|null, categoryId?: string|number|null, language?: string|null, scope?: { kind?: string, groupId?: string }|null }} args
+ * @returns {string} `cardDeck:append:public:<categoryKey|'all'>:<language|'any'>`
+ *   or `cardDeck:append:private:<groupId>:<categoryId|'all'>:<language|'any'>`.
+ */
+export function deckWriteLockKey({ categoryKey, categoryId, language, scope } = {}) {
+  const lang = language || 'any';
+  if (isPrivateScope(scope)) {
+    const cid = categoryId === 'all' ? undefined : categoryId;
+    return `cardDeck:append:private:${scope.groupId}:${cid ?? 'all'}:${lang}`;
+  }
+  return `cardDeck:append:public:${categoryKey || 'all'}:${lang}`;
 }
 
 /**
@@ -73,68 +106,6 @@ export async function clearExhaustedCategory(categoryKey, language, scope) {
   await AsyncStorage.removeItem(exhaustedCategoryKey(categoryKey, language));
 };
 
-export function playedPictureIdsKey(language, scope) {
-  return `${PLAYED_PICTURE_IDS_PREFIX}:${isPrivateScope(scope) ? `group:${scope.groupId}` : 'public'}:${language || 'any'}`;
-};
-
-export async function getPlayedPictureIds(language, scope) {
-  const stored = await AsyncStorage.getItem(playedPictureIdsKey(language, scope));
-  if (!stored) {
-    return [];
-  }
-  try {
-    const parsed = JSON.parse(stored);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-};
-
-export async function addPlayedPictureId(pictureId, language, scope) {
-  if (!pictureId) {
-    return;
-  }
-  const played = await getPlayedPictureIds(language, scope);
-  if (played.includes(pictureId)) {
-    return;
-  }
-  const next = [...played, pictureId].slice(-PLAYED_PICTURE_IDS_CAP);
-  await AsyncStorage.setItem(playedPictureIdsKey(language, scope), JSON.stringify(next));
-};
-
-export async function filterPlayedCards(cards, language, scope) {
-  if (!Array.isArray(cards)) {
-    return [];
-  }
-  let playedIds;
-  try {
-    playedIds = await getPlayedPictureIds(language, scope);
-  } catch {
-    return cards;
-  }
-  if (playedIds.length === 0) {
-    return cards;
-  }
-  const played = new Set(playedIds);
-  return cards.filter((card) => !card?.pictureId || !played.has(card.pictureId));
-};
-
-async function removeKeysByPrefix(prefix) {
-  const keys = await AsyncStorage.getAllKeys();
-  const target = keys.filter((key) => typeof key === 'string' && key.startsWith(prefix));
-  if (target.length > 0) {
-    await AsyncStorage.multiRemove(target);
-  }
-};
-
-export async function clearPlayedPictureIdsForGroup(groupId) {
-  await removeKeysByPrefix(`${PLAYED_PICTURE_IDS_PREFIX}:group:${groupId}:`);
-};
-
-export async function clearAllPrivatePlayedPictureIds() {
-  await removeKeysByPrefix(`${PLAYED_PICTURE_IDS_PREFIX}:group:`);
-};
-
 /**
  * Read the persisted deck for (categoryKey, language) and drop entries whose
  * local image file no longer exists, persisting the trimmed list when needed.
@@ -143,7 +114,8 @@ export async function clearAllPrivatePlayedPictureIds() {
  * @returns {Promise<Array<object>|null>} Viable cards, or null when none stored/unparseable.
  */
 export async function getLocalImages(categoryKey, language) {
-  const stored = await AsyncStorage.getItem(imageListKey(categoryKey, language));
+  const listKey = imageListKey(categoryKey, language);
+  const stored = await AsyncStorage.getItem(listKey);
   if (!stored) {
     return null;
   }
@@ -165,7 +137,37 @@ export async function getLocalImages(categoryKey, language) {
   const viable = images.filter((image) => localImageFileExists(image?.imageFile));
 
   if (viable.length !== images.length) {
-    await AsyncStorage.setItem(imageListKey(categoryKey, language), JSON.stringify(viable));
+    // Review-approved deviation from the plan's wrap-write-only fix: re-read
+    // and re-trim under the lock. Persisting the pre-lock snapshot would
+    // clobber appends committed while we waited for the lock; re-reading the
+    // persisted deck inside the critical section keeps the trim lossless
+    // against concurrent deck writers.
+    return withScopeLock(
+      deckWriteLockKey({ categoryKey, language, scope: null }),
+      async () => {
+        const latestStored = await AsyncStorage.getItem(listKey);
+        if (!latestStored) {
+          return [];
+        }
+
+        let latestImages;
+        try {
+          latestImages = JSON.parse(latestStored);
+        } catch {
+          return [];
+        }
+
+        if (!Array.isArray(latestImages)) {
+          return [];
+        }
+
+        const latestViable = latestImages.filter((image) => localImageFileExists(image?.imageFile));
+        if (latestViable.length !== latestImages.length) {
+          await AsyncStorage.setItem(listKey, JSON.stringify(latestViable));
+        }
+        return latestViable;
+      },
+    );
   }
 
   return viable;
@@ -384,30 +386,60 @@ export async function getLastImageId(categoryKey, language) {
 };
 
 /**
- * Persist the feed cursor (last-served image uuid) for (categoryKey, language).
- * Stored at `lastImageUuid:<categoryKey|'all'>:<language|'any'>`. Callers may
- * write the `PUBLIC_FEED_END_CURSOR` sentinel to mark the public feed as
- * exhausted; readers treat that sentinel as null.
- * @param {string} imageUuid - Cursor value (or PUBLIC_FEED_END_CURSOR sentinel).
+ * Resolve the feed-cursor storage key for (categoryKey, language, scope).
+ * PUBLIC (and legacy no-scope callers) keep the shared
+ * `lastImageUuid:<categoryKey|'all'>:<language|'any'>` shape untouched.
+ * PRIVATE scopes persist under the group-scoped game-cursor key
+ * `groupFeed:<groupId>:game:<categoryKey|'all'>:<language|'any'>:cursor`
+ * (F1/F2 review fix) so the private transport cursor never shares — and never
+ * poisons — the public cursor namespace.
+ */
+function lastImageUuidKeyForScope(categoryKey, language, scope) {
+  if (isPrivateScope(scope)) {
+    return groupGameCursorKey(scope.groupId, categoryKey, language);
+  }
+  return lastImageUuidKey(categoryKey, language);
+}
+
+/**
+ * Persist the feed cursor (last-served image uuid) for (categoryKey, language,
+ * scope). PUBLIC scope stores at `lastImageUuid:<categoryKey|'all'>:<language|'any'>`
+ * (callers may write the `PUBLIC_FEED_END_CURSOR` sentinel there; readers treat
+ * that sentinel as null). PRIVATE scope stores at the group-scoped
+ * `groupFeed:<groupId>:game:<categoryKey|'all'>:<language|'any'>:cursor` key,
+ * where the `PRIVATE_FEED_END_CURSOR` sentinel lives scope-isolated.
+ *
+ * Migration note: pre-fix app versions persisted private cursors/sentinels to
+ * the unscoped `lastImageUuid:*` keys. Those legacy keys are deliberately dead
+ * (no read fallback) — the first scoped read misses, one head probe re-serves,
+ * and the scoped cursor is rewritten. Stale legacy keys age out with the next
+ * dev wipe.
+ *
+ * @param {string} imageUuid - Cursor value (or scope-correct feed-end sentinel).
  * @param {string} categoryKey - Category key ('all' for the global deck).
  * @param {string} language - Language code ('any' when unset).
+ * @param {{ kind?: string, groupId?: string }|null|undefined} [scope] - Private scope object.
  * @returns {Promise<null>}
  */
-export async function saveLastImageUuid(imageUuid, categoryKey, language) {
-  await AsyncStorage.setItem(lastImageUuidKey(categoryKey, language), imageUuid);
+export async function saveLastImageUuid(imageUuid, categoryKey, language, scope) {
+  await AsyncStorage.setItem(lastImageUuidKeyForScope(categoryKey, language, scope), imageUuid);
   return null;
 };
 
 /**
- * Read the persisted feed cursor for (categoryKey, language).
- * Key: `lastImageUuid:<categoryKey|'all'>:<language|'any'>`. May return the
- * `PUBLIC_FEED_END_CURSOR` sentinel; callers MUST treat that as null/exhausted.
+ * Read the persisted feed cursor for (categoryKey, language, scope). Key
+ * shapes mirror saveLastImageUuid (public `lastImageUuid:*`, private
+ * group-scoped `groupFeed:<gid>:game:*:*:cursor`). The public read may return
+ * the `PUBLIC_FEED_END_CURSOR` sentinel; callers MUST treat that sentinel as
+ * null/exhausted. The private read may return the `PRIVATE_FEED_END_CURSOR`
+ * sentinel; its consumer (fetchPrivateFeedPageForGame) treats it as exhausted.
  * @param {string} categoryKey - Category key ('all' for the global deck).
  * @param {string} language - Language code ('any' when unset).
+ * @param {{ kind?: string, groupId?: string }|null|undefined} [scope] - Private scope object.
  * @returns {Promise<string|null>} Stored cursor, sentinel, or null when unset.
  */
-export async function getLastImageUuid(categoryKey, language) {
-  const lastImageUuid = await AsyncStorage.getItem(lastImageUuidKey(categoryKey, language));
+export async function getLastImageUuid(categoryKey, language, scope) {
+  const lastImageUuid = await AsyncStorage.getItem(lastImageUuidKeyForScope(categoryKey, language, scope));
   return lastImageUuid;
 };
 
@@ -552,6 +584,62 @@ export async function emptyImageList(categoryKey, language) {
   await AsyncStorage.removeItem(playedPictureIdsKey(language, null));
 };
 
+/**
+ * Delete the local cache files referenced by persisted image-list decks.
+ * Silent on unset/empty/corrupt decks — a bad deck must not abort the wipe.
+ * @param {Array<string>} imageListKeys - AsyncStorage keys of persisted decks.
+ * @returns {Promise<void>}
+ */
+async function deleteDeckCacheFiles(imageListKeys) {
+  for (const listKey of imageListKeys) {
+    const localList = await AsyncStorage.getItem(listKey);
+    if (localList === null || localList === '[]') {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(localList);
+      if (!Array.isArray(parsed)) {
+        continue;
+      }
+
+      for (const image of parsed) {
+        await removeFromCache(image?.imageFile);
+      }
+    } catch {
+    }
+  }
+}
+
+/**
+ * Wipe ALL public guess-side storage: delete every persisted deck's local
+ * cache files, then remove every public deck/tracking/cursor key plus every
+ * serving-cycle epoch key (public and group — epochs are session state, not
+ * per-group content). Private group content (groupFeed:*, groupFeedExhausted:*,
+ * playedPictureIds:group:*) is deliberately untouched — it is scoped per group,
+ * not per session.
+ * @returns {Promise<void>}
+ */
+export async function wipePublicGuessStorage() {
+  const keys = await AsyncStorage.getAllKeys();
+  await deleteDeckCacheFiles(keys.filter((key) => typeof key === 'string' && key.startsWith(IMAGE_LIST_KEY_PREFIX)));
+
+  const removalPrefixes = [
+    IMAGE_LIST_KEY_PREFIX,
+    LAST_IMAGE_UUID_KEY_PREFIX,
+    EXHAUSTED_CATEGORY_KEY_PREFIX,
+    `${PLAYED_PICTURE_IDS_PREFIX}:public:`,
+    `${SERVING_CYCLE_PREFIX}:`,
+  ];
+  const target = keys.filter((key) =>
+    typeof key === 'string' && removalPrefixes.some((prefix) => key.startsWith(prefix))
+  );
+
+  if (target.length > 0) {
+    await AsyncStorage.multiRemove(target);
+  }
+}
+
 export async function storeImageList(imageList, categoryKey, language) {
   await AsyncStorage.setItem(imageListKey(categoryKey, language), JSON.stringify(imageList));
 };
@@ -652,15 +740,20 @@ export async function updateImageList(updatedImageList, categoryKey, language) {
  * @returns {Promise<null>}
  */
 export async function removeImageFromList(listId, categoryKey, language) {
-  const listKey = imageListKey(categoryKey, language);
-  const imageList = await AsyncStorage.getItem(listKey);
-  if (imageList === null || imageList === undefined) {
-    return null;
-  };
-  const jsonImageList = JSON.parse(imageList);
-  const updatedImageList = removeObjectById(jsonImageList, listId);
-  await AsyncStorage.setItem(listKey, JSON.stringify(updatedImageList));
-  return null;
+  return withScopeLock(
+    deckWriteLockKey({ categoryKey, language, scope: null }),
+    async () => {
+      const listKey = imageListKey(categoryKey, language);
+      const imageList = await AsyncStorage.getItem(listKey);
+      if (imageList === null || imageList === undefined) {
+        return null;
+      };
+      const jsonImageList = JSON.parse(imageList);
+      const updatedImageList = removeObjectById(jsonImageList, listId);
+      await AsyncStorage.setItem(listKey, JSON.stringify(updatedImageList));
+      return null;
+    },
+  );
 };
 
 export async function deleteImageFromStorage(imageFilePath) {

--- a/utils/storageDatum.js
+++ b/utils/storageDatum.js
@@ -14,6 +14,8 @@ const ONBOARDING_COMPLETED_KEY = 'onboardingCompleted';
 const USER_TAGS_KEY = 'userTags';
 const DEFAULT_LANGUAGE = 'en';
 export const PUBLIC_FEED_END_CURSOR = '__public_feed_end__';
+const PLAYED_PICTURE_IDS_CAP = 200;
+const PLAYED_PICTURE_IDS_PREFIX = 'playedPictureIds';
 
 function imageListKey(categoryKey, language) {
   return `imageList:${categoryKey || 'all'}:${language || 'any'}`;
@@ -69,6 +71,68 @@ export async function clearExhaustedCategory(categoryKey, language, scope) {
     return;
   }
   await AsyncStorage.removeItem(exhaustedCategoryKey(categoryKey, language));
+};
+
+export function playedPictureIdsKey(language, scope) {
+  return `${PLAYED_PICTURE_IDS_PREFIX}:${isPrivateScope(scope) ? `group:${scope.groupId}` : 'public'}:${language || 'any'}`;
+};
+
+export async function getPlayedPictureIds(language, scope) {
+  const stored = await AsyncStorage.getItem(playedPictureIdsKey(language, scope));
+  if (!stored) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+export async function addPlayedPictureId(pictureId, language, scope) {
+  if (!pictureId) {
+    return;
+  }
+  const played = await getPlayedPictureIds(language, scope);
+  if (played.includes(pictureId)) {
+    return;
+  }
+  const next = [...played, pictureId].slice(-PLAYED_PICTURE_IDS_CAP);
+  await AsyncStorage.setItem(playedPictureIdsKey(language, scope), JSON.stringify(next));
+};
+
+export async function filterPlayedCards(cards, language, scope) {
+  if (!Array.isArray(cards)) {
+    return [];
+  }
+  let playedIds;
+  try {
+    playedIds = await getPlayedPictureIds(language, scope);
+  } catch {
+    return cards;
+  }
+  if (playedIds.length === 0) {
+    return cards;
+  }
+  const played = new Set(playedIds);
+  return cards.filter((card) => !card?.pictureId || !played.has(card.pictureId));
+};
+
+async function removeKeysByPrefix(prefix) {
+  const keys = await AsyncStorage.getAllKeys();
+  const target = keys.filter((key) => typeof key === 'string' && key.startsWith(prefix));
+  if (target.length > 0) {
+    await AsyncStorage.multiRemove(target);
+  }
+};
+
+export async function clearPlayedPictureIdsForGroup(groupId) {
+  await removeKeysByPrefix(`${PLAYED_PICTURE_IDS_PREFIX}:group:${groupId}:`);
+};
+
+export async function clearAllPrivatePlayedPictureIds() {
+  await removeKeysByPrefix(`${PLAYED_PICTURE_IDS_PREFIX}:group:`);
 };
 
 /**
@@ -131,9 +195,10 @@ export async function getNextImage(categoryKey, language, currentListId, exclude
     return null;
   }
 
+  const unplayed = await filterPlayedCards(raw, language);
   const images = excludePictureId
-    ? raw.filter((image) => image?.pictureId !== excludePictureId)
-    : raw;
+    ? unplayed.filter((image) => image?.pictureId !== excludePictureId)
+    : unplayed;
   if (images.length === 0) {
     return null;
   }
@@ -172,9 +237,10 @@ export async function getNextImageForScope({ category, language, currentListId, 
     return null;
   }
 
+  const unplayed = await filterPlayedCards(raw, language, scope);
   const images = excludePictureId
-    ? raw.filter((image) => image?.pictureId !== excludePictureId)
-    : raw;
+    ? unplayed.filter((image) => image?.pictureId !== excludePictureId)
+    : unplayed;
   if (images.length === 0) {
     return null;
   }
@@ -483,6 +549,7 @@ export async function emptyImageList(categoryKey, language) {
   await AsyncStorage.removeItem(listKey);
   await AsyncStorage.removeItem(lastImageUuidKey(categoryKey, language));
   await AsyncStorage.removeItem(exhaustedCategoryKey(categoryKey, language));
+  await AsyncStorage.removeItem(playedPictureIdsKey(language, null));
 };
 
 export async function storeImageList(imageList, categoryKey, language) {
@@ -505,19 +572,32 @@ function removeObjectById(imageListObject, listId) {
  * foreground-fetched cards are persisted without one (the server has no synthetic
  * listId), and getNextImage filters by `listId > currentListId` — so cards lacking
  * a finite listId would be invisible to the guess resolver. Assign sequential ids
- * continuing from the deck's current max: a stable no-op for already-healthy decks
- * and a one-time self-heal for null/missing/non-finite listId cards.
+ * continuing from the deck's current max.
+ *
+ * ALSO repairs duplicate FINITE listIds (two concurrent writers both numbering
+ * from the same base — Fix 3): a single order-preserving pass reassigns every
+ * LATER duplicate (and every missing/non-finite id) past the deck's pre-pass max.
+ * Healthy decks return the input array by identity (same reference, no copies).
  *
  * Centralized here (the storage-write boundary) so EVERY writer (feed handleData,
- * prefetcher, advance-path foregroundTopUp) produces resolvable cards. SwipeImage
- * re-imports this and still calls it read-time as a defensive backstop.
+ * prefetcher, advance-path foregroundTopUp) produces resolvable, collision-free
+ * cards. SwipeImage re-imports this and still calls it read-time as a defensive
+ * backstop.
  */
 export function normalizeListIds(cards) {
   if (!Array.isArray(cards) || cards.length === 0) return cards;
-  const hasMissing = cards.some((c) => c?.listId == null || !Number.isFinite(c.listId));
-  if (!hasMissing) return cards;
+  const seen = new Set();
   let next = cards.reduce((max, c) => (Number.isFinite(c?.listId) && c.listId > max ? c.listId : max), 0);
-  return cards.map((c) => (Number.isFinite(c?.listId) ? c : { ...c, listId: (next += 1) }));
+  let changed = false;
+  const result = cards.map((c) => {
+    if (!Number.isFinite(c?.listId) || seen.has(c.listId)) {
+      changed = true;
+      return { ...c, listId: (next += 1) };
+    }
+    seen.add(c.listId);
+    return c;
+  });
+  return changed ? result : cards;
 }
 
 /**

--- a/utils/storageDatum.js
+++ b/utils/storageDatum.js
@@ -443,6 +443,21 @@ export async function getLastImageUuid(categoryKey, language, scope) {
   return lastImageUuid;
 };
 
+/**
+ * Remove the persisted feed cursor for (categoryKey, language, scope). Key
+ * shapes mirror saveLastImageUuid/getLastImageUuid (public `lastImageUuid:*`,
+ * private group-scoped `groupFeed:<gid>:game:*:*:cursor`). Removing a REAL
+ * cursor is a destructive rewind — callers must only use this to un-stick a
+ * feed-end sentinel or an otherwise unusable cursor value.
+ * @param {string} categoryKey - Category key ('all' for the global deck).
+ * @param {string} language - Language code ('any' when unset).
+ * @param {{ kind?: string, groupId?: string }|null|undefined} [scope] - Private scope object.
+ * @returns {Promise<void>}
+ */
+export async function clearLastImageUuid(categoryKey, language, scope) {
+  await AsyncStorage.removeItem(lastImageUuidKeyForScope(categoryKey, language, scope));
+};
+
 export async function getSessionLanguageFilter() {
   const stored = await AsyncStorage.getItem(SESSION_LANGUAGE_FILTER_KEY);
 


### PR DESCRIPTION
This pull request primarily adds and updates tests to support new features and refactorings related to language handling, guess serving state reset, deck exhaustion, and card batch management. The changes include new test coverage for language fallback logic, a new guess serving reset action, updates to storage and serving cycle mocks, and a comprehensive new test suite for the card deck probe logic.

**Test coverage improvements:**

* Added tests to `GuessFeedScreen.test.js` to verify that when no language is set in the route or filter, the language defaults to `'any'` instead of `'en'`, and ensured navigation and startGuessing behavior correctly forwards `'any'` as the language. [[1]](diffhunk://#diff-da12f3647ffada6fc0c5c1578ea3d88a4dbe5b5f2cbfce140c71a5e665573a71L238-R238) [[2]](diffhunk://#diff-da12f3647ffada6fc0c5c1578ea3d88a4dbe5b5f2cbfce140c71a5e665573a71R255-R299)
* Added tests to `SettingsScreen.test.js` to cover a new "dev reset" action, ensuring it calls both `wipePublicGuessStorage` and `resetServingCycles`, and displays appropriate success or error alerts. [[1]](diffhunk://#diff-9cc56388b8453c22503efce060f304dbcf82db672268c3322b8efa3cfbb93ef7R43-R47) [[2]](diffhunk://#diff-9cc56388b8453c22503efce060f304dbcf82db672268c3322b8efa3cfbb93ef7L60-R66) [[3]](diffhunk://#diff-9cc56388b8453c22503efce060f304dbcf82db672268c3322b8efa3cfbb93ef7R91-R92) [[4]](diffhunk://#diff-9cc56388b8453c22503efce060f304dbcf82db672268c3322b8efa3cfbb93ef7R295-R323)
* Updated `auth-context.test.js` to replace `emptyImageList` with the new `wipePublicGuessStorage` in both mocks and assertions, ensuring logout and authentication flows now clear guess storage using the correct method. [[1]](diffhunk://#diff-afaf275a8296343114b8a8a02d1907fccfcdbc9921e7af3e854428a347f4c8f0L8-R9) [[2]](diffhunk://#diff-afaf275a8296343114b8a8a02d1907fccfcdbc9921e7af3e854428a347f4c8f0L21-R22) [[3]](diffhunk://#diff-afaf275a8296343114b8a8a02d1907fccfcdbc9921e7af3e854428a347f4c8f0L89-R90) [[4]](diffhunk://#diff-afaf275a8296343114b8a8a02d1907fccfcdbc9921e7af3e854428a347f4c8f0L186-R187) [[5]](diffhunk://#diff-afaf275a8296343114b8a8a02d1907fccfcdbc9921e7af3e854428a347f4c8f0L202-R203)
* Added a comprehensive new test suite in `cardDeck.probe.test.ts` for `probeAllPoolForUnplayed`, covering scenarios like batch paging, exhaustion, sentinel handling, fetch errors, probe caps, exclusion logic, and private group deck management.
* Improved `cardPrefetcher.test.ts` by mocking new helpers for batch management and exhaustion clearing, and ensuring warnings are suppressed during tests. [[1]](diffhunk://#diff-4588119da50568505f9df10332506a67be9f8deff8d1d077d0c89c02a6021ea1R10-R26) [[2]](diffhunk://#diff-4588119da50568505f9df10332506a67be9f8deff8d1d077d0c89c02a6021ea1R43-R44) [[3]](diffhunk://#diff-4588119da50568505f9df10332506a67be9f8deff8d1d077d0c89c02a6021ea1R56-R68)

**Mock and helper updates:**

* Updated and extended mocks for storage-related utilities in test files to support new methods such as `wipePublicGuessStorage`, `resetServingCycles`, and others required for the new and updated tests. [[1]](diffhunk://#diff-9cc56388b8453c22503efce060f304dbcf82db672268c3322b8efa3cfbb93ef7R43-R47) [[2]](diffhunk://#diff-4588119da50568505f9df10332506a67be9f8deff8d1d077d0c89c02a6021ea1R10-R26) [[3]](diffhunk://#diff-2472262f17fbd5a8ea1569ca48eb471515f9935d50da6d4d6b99e112c32d0008R35) [[4]](diffhunk://#diff-afaf275a8296343114b8a8a02d1907fccfcdbc9921e7af3e854428a347f4c8f0L8-R9)

These changes ensure robust test coverage for new and refactored features, particularly around language fallback, guess serving state management, and deck exhaustion logic.