### PR TITLE
Fix/private sub trigger

### DIFF
--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -29,6 +29,7 @@ jest.mock('@react-navigation/native', () => ({
     },
   },
   NavigationContainer: ({ children }) => children,
+  useFocusEffect: jest.fn(),
   useNavigationContainerRef: jest.fn(() => ({
     isReady: jest.fn(() => false),
     getCurrentRoute: jest.fn(() => ({ name: 'Login' })),

--- a/__tests__/GuessPathScreen.test.js
+++ b/__tests__/GuessPathScreen.test.js
@@ -393,8 +393,33 @@ describe('GuessPathScreen', () => {
       category: expect.objectContaining({ key: 'c-1', name: 'Cats' }),
       language: 'any',
       scope: { kind: 'private', groupId: 'g-1' },
-      activeGroup: { isOwnedByViewer: true, memberCount: 6 },
+      activeGroup: { isOwnedByViewer: true, memberCount: 6, locked: false },
     });
+  });
+
+  it('does not navigate to GuessFeedScreen and shows the lock alert when the private group is locked', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: {
+        owned: [{ id: 'g-1', role: 'owner', locked: true }],
+        joined: [],
+      },
+      refresh: jest.fn(),
+    });
+    emitCategoriesViaStore([{ id: 'c-1', key: 'c-1', name: 'Cats' }]);
+
+    await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    const privateCard = getCardPropsByKey('c-1');
+
+    await act(async () => {
+      await privateCard.onPress();
+    });
+
+    expect(navigation.navigate).not.toHaveBeenCalled();
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Group is locked',
+      'New private games are paused until the owner renews the subscription or transfers ownership.'
+    );
   });
 
   it('fetches groups on press when private hub data is still missing and then threads the active-group snapshot', async () => {
@@ -421,8 +446,35 @@ describe('GuessPathScreen', () => {
       category: expect.objectContaining({ key: 'c-1', name: 'Cats' }),
       language: 'any',
       scope: { kind: 'private', groupId: 'g-1' },
-      activeGroup: { isOwnedByViewer: true, memberCount: 7 },
+      activeGroup: { isOwnedByViewer: true, memberCount: 7, locked: false },
     });
+  });
+
+  it('blocks navigation and shows the lock alert when the on-demand fetch resolves a locked group', async () => {
+    mockUseGroupsHub.mockReturnValue({ data: null, refresh: jest.fn() });
+    emitCategoriesViaStore([{ id: 'c-1', key: 'c-1', name: 'Cats' }]);
+    fetchGroups.mockResolvedValue({
+      status: 200,
+      data: {
+        owned: [{ id: 'g-1', role: 'owner', member_count: 7, locked: true }],
+        joined: [],
+      },
+    });
+
+    await renderScreen({ params: { scope: { kind: 'private', groupId: 'g-1' } } });
+
+    const privateCard = getCardPropsByKey('c-1');
+
+    await act(async () => {
+      await privateCard.onPress();
+    });
+
+    expect(fetchGroups).toHaveBeenCalledWith(contextValue);
+    expect(navigation.navigate).not.toHaveBeenCalled();
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Group is locked',
+      'New private games are paused until the owner renews the subscription or transfers ownership.'
+    );
   });
 
   it('renders private categories optimistically via the store onCategories callback', async () => {

--- a/__tests__/HidingPathScreen.test.js
+++ b/__tests__/HidingPathScreen.test.js
@@ -1,0 +1,130 @@
+const mockLogicalImagePicker = jest.fn(() => null);
+const mockUseActiveGroup = jest.fn();
+const mockUseGroupsHub = jest.fn();
+
+jest.mock('../components/Picture/LogicalImagePicker', () => {
+  return function MockLogicalImagePicker(props) {
+    mockLogicalImagePicker(props);
+    return null;
+  };
+});
+
+jest.mock('../hooks/useActiveGroup', () => ({
+  useActiveGroup: () => mockUseActiveGroup(),
+}));
+
+jest.mock('../hooks/useGroupsHub', () => ({
+  useGroupsHub: () => mockUseGroupsHub(),
+}));
+
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import HidingPathScreen from '../screens/HideScreens/HidingPathScreen';
+
+describe('HidingPathScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    mockUseActiveGroup.mockReturnValue({ scope: null, clear: jest.fn() });
+    mockUseGroupsHub.mockReturnValue({ data: null, refresh: jest.fn() });
+  });
+
+  afterEach(() => {
+    Alert.alert.mockRestore();
+  });
+
+  async function renderScreen(route = { params: {} }) {
+    const navigation = {
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      canGoBack: jest.fn(() => true),
+      setOptions: jest.fn(),
+    };
+
+    let renderer;
+    await act(async () => {
+      renderer = create(
+        <HidingPathScreen navigation={navigation} route={route} />
+      );
+      await Promise.resolve();
+    });
+
+    return { renderer, navigation };
+  }
+
+  it('shows the lock alert once and goes back when the private group is locked', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: {
+        owned: [{ id: 'g-1', name: 'Waldos', role: 'owner', locked: true }],
+        joined: [],
+      },
+      refresh: jest.fn(),
+    });
+
+    const { navigation } = await renderScreen({
+      params: { scope: { kind: 'private', groupId: 'g-1' } },
+    });
+
+    expect(Alert.alert).toHaveBeenCalledTimes(1);
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Group is locked',
+      'New private games are paused until the owner renews the subscription or transfers ownership.'
+    );
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the lock alert and goes back when the locked group is resolved via activeScope only (no route scope param)', async () => {
+    mockUseActiveGroup.mockReturnValue({
+      scope: { kind: 'private', groupId: 'g-1' },
+      clear: jest.fn(),
+    });
+    mockUseGroupsHub.mockReturnValue({
+      data: {
+        owned: [{ id: 'g-1', name: 'Waldos', role: 'owner', locked: true }],
+        joined: [],
+      },
+      refresh: jest.fn(),
+    });
+
+    const { navigation } = await renderScreen({ params: {} });
+
+    expect(Alert.alert).toHaveBeenCalledTimes(1);
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Group is locked',
+      'New private games are paused until the owner renews the subscription or transfers ownership.'
+    );
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not alert or go back when the private group is unlocked', async () => {
+    mockUseGroupsHub.mockReturnValue({
+      data: {
+        owned: [{ id: 'g-1', name: 'Waldos', role: 'owner', locked: false }],
+        joined: [],
+      },
+      refresh: jest.fn(),
+    });
+
+    const scope = { kind: 'private', groupId: 'g-1' };
+    const { navigation } = await renderScreen({ params: { scope } });
+
+    expect(Alert.alert).not.toHaveBeenCalled();
+    expect(navigation.goBack).not.toHaveBeenCalled();
+
+    const pickerProps = mockLogicalImagePicker.mock.calls.map(([props]) => props).pop();
+    expect(pickerProps.scope).toEqual(scope);
+    expect(pickerProps.navigation).toBe(navigation);
+  });
+
+  it('does not alert when the scope is public', async () => {
+    mockUseActiveGroup.mockReturnValue({ scope: null, clear: jest.fn() });
+
+    const { navigation } = await renderScreen();
+
+    expect(Alert.alert).not.toHaveBeenCalled();
+    expect(navigation.goBack).not.toHaveBeenCalled();
+    expect(mockLogicalImagePicker).toHaveBeenCalled();
+  });
+});

--- a/__tests__/HomeHeaderRight.test.js
+++ b/__tests__/HomeHeaderRight.test.js
@@ -1,4 +1,23 @@
 const mockIconButton = jest.fn(() => null);
+const mockFocusEffects = new Set();
+
+jest.mock('@react-navigation/native', () => {
+  const React = require('react');
+
+  return {
+    useFocusEffect: (callback) => {
+      React.useEffect(() => {
+        mockFocusEffects.add(callback);
+        const cleanup = callback();
+
+        return () => {
+          mockFocusEffects.delete(callback);
+          cleanup?.();
+        };
+      }, [callback]);
+    },
+  };
+});
 
 jest.mock('../components/UI/IconButton', () => {
   return function MockIconButton(props) {
@@ -8,36 +27,58 @@ jest.mock('../components/UI/IconButton', () => {
 });
 
 jest.mock('../hooks/useActiveGroup', () => ({
-  useActiveGroup: jest.fn(() => ({
-    scope: { kind: 'public' },
-    activeGroupId: null,
-    setActive: jest.fn(),
-    clear: jest.fn(),
-  })),
+  useActiveGroup: jest.fn(),
 }));
 
 jest.mock('../hooks/useGroupsHub', () => ({
-  useGroupsHub: jest.fn(() => ({
-    data: { owned: [], joined: [] },
-    isLoading: false,
-    error: null,
-    refresh: jest.fn(),
-  })),
+  useGroupsHub: jest.fn(),
 }));
+
+jest.mock('../store/auth-context', () => {
+  const React = require('react');
+  return {
+    AuthContext: React.createContext({}),
+  };
+});
 
 import React from 'react';
 import { act, create } from 'react-test-renderer';
 
 import { HomeHeaderRight } from '../screens/Groups/HomeHeaderRight';
+import { useActiveGroup } from '../hooks/useActiveGroup';
+import { useGroupsHub } from '../hooks/useGroupsHub';
+import { AuthContext } from '../store/auth-context';
+
+const defaultActiveGroup = {
+  scope: { kind: 'public' },
+  activeGroupId: null,
+  setActive: jest.fn(),
+  clear: jest.fn(),
+};
 
 describe('HomeHeaderRight', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFocusEffects.clear();
+    useActiveGroup.mockReturnValue(defaultActiveGroup);
+    useGroupsHub.mockReturnValue({
+      data: { owned: [], joined: [] },
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
   });
 
   function getIconButtonProps(testID) {
     const matchingCalls = mockIconButton.mock.calls.filter(([{ testID: id }]) => id === testID);
     return matchingCalls[matchingCalls.length - 1]?.[0];
+  }
+
+  async function openMenu(renderer) {
+    const overflowProps = getIconButtonProps('home.header.other-options');
+    await act(async () => {
+      overflowProps.onPress();
+    });
   }
 
   it('renders the store entry point and navigates to the paywall with intent=store on tap', async () => {
@@ -64,5 +105,68 @@ describe('HomeHeaderRight', () => {
     });
 
     expect(navigation.navigate).toHaveBeenCalledWith('PaywallScreen', { intent: 'store' });
+  });
+
+  it('keeps scope-toggle enabled for a group owner when the hub fetch failed, and switches to private', async () => {
+    const navigation = { navigate: jest.fn() };
+    const setActive = jest.fn().mockResolvedValue({ status: 200 });
+    useActiveGroup.mockReturnValue({
+      scope: { kind: 'public' },
+      activeGroupId: 'group-1',
+      setActive,
+      clear: jest.fn(),
+    });
+    useGroupsHub.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: { message: 'Not Found' },
+      refresh: jest.fn(),
+    });
+
+    let renderer;
+    await act(async () => {
+      renderer = create(
+        <AuthContext.Provider value={{ isGroupOwner: true }}>
+          <HomeHeaderRight navigation={navigation} tintColor="#fff" />
+        </AuthContext.Provider>
+      );
+    });
+
+    await openMenu(renderer);
+
+    const scopeToggle = renderer.root.findByProps({ testID: 'home.menu.scope-toggle' });
+    expect(scopeToggle.props.disabled).toBe(false);
+
+    await act(async () => {
+      scopeToggle.props.onPress();
+    });
+
+    expect(setActive).toHaveBeenCalledWith('group-1');
+    expect(navigation.navigate).toHaveBeenCalledWith('PrivateHomeScreen', {
+      scope: { kind: 'private', groupId: 'group-1' },
+    });
+  });
+
+  it('refreshes the groups hub when the screen comes into focus', async () => {
+    const refresh = jest.fn();
+    useGroupsHub.mockReturnValue({
+      data: { owned: [], joined: [] },
+      isLoading: false,
+      error: null,
+      refresh,
+    });
+
+    await act(async () => {
+      create(<HomeHeaderRight navigation={{ navigate: jest.fn() }} tintColor="#fff" />);
+    });
+
+    expect(mockFocusEffects.size).toBeGreaterThan(0);
+
+    refresh.mockClear();
+    await act(async () => {
+      mockFocusEffects.forEach((callback) => callback());
+    });
+
+    expect(refresh).toHaveBeenCalled();
   });
 });

--- a/__tests__/screens/HomeHeaderRight.test.js
+++ b/__tests__/screens/HomeHeaderRight.test.js
@@ -1,3 +1,12 @@
+jest.mock('@react-navigation/native', () => {
+  const React = require('react');
+  return {
+    useFocusEffect: (callback) => {
+      React.useEffect(() => callback(), [callback]);
+    },
+  };
+});
+
 jest.mock('../../components/UI/IconButton', () => {
   function MockIconButton(props) {
     return null;
@@ -44,7 +53,7 @@ describe('HomeHeaderRight', () => {
 
   function renderHeader({ activeGroup, groupsHubData, navigation = { navigate: jest.fn() } } = {}) {
     useActiveGroup.mockReturnValue(activeGroup);
-    useGroupsHub.mockReturnValue({ data: groupsHubData });
+    useGroupsHub.mockReturnValue({ data: groupsHubData, refresh: jest.fn() });
     let renderer;
     act(() => {
       renderer = create(<HomeHeaderRight navigation={navigation} tintColor="#fff" />);

--- a/__tests__/screens/PaywallScreen.test.js
+++ b/__tests__/screens/PaywallScreen.test.js
@@ -199,6 +199,47 @@ describe('PaywallScreen', () => {
     });
   });
 
+  it('applies isGroupOwner and activeGroupId from the syncEntitlement response after purchase', async () => {
+    syncEntitlement.mockResolvedValue({
+      status: 200,
+      data: {
+        is_paid: true,
+        paid_tier: 2,
+        paid_expires_at: null,
+        is_group_owner: true,
+        active_group_id: 'group-7',
+      },
+    });
+
+    const navigation = { replace: jest.fn() };
+    const authContext = { setEntitlement: jest.fn() };
+    const renderer = await renderScreen({
+      authContext,
+      navigation,
+      route: { params: { intent: 'store' } },
+    });
+
+    await act(async () => {
+      const subscribeButtons = renderer.root.findAll((node) =>
+        typeof node.props.testID === 'string' && node.props.testID.endsWith('.subscribe')
+      );
+      subscribeButtons[0].props.onPress();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(authContext.setEntitlement).toHaveBeenCalledTimes(1);
+    expect(authContext.setEntitlement).toHaveBeenCalledWith({
+      isPaid: true,
+      paidTier: 2,
+      paidExpiresAt: null,
+      isGroupOwner: true,
+      activeGroupId: 'group-7',
+    });
+  });
+
   it('surfaces Alert.alert and still navigates when syncEntitlement returns a non-200 status', async () => {
     const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
     syncEntitlement.mockResolvedValue({ status: 502, data: { error: 'revenuecat_unavailable' } });

--- a/__tests__/screens/PrivateHomeScreen.test.js
+++ b/__tests__/screens/PrivateHomeScreen.test.js
@@ -6,13 +6,25 @@ const mockLockedGroupOwnerModal = jest.fn(() => null);
 const mockLockedGroupMemberBanner = jest.fn(() => null);
 const mockUseActiveGroup = jest.fn();
 const mockUseGroupsHub = jest.fn();
+const mockFocusEffects = new Set();
 
-jest.mock('@react-navigation/native', () => ({
-  useFocusEffect: (callback) => {
-    const React = require('react');
-    React.useEffect(() => callback(), [callback]);
-  },
-}));
+jest.mock('@react-navigation/native', () => {
+  const React = require('react');
+
+  return {
+    useFocusEffect: (callback) => {
+      React.useEffect(() => {
+        mockFocusEffects.add(callback);
+        const cleanup = callback();
+
+        return () => {
+          mockFocusEffects.delete(callback);
+          cleanup?.();
+        };
+      }, [callback]);
+    },
+  };
+});
 
 jest.mock('../../utils/orientation', () => ({
   handleOrientation: jest.fn(),
@@ -102,6 +114,7 @@ import { getPrivateGroupTheme } from '../../utils/privateGroupTheme';
 describe('PrivateHomeScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFocusEffects.clear();
     jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
     jest.spyOn(Alert, 'alert').mockImplementation(() => {});
     resolveHomeBackground.mockResolvedValue(null);
@@ -135,6 +148,13 @@ describe('PrivateHomeScreen', () => {
   function lastSetOptions(navigation) {
     const calls = navigation.setOptions.mock.calls;
     return calls[calls.length - 1][0];
+  }
+
+  async function triggerFocusEffects() {
+    await act(async () => {
+      [...mockFocusEffects].forEach((callback) => callback());
+      await Promise.resolve();
+    });
   }
 
   async function renderHeader(navigation) {
@@ -412,6 +432,26 @@ describe('PrivateHomeScreen', () => {
       expect(navigation.navigate).not.toHaveBeenCalled();
     });
 
+    it('re-arms the owner modal on the next focus after dismissal', async () => {
+      await renderScreen({
+        groupsData: {
+          owned: [{ id: 'g-7', name: 'Waldos', role: 'owner', locked: true }],
+          joined: [],
+        },
+      });
+
+      const lastModal = () => mockLockedGroupOwnerModal.mock.calls.map(([props]) => props).pop();
+
+      await act(async () => {
+        lastModal().onDismiss();
+      });
+      expect(lastModal().visible).toBe(false);
+
+      await triggerFocusEffects();
+
+      expect(lastModal().visible).toBe(true);
+    });
+
     it('shows the member banner (and no owner modal) when a non-owner views a locked group', async () => {
       await renderScreen({
         groupsData: {
@@ -444,6 +484,94 @@ describe('PrivateHomeScreen', () => {
       expect(visibleOwnerModals).toHaveLength(0);
 
       expect(mockLockedGroupMemberBanner.mock.calls).toHaveLength(0);
+    });
+  });
+
+  describe('locked play gating', () => {
+    function lastHomeCardProps(testID) {
+      const calls = mockHomeCard.mock.calls.filter(
+        ([props]) => props && props.testID === testID
+      );
+      return calls[calls.length - 1][0];
+    }
+
+    it('disables the Hide card when the group is locked (owner)', async () => {
+      const { navigation } = await renderScreen({
+        groupsData: {
+          owned: [{ id: 'g-7', name: 'Waldos', role: 'owner', locked: true }],
+          joined: [],
+        },
+      });
+
+      const hideCard = lastHomeCardProps('private-home.button.hide');
+      expect(hideCard.onPress).toBeUndefined();
+      expect(hideCard.accessibilityState).toEqual({ disabled: true });
+      expect(hideCard.pointerEvents).toBe('none');
+
+      const findCard = lastHomeCardProps('private-home.button.find');
+      expect(findCard.onPress).toBeUndefined();
+      expect(findCard.accessibilityState).toEqual({ disabled: true });
+      expect(findCard.pointerEvents).toBe('none');
+
+      const rankingCard = lastHomeCardProps('private-home.button.ranking');
+      expect(rankingCard.onPress).toBeInstanceOf(Function);
+      expect(rankingCard.pointerEvents).toBeUndefined();
+
+      expect(navigation.navigate).not.toHaveBeenCalled();
+    });
+
+    it('disables the Hide card when the group is locked (member)', async () => {
+      await renderScreen({
+        groupsData: {
+          owned: [],
+          joined: [{ id: 'g-7', name: 'Waldos', role: 'member', locked: true }],
+        },
+      });
+
+      const hideCard = lastHomeCardProps('private-home.button.hide');
+      expect(hideCard.onPress).toBeUndefined();
+      expect(hideCard.accessibilityState).toEqual({ disabled: true });
+      expect(hideCard.pointerEvents).toBe('none');
+
+      const findCard = lastHomeCardProps('private-home.button.find');
+      expect(findCard.onPress).toBeUndefined();
+      expect(findCard.accessibilityState).toEqual({ disabled: true });
+      expect(findCard.pointerEvents).toBe('none');
+    });
+
+    it('keeps the Hide card enabled and navigating when the group is unlocked', async () => {
+      const { navigation } = await renderScreen({
+        groupsData: {
+          owned: [{ id: 'g-7', name: 'Waldos', role: 'owner', locked: false }],
+          joined: [],
+        },
+      });
+
+      const hideCard = lastHomeCardProps('private-home.button.hide');
+      expect(hideCard.onPress).toBeInstanceOf(Function);
+      expect(hideCard.accessibilityState).toBeUndefined();
+      expect(hideCard.pointerEvents).toBe('auto');
+
+      const findCard = lastHomeCardProps('private-home.button.find');
+      expect(findCard.onPress).toBeInstanceOf(Function);
+      expect(findCard.accessibilityState).toBeUndefined();
+      expect(findCard.pointerEvents).toBe('auto');
+
+      await act(async () => {
+        hideCard.onPress();
+      });
+
+      expect(navigation.navigate).toHaveBeenCalledWith('HidingPathScreen', {
+        scope: { kind: 'private', groupId: 'g-7' },
+      });
+
+      await act(async () => {
+        findCard.onPress();
+      });
+
+      expect(navigation.navigate).toHaveBeenCalledWith('GuessPathScreen', {
+        scope: { kind: 'private', groupId: 'g-7' },
+      });
     });
   });
 

--- a/screens/Billing/PaywallScreen.js
+++ b/screens/Billing/PaywallScreen.js
@@ -11,6 +11,7 @@ import { syncEntitlement } from '../../services/billing/billingApi';
 import {
   getPurchasesModule,
   applyEntitlementToContext,
+  entitlementToContextPayload,
   restoreAndSync,
 } from '../../utils/purchases';
 
@@ -53,11 +54,7 @@ export default function PaywallScreen({ navigation, route }) {
     const ok = response?.status === 200;
     const entitlement = response?.data;
     if (ok && entitlement) {
-      authContext.setEntitlement({
-        isPaid: entitlement.is_paid,
-        paidTier: entitlement.paid_tier,
-        paidExpiresAt: entitlement.paid_expires_at,
-      });
+      authContext.setEntitlement(entitlementToContextPayload(entitlement));
     }
     if (!ok) {
       Alert.alert(

--- a/screens/Groups/HomeHeaderRight.js
+++ b/screens/Groups/HomeHeaderRight.js
@@ -1,21 +1,30 @@
-import { useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 import { View, Modal, Pressable, Text, StyleSheet, Alert } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 import Ionicons from '@react-native-vector-icons/ionicons';
 
 import IconButton from '../../components/UI/IconButton';
 import { useActiveGroup } from '../../hooks/useActiveGroup';
 import { useGroupsHub } from '../../hooks/useGroupsHub';
+import { AuthContext } from '../../store/auth-context';
 import { GlobalStyle } from '../../constants/theme';
 
 export function HomeHeaderRight({ navigation, tintColor, onStartTutorial }) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const authContext = useContext(AuthContext);
   const { scope, activeGroupId, setActive, clear } = useActiveGroup();
-  const { data } = useGroupsHub();
+  const { data, refresh } = useGroupsHub();
   const owned = data?.owned ?? [];
   const joined = data?.joined ?? [];
   const isPrivate = scope.kind === 'private';
   const hasAnyMembership = owned.length > 0 || joined.length > 0;
-  const canToggleScope = hasAnyMembership;
+  const canToggleScope = hasAnyMembership || !!authContext?.isGroupOwner;
+
+  useFocusEffect(
+    useCallback(() => {
+      refresh();
+    }, [refresh])
+  );
 
   const toggleScope = () => {
     if (isPrivate) {

--- a/screens/Groups/PrivateHomeScreen.js
+++ b/screens/Groups/PrivateHomeScreen.js
@@ -55,7 +55,7 @@ export default function PrivateHomeScreen({ navigation, route }) {
   });
 
   const [isColorEditorVisible, setIsColorEditorVisible] = useState(false);
-  const [isLockedOwnerModalVisible, setIsLockedOwnerModalVisible] = useState(isLocked && isOwner);
+  const [dismissedGroupId, setDismissedGroupId] = useState(null);
   const [bgUris, setBgUris] = useState({});
   const [savingSlot, setSavingSlot] = useState({});
   const savingSlotRef = useRef({});
@@ -64,10 +64,6 @@ export default function PrivateHomeScreen({ navigation, route }) {
     savingSlotRef.current = { ...savingSlotRef.current, [slot]: value };
     setSavingSlot((prev) => ({ ...prev, [slot]: value }));
   }, []);
-
-  useEffect(() => {
-    setIsLockedOwnerModalVisible(isLocked && isOwner);
-  }, [isLocked, isOwner, groupId]);
 
   useEffect(() => {
     let mounted = true;
@@ -247,6 +243,14 @@ export default function PrivateHomeScreen({ navigation, route }) {
     }, [setPrivateMode])
   );
 
+  const isLockedOwnerModalVisible = isLocked && isOwner && dismissedGroupId !== groupId;
+
+  useFocusEffect(
+    useCallback(() => {
+      setDismissedGroupId(null);
+    }, [])
+  );
+
   const goScoped = (target) =>
     navigation.navigate(target, {
       scope: { kind: 'private', groupId },
@@ -261,8 +265,8 @@ export default function PrivateHomeScreen({ navigation, route }) {
   }, [navigation]);
 
   const dismissLockedOwnerModal = useCallback(() => {
-    setIsLockedOwnerModalVisible(false);
-  }, []);
+    setDismissedGroupId(groupId);
+  }, [groupId]);
 
   return (
     <View
@@ -286,10 +290,12 @@ export default function PrivateHomeScreen({ navigation, route }) {
       )}
       <HomeCard
         text="Hide Waldo"
-        onPress={() => goScoped('HidingPathScreen')}
+        onPress={isLocked ? undefined : () => goScoped('HidingPathScreen')}
         backgroundImage={bgUris.hide ? { uri: bgUris.hide } : HideImage}
         heightPercent={40}
         testID="private-home.button.hide"
+        accessibilityState={isLocked ? { disabled: true } : undefined}
+        pointerEvents={isLocked ? 'none' : 'auto'}
       />
       <HomeCard
         text="Find Waldo"

--- a/screens/GuessScreens/GuessPathScreen.js
+++ b/screens/GuessScreens/GuessPathScreen.js
@@ -64,6 +64,7 @@ function buildActiveGroupSnapshot(groupsHubData, groupId) {
   return {
     isOwnedByViewer: activeGroup.role === 'owner',
     memberCount: Number(activeGroup.memberCount ?? activeGroup.member_count ?? 0),
+    locked: activeGroup?.locked === true,
   };
 }
 
@@ -103,6 +104,7 @@ export default function GuessPathScreen({ navigation, route }) {
   const activeGroup = isPrivateScope ? buildActiveGroupSnapshot(groupsHubData, scope.groupId) : null;
   const isOwner = activeGroup?.isOwnedByViewer === true;
   const { group, theme } = useScopedPrivateGroupTheme(routeScope);
+  const isGroupLocked = isPrivateScope && group?.locked === true;
 
   const enrichAndSetPrivateCategories = useCallback(async (nextCategories) => {
     const list = Array.isArray(nextCategories) ? nextCategories : [];
@@ -186,6 +188,14 @@ export default function GuessPathScreen({ navigation, route }) {
   const navigationLanguage = sessionLanguage ?? NAVIGATION_ANY_LANGUAGE;
 
   const handleCategoryPress = async (category) => {
+    if (isPrivateScope && isGroupLocked) {
+      Alert.alert(
+        'Group is locked',
+        'New private games are paused until the owner renews the subscription or transfers ownership.'
+      );
+      return;
+    }
+
     const params = {
       category,
       language: navigationLanguage,
@@ -197,6 +207,13 @@ export default function GuessPathScreen({ navigation, route }) {
         context,
         scope,
       });
+      if (resolvedActiveGroup?.locked) {
+        Alert.alert(
+          'Group is locked',
+          'New private games are paused until the owner renews the subscription or transfers ownership.'
+        );
+        return;
+      }
       params.scope = scope;
       params.activeGroup = resolvedActiveGroup;
     }

--- a/screens/HideScreens/HidingPathScreen.js
+++ b/screens/HideScreens/HidingPathScreen.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { View } from 'react-native';
+import { Alert, View } from 'react-native';
 import LogicalImagePicker from '../../components/Picture/LogicalImagePicker';
 import { useActiveGroup } from '../../hooks/useActiveGroup';
 import { PrivateGroupThemeProvider, useScopedPrivateGroupTheme } from '../../store/privateGroupTheme-context';
@@ -9,7 +9,19 @@ export default function HidingPathScreen({ navigation, route }) {
   const routeScope = route?.params?.scope;
   const { scope: activeScope } = useActiveGroup();
   const scope = routeScope ?? activeScope;
-  const { group, theme } = useScopedPrivateGroupTheme(routeScope);
+  const { group, theme, isPrivate } = useScopedPrivateGroupTheme(scope);
+  const isLocked = isPrivate && group?.locked === true;
+
+  useEffect(() => {
+    if (!isLocked) return;
+    Alert.alert(
+      'Group is locked',
+      'New private games are paused until the owner renews the subscription or transfers ownership.'
+    );
+    if (navigation.canGoBack?.()) {
+      navigation.goBack();
+    }
+  }, [isLocked, navigation]);
 
   useEffect(() => {
     if (!theme) return;


### PR DESCRIPTION
This pull request adds comprehensive test coverage for scenarios involving locked private groups, improves test utilities for navigation focus effects, and ensures correct state updates after entitlement changes. The main themes are improved locked group gating logic, better test mocking for navigation and focus, and validation of entitlement synchronization.

**Locked group gating and alerts:**

* Added tests to ensure that navigation is blocked and a lock alert is shown when a private group is locked, both on direct access and after on-demand group fetches (`__tests__/GuessPathScreen.test.js`, `__tests__/HidingPathScreen.test.js`) [[1]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfL396-R424) [[2]](diffhunk://#diff-3c3acb4a185eb57a19d7509884d6da154c2466b0689e6821c4a0d742a46287bfL424-R477) [[3]](diffhunk://#diff-3dc6755c8a137d35e9af8a4effaaba1ee4f0a02d23c4706a64026f9b2b51af90R1-R130).
* Added tests to verify that locked group owners and members see appropriate UI gating (disabled cards, alerts, and modals) in `PrivateHomeScreen` (`__tests__/screens/PrivateHomeScreen.test.js`) [[1]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645R435-R454) [[2]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645R490-R577).

**Navigation and focus effect mocking:**

* Improved mocks for `useFocusEffect` in navigation, allowing tests to trigger focus events and verify side effects such as refreshing group data (`__tests__/HomeHeaderRight.test.js`, `__tests__/screens/PrivateHomeScreen.test.js`, `__tests__/screens/HomeHeaderRight.test.js`) [[1]](diffhunk://#diff-c1000f6c6720cf7b59a40d115f42c17892db540cdc5ab81dbbbe6237248b5992R2-R20) [[2]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645R9-R27) [[3]](diffhunk://#diff-f36c64a2c761d9c061a63ba05e4f6b399af228d82ddbcefd40b6108747c07ebaR1-R9).
* Added utilities to trigger focus effects and verify that focus-driven refresh logic works as intended [[1]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645R153-R159) [[2]](diffhunk://#diff-c1000f6c6720cf7b59a40d115f42c17892db540cdc5ab81dbbbe6237248b5992R109-R171).

**Entitlement and context synchronization:**

* Added a test to verify that after a successful purchase and entitlement sync, the app correctly updates both `isGroupOwner` and `activeGroupId` in the authentication context (`__tests__/screens/PaywallScreen.test.js`).
* Updated imports to use a new utility for entitlement-to-context payload conversion (`screens/Billing/PaywallScreen.js`).

**Test utility improvements:**

* Enhanced test setup by clearing mocks and focus effect sets before each test for isolation and reliability (`__tests__/HomeHeaderRight.test.js`, `__tests__/screens/PrivateHomeScreen.test.js`) [[1]](diffhunk://#diff-c1000f6c6720cf7b59a40d115f42c17892db540cdc5ab81dbbbe6237248b5992L11-R83) [[2]](diffhunk://#diff-dcea98be4c13c4033a5641343103bcc849f64c33f5eb01daf3ad59b4b6cc7645R117).
* Provided consistent mock return values for hooks like `useActiveGroup` and `useGroupsHub` across tests for more accurate scenario simulation [[1]](diffhunk://#diff-c1000f6c6720cf7b59a40d115f42c17892db540cdc5ab81dbbbe6237248b5992L11-R83) [[2]](diffhunk://#diff-f36c64a2c761d9c061a63ba05e4f6b399af228d82ddbcefd40b6108747c07ebaL47-R56).

**General test coverage:**

* Ensured that all critical user flows for locked/unlocked group access, navigation, and UI state are covered by new or updated tests in the relevant screen test files (multiple files and references above).